### PR TITLE
feat(swagger): springdoc-openapi 적용 및 dev 프로필 한정 활성화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
 	implementation 'com.github.ben-manes.caffeine:caffeine'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/com/readum/presentation/common/security/SecurityConfig.java
+++ b/src/main/java/com/readum/presentation/common/security/SecurityConfig.java
@@ -29,6 +29,12 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/refresh").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/logout").permitAll()
+                        .requestMatchers(
+                                "/v3/api-docs",
+                                "/v3/api-docs/**",
+                                "/swagger-ui.html",
+                                "/swagger-ui/**"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(exception -> exception

--- a/src/main/java/com/readum/presentation/common/swagger/OpenApiConfig.java
+++ b/src/main/java/com/readum/presentation/common/swagger/OpenApiConfig.java
@@ -1,0 +1,33 @@
+package com.readum.presentation.common.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("dev")
+public class OpenApiConfig {
+
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
+
+    @Bean
+    public OpenAPI readumOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Readum API")
+                        .description("Readum 서비스 API 문서")
+                        .version("v1"))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
+                                .name(SECURITY_SCHEME_NAME)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT:3306}/${MYSQL_DATABASE}?sslMode=VERIFY_IDENTITY&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT:3306}/${MYSQL_DATABASE}?sslMode=REQUIRED&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: ${MYSQL_USER}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -16,3 +16,14 @@ logging:
     com.readum: DEBUG
     org.hibernate.SQL: DEBUG
     org.hibernate.orm.jdbc.bind: WARN
+
+springdoc:
+  api-docs:
+    enabled: true
+    path: /v3/api-docs
+  swagger-ui:
+    enabled: true
+    path: /swagger-ui.html
+    operations-sorter: method
+    tags-sorter: alpha
+    display-request-duration: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,9 @@ jwt:
   refresh-grace-period: PT3S
   refresh-cookie-secure: true
   blacklist-max-size: 10000
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false


### PR DESCRIPTION
## 작업 사항

Spring Boot 4.0.5 환경에서 OpenAPI 문서를 자동 생성·노출하기 위해 springdoc-openapi 3.0.3 을 도입했습니다. springdoc 2.x 계열은 Spring Framework 6 / Spring Boot 3 까지만 호환되므로, Spring Boot 4 의 Framework 7 / Jakarta 11 변경을 반영해 새로 컷된 3.0.x 라인 중 4.0.5 와 함께 빌드된 첫 stable 인 3.0.3 을 선택했습니다.

API 인증이 JWT Access Token 기반이라는 점을 고려해 `OpenApiConfig` 에서 `bearerAuth` HTTP Bearer (JWT) 보안 스킴을 등록하고, 전역 `SecurityRequirement` 로 묶었습니다. 이 덕분에 Swagger UI 우측 상단 Authorize 다이얼로그에 토큰을 한 번 넣으면 보호된 엔드포인트들이 자동으로 `Authorization: Bearer <token>` 헤더와 함께 호출됩니다. 함께 `SecurityFilterChain` 에 `/v3/api-docs/**`, `/swagger-ui.html`, `/swagger-ui/**` 를 `permitAll` 매처로 추가해 Swagger 자체 진입은 비인증 상태에서도 가능하도록 열어두었습니다.

운영 환경에 문서가 노출되지 않도록 활성 범위를 `dev` 프로필에 한정했습니다. `OpenApiConfig` 클래스에는 `@Profile("dev")` 를 부여해 비-dev 컨텍스트에서는 Bean 자체가 등록되지 않도록 하고, 기본 `application.yml` 은 `springdoc.api-docs.enabled` / `springdoc.swagger-ui.enabled` 를 모두 `false` 로 명시해 자동 구성이 떠도 엔드포인트가 비활성 상태로 유지되게 했습니다. UI 경로와 정렬·요청 시간 표시 등 사용성 옵션은 `application-dev.yml` 로 옮겨 dev 에서만 동작합니다.

## 테스트 결과
- [x] `./gradlew clean compileJava` 빌드 통과 (springdoc 의존성·심볼 해석 검증)
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과

## 관련 이슈
- closes #13

## 참고 사항

로컬 검증 시 `--spring.profiles.active=dev` 로 기동 후 `http://localhost:8080/swagger-ui.html` 와 `http://localhost:8080/v3/api-docs` 가 200 으로 응답하는지, dev 외 프로필에서는 두 경로가 404 가 되는지 함께 확인해주세요. JWT 가 필요한 엔드포인트는 Authorize 다이얼로그에 access token 만 입력하면 됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * API 문서 및 Swagger UI 지원 추가

* **구성 변경**
  * 개발 환경에서 API 문서 및 Swagger UI 활성화
  * 보안 설정 업데이트: API 문서 엔드포인트는 인증 없이 접근 가능
  * 기본 환경에서는 API 문서 비활성화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->