### PR TITLE
Chore/#12 common response and error handling

### DIFF
--- a/src/main/java/com/readwith/domain/example/service/ExampleSearchService.java
+++ b/src/main/java/com/readwith/domain/example/service/ExampleSearchService.java
@@ -2,8 +2,8 @@ package com.readwith.domain.example.service;
 
 import com.readwith.domain.example.dto.ExampleResult;
 import com.readwith.domain.example.out.ExampleSearchClient;
-import com.readwith.domain.exception.BusinessException;
 import com.readwith.domain.exception.ErrorCode;
+import com.readwith.domain.exception.NotFoundException;
 import com.readwith.model.example.repository.ExampleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,7 +20,7 @@ public class ExampleSearchService {
     public ExampleResult searchById(long id) {
         return exampleRepository.findById(id)
                 .map(ExampleResult::from)
-                .orElseThrow(() -> new BusinessException(ErrorCode.EXAMPLE_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(ErrorCode.EXAMPLE_NOT_FOUND));
     }
 
     public List<ExampleResult> searchAll() {

--- a/src/main/java/com/readwith/domain/example/service/ExampleSearchService.java
+++ b/src/main/java/com/readwith/domain/example/service/ExampleSearchService.java
@@ -2,12 +2,13 @@ package com.readwith.domain.example.service;
 
 import com.readwith.domain.example.dto.ExampleResult;
 import com.readwith.domain.example.out.ExampleSearchClient;
+import com.readwith.domain.exception.BusinessException;
+import com.readwith.domain.exception.ErrorCode;
 import com.readwith.model.example.repository.ExampleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -19,9 +20,7 @@ public class ExampleSearchService {
     public ExampleResult searchById(long id) {
         return exampleRepository.findById(id)
                 .map(ExampleResult::from)
-                .orElseThrow(() -> new NoSuchElementException(
-                        "Example not found: id=" + id
-                ));
+                .orElseThrow(() -> new BusinessException(ErrorCode.EXAMPLE_NOT_FOUND));
     }
 
     public List<ExampleResult> searchAll() {

--- a/src/main/java/com/readwith/domain/exception/BadRequestException.java
+++ b/src/main/java/com/readwith/domain/exception/BadRequestException.java
@@ -1,0 +1,8 @@
+package com.readwith.domain.exception;
+
+public class BadRequestException extends BusinessException {
+
+    public BadRequestException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/readwith/domain/exception/BusinessException.java
+++ b/src/main/java/com/readwith/domain/exception/BusinessException.java
@@ -1,0 +1,15 @@
+package com.readwith.domain.exception;
+
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/readwith/domain/exception/ConflictException.java
+++ b/src/main/java/com/readwith/domain/exception/ConflictException.java
@@ -1,0 +1,8 @@
+package com.readwith.domain.exception;
+
+public class ConflictException extends BusinessException {
+
+    public ConflictException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/readwith/domain/exception/ErrorCode.java
+++ b/src/main/java/com/readwith/domain/exception/ErrorCode.java
@@ -1,0 +1,25 @@
+package com.readwith.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+
+    // Example
+    EXAMPLE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 예시입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/readwith/domain/exception/ErrorCode.java
+++ b/src/main/java/com/readwith/domain/exception/ErrorCode.java
@@ -1,22 +1,14 @@
 package com.readwith.domain.exception;
 
-import org.springframework.http.HttpStatus;
-
 public enum ErrorCode {
 
     // Example
-    EXAMPLE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 예시입니다.");
+    EXAMPLE_NOT_FOUND("존재하지 않는 예시입니다.");
 
-    private final HttpStatus status;
     private final String message;
 
-    ErrorCode(HttpStatus status, String message) {
-        this.status = status;
+    ErrorCode(String message) {
         this.message = message;
-    }
-
-    public HttpStatus getStatus() {
-        return status;
     }
 
     public String getMessage() {

--- a/src/main/java/com/readwith/domain/exception/ForbiddenException.java
+++ b/src/main/java/com/readwith/domain/exception/ForbiddenException.java
@@ -1,0 +1,8 @@
+package com.readwith.domain.exception;
+
+public class ForbiddenException extends BusinessException {
+
+    public ForbiddenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/readwith/domain/exception/NotFoundException.java
+++ b/src/main/java/com/readwith/domain/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package com.readwith.domain.exception;
+
+public class NotFoundException extends BusinessException {
+
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/readwith/presentation/common/ApiResponse.java
+++ b/src/main/java/com/readwith/presentation/common/ApiResponse.java
@@ -1,0 +1,27 @@
+package com.readwith.presentation.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiResponse<T>(T data, ErrorBody error) {
+
+    public record ErrorBody(String message) {}
+
+    public static <T> ResponseEntity<ApiResponse<T>> ok(T data) {
+        return ResponseEntity.ok(new ApiResponse<>(data, null));
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> created(T data) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(new ApiResponse<>(data, null));
+    }
+
+    public static ResponseEntity<ApiResponse<?>> error(HttpStatus status, String message) {
+        return ResponseEntity
+                .status(status)
+                .body(new ApiResponse<>(null, new ErrorBody(message)));
+    }
+}

--- a/src/main/java/com/readwith/presentation/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/readwith/presentation/common/GlobalExceptionHandler.java
@@ -1,0 +1,43 @@
+package com.readwith.presentation.common;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.NoSuchElementException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<ApiResponse<?>> handleNoSuchElement(NoSuchElementException ex) {
+        return ApiResponse.error(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<?>> handleIllegalArgument(IllegalArgumentException ex) {
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<?>> handleValidation(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .findFirst()
+                .orElse("유효하지 않은 요청입니다.");
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<?>> handleUnreadableMessage(HttpMessageNotReadableException ex) {
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, "요청 본문을 읽을 수 없습니다.");
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<?>> handleGeneral(Exception ex) {
+        return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+    }
+}

--- a/src/main/java/com/readwith/presentation/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/readwith/presentation/common/GlobalExceptionHandler.java
@@ -1,6 +1,11 @@
 package com.readwith.presentation.common;
 
+import com.readwith.domain.exception.BadRequestException;
 import com.readwith.domain.exception.BusinessException;
+import com.readwith.domain.exception.ConflictException;
+import com.readwith.domain.exception.ForbiddenException;
+import com.readwith.domain.exception.NotFoundException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -9,18 +14,49 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    // 도메인 비즈니스 규칙 위반 (ErrorCode에 정의된 상태코드와 메시지 사용)
+    // 도메인 비즈니스 예외 - 잘못된 요청
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(BadRequestException ex) {
+        log.warn("Bad request: {}", ex.getErrorCode().getMessage());
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, ex.getErrorCode().getMessage());
+    }
+
+    // 도메인 비즈니스 예외 - 접근 권한 없음
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ApiResponse<?>> handleForbidden(ForbiddenException ex) {
+        log.warn("Forbidden: {}", ex.getErrorCode().getMessage());
+        return ApiResponse.error(HttpStatus.FORBIDDEN, ex.getErrorCode().getMessage());
+    }
+
+    // 도메인 비즈니스 예외 - 리소스 미존재
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ApiResponse<?>> handleNotFound(NotFoundException ex) {
+        log.warn("Not found: {}", ex.getErrorCode().getMessage());
+        return ApiResponse.error(HttpStatus.NOT_FOUND, ex.getErrorCode().getMessage());
+    }
+
+    // 도메인 비즈니스 예외 - 상태 충돌
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ApiResponse<?>> handleConflict(ConflictException ex) {
+        log.warn("Conflict: {}", ex.getErrorCode().getMessage());
+        return ApiResponse.error(HttpStatus.CONFLICT, ex.getErrorCode().getMessage());
+    }
+
+    // 도메인 비즈니스 예외 - 미분류 (fallback)
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ApiResponse<?>> handleBusiness(BusinessException ex) {
-        return ApiResponse.error(ex.getErrorCode().getStatus(), ex.getErrorCode().getMessage());
+        log.error("Unclassified business exception", ex);
+        return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
     }
 
     // 잘못된 인자 전달 (도메인 서비스의 명시적 유효성 검사 실패 등)
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<?>> handleIllegalArgument(IllegalArgumentException ex) {
+        log.warn("Illegal argument: {}", ex.getMessage());
         return ApiResponse.error(HttpStatus.BAD_REQUEST, ex.getMessage());
     }
 
@@ -31,6 +67,7 @@ public class GlobalExceptionHandler {
                 .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
                 .findFirst()
                 .orElse("유효하지 않은 요청입니다.");
+        log.debug("Validation failed: {}", message);
         return ApiResponse.error(HttpStatus.BAD_REQUEST, message);
     }
 
@@ -38,18 +75,21 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ApiResponse<?>> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
         String message = String.format("'%s'에 잘못된 값이 전달되었습니다: %s", ex.getName(), ex.getValue());
+        log.debug("Type mismatch: {}", message);
         return ApiResponse.error(HttpStatus.BAD_REQUEST, message);
     }
 
     // 요청 바디 JSON 파싱 실패 (잘못된 형식 또는 타입 불일치)
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiResponse<?>> handleUnreadableMessage(HttpMessageNotReadableException ex) {
+        log.debug("Unreadable message: {}", ex.getMessage());
         return ApiResponse.error(HttpStatus.BAD_REQUEST, "요청 본문을 읽을 수 없습니다.");
     }
 
     // 위에서 처리되지 않은 모든 예외 (예기치 않은 서버 오류)
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<?>> handleGeneral(Exception ex) {
+        log.error("Unhandled exception", ex);
         return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
     }
 }

--- a/src/main/java/com/readwith/presentation/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/readwith/presentation/common/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.readwith.presentation.common;
 
+import com.readwith.domain.exception.BusinessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -7,14 +8,12 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.NoSuchElementException;
-
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(NoSuchElementException.class)
-    public ResponseEntity<ApiResponse<?>> handleNoSuchElement(NoSuchElementException ex) {
-        return ApiResponse.error(HttpStatus.NOT_FOUND, ex.getMessage());
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<?>> handleBusiness(BusinessException ex) {
+        return ApiResponse.error(ex.getErrorCode().getStatus(), ex.getErrorCode().getMessage());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/com/readwith/presentation/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/readwith/presentation/common/GlobalExceptionHandler.java
@@ -7,20 +7,24 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    // 도메인 비즈니스 규칙 위반 (ErrorCode에 정의된 상태코드와 메시지 사용)
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ApiResponse<?>> handleBusiness(BusinessException ex) {
         return ApiResponse.error(ex.getErrorCode().getStatus(), ex.getErrorCode().getMessage());
     }
 
+    // 잘못된 인자 전달 (도메인 서비스의 명시적 유효성 검사 실패 등)
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<?>> handleIllegalArgument(IllegalArgumentException ex) {
         return ApiResponse.error(HttpStatus.BAD_REQUEST, ex.getMessage());
     }
 
+    // @Valid 어노테이션 검증 실패 (필드 제약 조건 위반)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<?>> handleValidation(MethodArgumentNotValidException ex) {
         String message = ex.getBindingResult().getFieldErrors().stream()
@@ -30,11 +34,20 @@ public class GlobalExceptionHandler {
         return ApiResponse.error(HttpStatus.BAD_REQUEST, message);
     }
 
+    // @PathVariable, @RequestParam 타입 변환 실패 (예: long 파라미터에 문자열 전달)
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<?>> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        String message = String.format("'%s'에 잘못된 값이 전달되었습니다: %s", ex.getName(), ex.getValue());
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, message);
+    }
+
+    // 요청 바디 JSON 파싱 실패 (잘못된 형식 또는 타입 불일치)
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiResponse<?>> handleUnreadableMessage(HttpMessageNotReadableException ex) {
         return ApiResponse.error(HttpStatus.BAD_REQUEST, "요청 본문을 읽을 수 없습니다.");
     }
 
+    // 위에서 처리되지 않은 모든 예외 (예기치 않은 서버 오류)
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<?>> handleGeneral(Exception ex) {
         return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");

--- a/src/main/java/com/readwith/presentation/controller/example/ExampleController.java
+++ b/src/main/java/com/readwith/presentation/controller/example/ExampleController.java
@@ -4,10 +4,11 @@ import com.readwith.domain.example.service.ExampleCreateService;
 import com.readwith.domain.example.service.ExampleSearchService;
 import com.readwith.domain.example.dto.ExampleCreateResult;
 import com.readwith.domain.example.dto.ExampleResult;
+import com.readwith.presentation.common.ApiResponse;
 import com.readwith.presentation.controller.example.dto.ExampleCreateRequest;
+import com.readwith.presentation.controller.example.dto.ExampleListResponse;
 import com.readwith.presentation.controller.example.dto.ExampleResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,25 +28,21 @@ public class ExampleController {
     private final ExampleSearchService exampleSearchService;
 
     @PostMapping
-    public ResponseEntity<ExampleResponse> create(
+    public ResponseEntity<ApiResponse<ExampleResponse>> create(
             @RequestBody ExampleCreateRequest request) {
         ExampleCreateResult result = exampleCreateService.execute(request.toCommand());
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(ExampleResponse.from(result));
+        return ApiResponse.created(ExampleResponse.from(result));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ExampleResponse> getById(@PathVariable long id) {
+    public ResponseEntity<ApiResponse<ExampleResponse>> getById(@PathVariable long id) {
         ExampleResult result = exampleSearchService.searchById(id);
-        return ResponseEntity.ok(ExampleResponse.from(result));
+        return ApiResponse.ok(ExampleResponse.from(result));
     }
 
     @GetMapping
-    public ResponseEntity<List<ExampleResponse>> getAll() {
-        List<ExampleResponse> responses = exampleSearchService.searchAll().stream()
-                .map(ExampleResponse::from)
-                .toList();
-        return ResponseEntity.ok(responses);
+    public ResponseEntity<ApiResponse<ExampleListResponse>> getAll() {
+        List<ExampleResult> results = exampleSearchService.searchAll();
+        return ApiResponse.ok(ExampleListResponse.from(results));
     }
 }

--- a/src/main/java/com/readwith/presentation/controller/example/dto/ExampleListResponse.java
+++ b/src/main/java/com/readwith/presentation/controller/example/dto/ExampleListResponse.java
@@ -1,0 +1,14 @@
+package com.readwith.presentation.controller.example.dto;
+
+import com.readwith.domain.example.dto.ExampleResult;
+
+import java.util.List;
+
+public record ExampleListResponse(List<ExampleResponse> examples) {
+
+    public static ExampleListResponse from(List<ExampleResult> results) {
+        return new ExampleListResponse(
+                results.stream().map(ExampleResponse::from).toList()
+        );
+    }
+}


### PR DESCRIPTION
## 작업 사항
<!-- 이 PR에서 수행한 작업을 간단히 요약해주세요 -->
**✔️ 공통 API 응답 포맷 구현**
- ApiResponse<T> — 성공/에러 통합 단일 래퍼 레코드 (@JsonInclude(NON_NULL)으로 null 필드 직렬화 제외)                                                                                                                                                                                              
- ok() / created() / error() 팩토리 메서드로 ResponseEntity 직접 반환 → 컨트롤러 보일러플레이트 최소화                                                                                                                                                                                             
- 키 문자열 제거 — DTO 필드명이 JSON 키를 결정하는 방식 채택

**✔️ 전역 예외 처리 구현**                                                                                                                                                                                                                                                                                
- GlobalExceptionHandler (@RestControllerAdvice) 추가                                                                                                                                                                                                                                              
- BusinessException / IllegalArgumentException / MethodArgumentNotValidException / HttpMessageNotReadableException / Exception(500 catch-all) 처리                                                                                                                                                 
                                                                                                                                                                                                                                                                                                     
**✔️ 도메인 비즈니스 예외 체계 구축**                                                                                                                                                                                                                                                  
- ErrorCode enum — HTTP 상태 코드와 메시지를 한 곳에서 관리                                                                                                                                                                                                                                        
- BusinessException — ErrorCode를 감싸는 도메인 예외 클래스 (domain/exception/)                                                                                                                                                                                                                    
- ExampleSearchService — NoSuchElementException → BusinessException(ErrorCode.EXAMPLE_NOT_FOUND) 교체                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                     

**✔️ Example 참조 구현체에 응답 포맷 적용**                                                                                                                                                                                                                                                        - ExampleListResponse 추가 — 목록 응답용 래퍼 DTO (examples 필드명 → JSON 키)                                                                                                                                                                                                                     - ExampleController — ApiResponse 팩토리 메서드로 전면 교체       

## 테스트 결과
<!-- 테스트 수행 결과를 작성해주세요 -->
- ./gradlew build 성공
- POST `/api/v1/examples` → { "data": { "id": 1, ... } } (201)                                                                                                                                                                                                                                       
- GET `/api/v1/examples/{id}` → { "data": { "id": 1, ... } } (200)                                                                                                                                                                                                                                   
- GET `/api/v1/examples` → { "data": { "examples": [...] } } (200)
- GET `/api/v1/examples/999` → { "error": { "message": "존재하지 않는 예시입니다." } } (404)   

## 관련 이슈
<!-- 관련 이슈 번호를 작성해주세요 (예: #123) -->
- closes #12 

## 참고 사항
<!-- 리뷰어가 알아야 할 사항이 있다면 작성해주세요 (시퀀스/클래스 다이어그램 등) -->

- `ErrorCode`에 `HttpStatus` 의존성이 있어 도메인 레이어에 Spring 의존성이 생기나, `@Service` 처럼 이미 주입되어 있는 의존성과 동일한 수준이라고 판단해서 도메인 레이어에 뒀습니다. 
원래  global 패키지라는 걸 따로 둬서 관리를 했었거든요. 
그런데,  이 아키텍쳐는 global 패키지라는 걸 따로 두지 않아서, 도메인 레이어에 뒀는데 이게 괜찮은 건지는 잘 모르겠습니다..
                                                                                                        
- 새 에러 상황 추가 시 ErrorCode에 항목 추가 후 `throw new BusinessException(ErrorCode.XXX)` 한 줄로 처리 가능하도록 했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 일관된 API 응답 형식으로 모든 엔드포인트 통일
  * 향상된 예외 처리 체계로 구조화된 에러 응답 제공
  * 전역 예외 핸들러로 모든 오류에 대한 일관된 HTTP 상태 코드 및 한국어 에러 메시지 반환
  * 입력 검증 오류, 타입 미스매치, 리소스 미발견 등 다양한 오류 상황에 대한 표준화된 응답

<!-- end of auto-generated comment: release notes by coderabbit.ai -->