### PR TITLE
feat(aiChat): AI 채팅 세션 생성 API 추가

### DIFF
--- a/src/main/java/com/readum/domain/aiChat/dto/AiChatCommand.java
+++ b/src/main/java/com/readum/domain/aiChat/dto/AiChatCommand.java
@@ -1,4 +1,4 @@
-package com.readum.domain.ai.dto;
+package com.readum.domain.aiChat.dto;
 
 public record AiChatCommand(String message) {
 }

--- a/src/main/java/com/readum/domain/aiChat/dto/AiChatSessionCreateCommand.java
+++ b/src/main/java/com/readum/domain/aiChat/dto/AiChatSessionCreateCommand.java
@@ -1,0 +1,7 @@
+package com.readum.domain.aiChat.dto;
+
+public record AiChatSessionCreateCommand(
+        Long userId,
+        Long userBookId
+) {
+}

--- a/src/main/java/com/readum/domain/aiChat/dto/AiChatSessionCreateResult.java
+++ b/src/main/java/com/readum/domain/aiChat/dto/AiChatSessionCreateResult.java
@@ -1,0 +1,4 @@
+package com.readum.domain.aiChat.dto;
+
+public record AiChatSessionCreateResult(Long id) {
+}

--- a/src/main/java/com/readum/domain/aiChat/exception/AiChatErrorCode.java
+++ b/src/main/java/com/readum/domain/aiChat/exception/AiChatErrorCode.java
@@ -1,0 +1,19 @@
+package com.readum.domain.aiChat.exception;
+
+import com.readum.domain.exception.ErrorCode;
+
+public enum AiChatErrorCode implements ErrorCode {
+
+    USER_BOOK_NOT_FOUND("해당 도서를 찾을 수 없습니다.");
+
+    private final String message;
+
+    AiChatErrorCode(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/readum/domain/aiChat/out/AiChatClient.java
+++ b/src/main/java/com/readum/domain/aiChat/out/AiChatClient.java
@@ -1,6 +1,6 @@
-package com.readum.domain.ai.out;
+package com.readum.domain.aiChat.out;
 
-import com.readum.domain.ai.dto.AiChatCommand;
+import com.readum.domain.aiChat.dto.AiChatCommand;
 import reactor.core.publisher.Flux;
 
 public interface AiChatClient {

--- a/src/main/java/com/readum/domain/aiChat/service/AiChatSessionCreateService.java
+++ b/src/main/java/com/readum/domain/aiChat/service/AiChatSessionCreateService.java
@@ -1,0 +1,29 @@
+package com.readum.domain.aiChat.service;
+
+import com.readum.domain.aiChat.dto.AiChatSessionCreateCommand;
+import com.readum.domain.aiChat.dto.AiChatSessionCreateResult;
+import com.readum.domain.aiChat.exception.AiChatErrorCode;
+import com.readum.domain.exception.NotFoundException;
+import com.readum.model.aiChat.entity.AiChatSession;
+import com.readum.model.aiChat.repository.AiChatSessionRepository;
+import com.readum.model.book.repository.UserBookRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AiChatSessionCreateService {
+
+    private final UserBookRepository userBookRepository;
+    private final AiChatSessionRepository aiChatSessionRepository;
+
+    @Transactional
+    public AiChatSessionCreateResult execute(AiChatSessionCreateCommand command) {
+        userBookRepository.findByIdAndUserId(command.userBookId(), command.userId())
+                .orElseThrow(() -> new NotFoundException(AiChatErrorCode.USER_BOOK_NOT_FOUND));
+
+        AiChatSession saved = aiChatSessionRepository.save(AiChatSession.create(command.userBookId()));
+        return new AiChatSessionCreateResult(saved.getId());
+    }
+}

--- a/src/main/java/com/readum/domain/aiChat/service/AiStreamChatService.java
+++ b/src/main/java/com/readum/domain/aiChat/service/AiStreamChatService.java
@@ -1,7 +1,7 @@
-package com.readum.domain.ai.service;
+package com.readum.domain.aiChat.service;
 
-import com.readum.domain.ai.dto.AiChatCommand;
-import com.readum.domain.ai.out.AiChatClient;
+import com.readum.domain.aiChat.dto.AiChatCommand;
+import com.readum.domain.aiChat.out.AiChatClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;

--- a/src/main/java/com/readum/infrastructure/ai/openai/AiChatClientImpl.java
+++ b/src/main/java/com/readum/infrastructure/ai/openai/AiChatClientImpl.java
@@ -1,7 +1,7 @@
 package com.readum.infrastructure.ai.openai;
 
-import com.readum.domain.ai.dto.AiChatCommand;
-import com.readum.domain.ai.out.AiChatClient;
+import com.readum.domain.aiChat.dto.AiChatCommand;
+import com.readum.domain.aiChat.out.AiChatClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;

--- a/src/main/java/com/readum/model/aiChat/entity/AiChatMessage.java
+++ b/src/main/java/com/readum/model/aiChat/entity/AiChatMessage.java
@@ -1,4 +1,4 @@
-package com.readum.model.chat.entity;
+package com.readum.model.aiChat.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,14 +19,14 @@ import java.time.LocalDateTime;
 @Getter
 @Entity
 @Table(
-        name = "chat_message",
+        name = "ai_chat_message",
         indexes = {
-                @Index(name = "idx_chat_message_session", columnList = "session_id")
+                @Index(name = "idx_ai_chat_message_session", columnList = "session_id")
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class ChatMessage {
+public class AiChatMessage {
 
     public enum Role {
         USER, ASSISTANT, SYSTEM
@@ -61,7 +61,7 @@ public class ChatMessage {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    public static ChatMessage create(
+    public static AiChatMessage create(
             Long sessionId,
             Role role,
             String content,
@@ -70,10 +70,10 @@ public class ChatMessage {
             Integer outputTokens,
             Integer totalTokens
     ) {
-        return new ChatMessage(null, sessionId, role, content, quoteText, inputTokens, outputTokens, totalTokens, LocalDateTime.now());
+        return new AiChatMessage(null, sessionId, role, content, quoteText, inputTokens, outputTokens, totalTokens, LocalDateTime.now());
     }
 
-    public static ChatMessage of(
+    public static AiChatMessage of(
             Long id,
             Long sessionId,
             Role role,
@@ -84,6 +84,6 @@ public class ChatMessage {
             Integer totalTokens,
             LocalDateTime createdAt
     ) {
-        return new ChatMessage(id, sessionId, role, content, quoteText, inputTokens, outputTokens, totalTokens, createdAt);
+        return new AiChatMessage(id, sessionId, role, content, quoteText, inputTokens, outputTokens, totalTokens, createdAt);
     }
 }

--- a/src/main/java/com/readum/model/aiChat/entity/AiChatSession.java
+++ b/src/main/java/com/readum/model/aiChat/entity/AiChatSession.java
@@ -1,4 +1,4 @@
-package com.readum.model.chat.entity;
+package com.readum.model.aiChat.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,14 +19,14 @@ import java.time.LocalDateTime;
 @Getter
 @Entity
 @Table(
-        name = "chat_session",
+        name = "ai_chat_session",
         indexes = {
-                @Index(name = "idx_chat_session_user_book", columnList = "user_book_id")
+                @Index(name = "idx_ai_chat_session_user_book", columnList = "user_book_id")
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class ChatSession {
+public class AiChatSession {
 
     public enum Status {
         ACTIVE, CLOSED
@@ -58,12 +58,12 @@ public class ChatSession {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    public static ChatSession create(Long userBookId) {
+    public static AiChatSession create(Long userBookId) {
         LocalDateTime now = LocalDateTime.now();
-        return new ChatSession(null, userBookId, Status.ACTIVE, 0, 0, null, now, now);
+        return new AiChatSession(null, userBookId, Status.ACTIVE, 0, 0, null, now, now);
     }
 
-    public static ChatSession of(
+    public static AiChatSession of(
             Long id,
             Long userBookId,
             Status status,
@@ -73,6 +73,6 @@ public class ChatSession {
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
-        return new ChatSession(id, userBookId, status, userMessageCount, accumulatedTokens, lastMessagePreview, createdAt, updatedAt);
+        return new AiChatSession(id, userBookId, status, userMessageCount, accumulatedTokens, lastMessagePreview, createdAt, updatedAt);
     }
 }

--- a/src/main/java/com/readum/model/aiChat/repository/AiChatSessionRepository.java
+++ b/src/main/java/com/readum/model/aiChat/repository/AiChatSessionRepository.java
@@ -1,0 +1,7 @@
+package com.readum.model.aiChat.repository;
+
+import com.readum.model.aiChat.entity.AiChatSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AiChatSessionRepository extends JpaRepository<AiChatSession, Long> {
+}

--- a/src/main/java/com/readum/model/book/repository/UserBookRepository.java
+++ b/src/main/java/com/readum/model/book/repository/UserBookRepository.java
@@ -1,0 +1,11 @@
+package com.readum.model.book.repository;
+
+import com.readum.model.book.entity.UserBook;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserBookRepository extends JpaRepository<UserBook, Long> {
+
+    Optional<UserBook> findByIdAndUserId(Long id, Long userId);
+}

--- a/src/main/java/com/readum/model/summary/entity/Summary.java
+++ b/src/main/java/com/readum/model/summary/entity/Summary.java
@@ -23,7 +23,7 @@ import java.time.LocalDateTime;
                 @Index(name = "idx_summary_user_book", columnList = "user_book_id")
         },
         uniqueConstraints = {
-                @UniqueConstraint(name = "uk_summary_chat_session", columnNames = "chat_session_id")
+                @UniqueConstraint(name = "uk_summary_ai_chat_session", columnNames = "ai_chat_session_id")
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -37,8 +37,8 @@ public class Summary {
     @Column(name = "user_book_id", nullable = false)
     private Long userBookId;
 
-    @Column(name = "chat_session_id", nullable = false)
-    private Long chatSessionId;
+    @Column(name = "ai_chat_session_id", nullable = false)
+    private Long aiChatSessionId;
 
     @Column(name = "quote", columnDefinition = "TEXT")
     private String quote;
@@ -57,25 +57,25 @@ public class Summary {
 
     public static Summary create(
             Long userBookId,
-            Long chatSessionId,
+            Long aiChatSessionId,
             String quote,
             String title,
             String body
     ) {
         LocalDateTime now = LocalDateTime.now();
-        return new Summary(null, userBookId, chatSessionId, quote, title, body, now, now);
+        return new Summary(null, userBookId, aiChatSessionId, quote, title, body, now, now);
     }
 
     public static Summary of(
             Long id,
             Long userBookId,
-            Long chatSessionId,
+            Long aiChatSessionId,
             String quote,
             String title,
             String body,
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
-        return new Summary(id, userBookId, chatSessionId, quote, title, body, createdAt, updatedAt);
+        return new Summary(id, userBookId, aiChatSessionId, quote, title, body, createdAt, updatedAt);
     }
 }

--- a/src/main/java/com/readum/presentation/controller/aiChat/AiChatController.java
+++ b/src/main/java/com/readum/presentation/controller/aiChat/AiChatController.java
@@ -1,7 +1,7 @@
-package com.readum.presentation.controller.ai;
+package com.readum.presentation.controller.aiChat;
 
-import com.readum.domain.ai.service.AiStreamChatService;
-import com.readum.presentation.controller.ai.dto.AiChatRequest;
+import com.readum.domain.aiChat.service.AiStreamChatService;
+import com.readum.presentation.controller.aiChat.dto.AiChatRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -14,13 +14,13 @@ import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
 
 @RestController
-@RequestMapping("/api/v1/ai")
+@RequestMapping("/api/v1/ai-chat")
 @RequiredArgsConstructor
 public class AiChatController {
 
     private final AiStreamChatService aiStreamChatService;
 
-    @PostMapping(value = "/chat/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @PostMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<Flux<ServerSentEvent<String>>> chatStream(@Valid @RequestBody AiChatRequest request) {
         Flux<ServerSentEvent<String>> stream = aiStreamChatService.stream(request.toCommand())
                 .map(text -> ServerSentEvent.<String>builder()

--- a/src/main/java/com/readum/presentation/controller/aiChat/AiChatController.java
+++ b/src/main/java/com/readum/presentation/controller/aiChat/AiChatController.java
@@ -1,12 +1,18 @@
 package com.readum.presentation.controller.aiChat;
 
+import com.readum.domain.aiChat.dto.AiChatSessionCreateResult;
+import com.readum.domain.aiChat.service.AiChatSessionCreateService;
 import com.readum.domain.aiChat.service.AiStreamChatService;
+import com.readum.presentation.common.ApiResponse;
 import com.readum.presentation.controller.aiChat.dto.AiChatRequest;
+import com.readum.presentation.controller.aiChat.dto.AiChatSessionCreateRequest;
+import com.readum.presentation.controller.aiChat.dto.AiChatSessionCreateResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +25,16 @@ import reactor.core.publisher.Flux;
 public class AiChatController {
 
     private final AiStreamChatService aiStreamChatService;
+    private final AiChatSessionCreateService aiChatSessionCreateService;
+
+    @PostMapping("/sessions")
+    public ResponseEntity<ApiResponse<AiChatSessionCreateResponse>> createSession(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody AiChatSessionCreateRequest request
+    ) {
+        AiChatSessionCreateResult result = aiChatSessionCreateService.execute(request.toCommand(userId));
+        return ApiResponse.created(AiChatSessionCreateResponse.from(result));
+    }
 
     @PostMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<Flux<ServerSentEvent<String>>> chatStream(@Valid @RequestBody AiChatRequest request) {

--- a/src/main/java/com/readum/presentation/controller/aiChat/dto/AiChatRequest.java
+++ b/src/main/java/com/readum/presentation/controller/aiChat/dto/AiChatRequest.java
@@ -1,6 +1,6 @@
-package com.readum.presentation.controller.ai.dto;
+package com.readum.presentation.controller.aiChat.dto;
 
-import com.readum.domain.ai.dto.AiChatCommand;
+import com.readum.domain.aiChat.dto.AiChatCommand;
 import jakarta.validation.constraints.NotBlank;
 
 public record AiChatRequest(@NotBlank String message) {

--- a/src/main/java/com/readum/presentation/controller/aiChat/dto/AiChatSessionCreateRequest.java
+++ b/src/main/java/com/readum/presentation/controller/aiChat/dto/AiChatSessionCreateRequest.java
@@ -1,0 +1,16 @@
+package com.readum.presentation.controller.aiChat.dto;
+
+import com.readum.domain.aiChat.dto.AiChatSessionCreateCommand;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record AiChatSessionCreateRequest(
+        @NotNull(message = "userBookId는 필수입니다.")
+        @Positive(message = "userBookId는 양수여야 합니다.")
+        Long userBookId
+) {
+
+    public AiChatSessionCreateCommand toCommand(Long userId) {
+        return new AiChatSessionCreateCommand(userId, userBookId);
+    }
+}

--- a/src/main/java/com/readum/presentation/controller/aiChat/dto/AiChatSessionCreateResponse.java
+++ b/src/main/java/com/readum/presentation/controller/aiChat/dto/AiChatSessionCreateResponse.java
@@ -1,0 +1,10 @@
+package com.readum.presentation.controller.aiChat.dto;
+
+import com.readum.domain.aiChat.dto.AiChatSessionCreateResult;
+
+public record AiChatSessionCreateResponse(Long sessionId) {
+
+    public static AiChatSessionCreateResponse from(AiChatSessionCreateResult result) {
+        return new AiChatSessionCreateResponse(result.id());
+    }
+}

--- a/src/test/java/com/readum/domain/aiChat/service/AiChatSessionCreateServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/AiChatSessionCreateServiceTest.java
@@ -1,0 +1,90 @@
+package com.readum.domain.aiChat.service;
+
+import com.readum.domain.aiChat.dto.AiChatSessionCreateCommand;
+import com.readum.domain.aiChat.dto.AiChatSessionCreateResult;
+import com.readum.domain.aiChat.exception.AiChatErrorCode;
+import com.readum.domain.exception.NotFoundException;
+import com.readum.model.aiChat.entity.AiChatSession;
+import com.readum.model.aiChat.repository.AiChatSessionRepository;
+import com.readum.model.book.entity.UserBook;
+import com.readum.model.book.repository.UserBookRepository;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AiChatSessionCreateServiceTest {
+
+    @Mock
+    private UserBookRepository userBookRepository;
+
+    @Mock
+    private AiChatSessionRepository aiChatSessionRepository;
+
+    @InjectMocks
+    private AiChatSessionCreateService aiChatSessionCreateService;
+
+    @Test
+    void 본인_소유_userBook_으로_세션_생성_성공() {
+        Long userId = 1L;
+        Long userBookId = 10L;
+        AiChatSessionCreateCommand command = new AiChatSessionCreateCommand(userId, userBookId);
+
+        UserBook userBook = UserBook.of(userBookId, userId, 100L, LocalDateTime.now());
+        given(userBookRepository.findByIdAndUserId(userBookId, userId)).willReturn(Optional.of(userBook));
+
+        LocalDateTime now = LocalDateTime.now();
+        AiChatSession persisted = AiChatSession.of(
+                42L, userBookId, AiChatSession.Status.ACTIVE, 0, 0, null, now, now
+        );
+        given(aiChatSessionRepository.save(any(AiChatSession.class))).willReturn(persisted);
+
+        AiChatSessionCreateResult result = aiChatSessionCreateService.execute(command);
+
+        assertThat(result.id()).isEqualTo(42L);
+    }
+
+    @Test
+    void 다른_사용자_소유_userBook_은_NotFoundException_을_던지고_save_는_호출되지_않는다() {
+        Long userId = 1L;
+        Long userBookId = 10L;
+        AiChatSessionCreateCommand command = new AiChatSessionCreateCommand(userId, userBookId);
+
+        given(userBookRepository.findByIdAndUserId(userBookId, userId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> aiChatSessionCreateService.execute(command))
+                .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
+                .extracting(NotFoundException::getErrorCode)
+                .isEqualTo(AiChatErrorCode.USER_BOOK_NOT_FOUND);
+
+        verify(aiChatSessionRepository, never()).save(any());
+    }
+
+    @Test
+    void 존재하지_않는_userBook_도_동일한_USER_BOOK_NOT_FOUND_예외() {
+        // 존재하지 않는 케이스와 권한 없는 케이스가 정보 누설 없이 동일하게 처리되는지 검증
+        Long userId = 1L;
+        Long userBookId = 999_999L;
+        AiChatSessionCreateCommand command = new AiChatSessionCreateCommand(userId, userBookId);
+
+        given(userBookRepository.findByIdAndUserId(userBookId, userId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> aiChatSessionCreateService.execute(command))
+                .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
+                .extracting(NotFoundException::getErrorCode)
+                .isEqualTo(AiChatErrorCode.USER_BOOK_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/readum/domain/aiChat/service/AiStreamChatServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/AiStreamChatServiceTest.java
@@ -1,7 +1,7 @@
-package com.readum.domain.ai.service;
+package com.readum.domain.aiChat.service;
 
-import com.readum.domain.ai.dto.AiChatCommand;
-import com.readum.domain.ai.out.AiChatClient;
+import com.readum.domain.aiChat.dto.AiChatCommand;
+import com.readum.domain.aiChat.out.AiChatClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;

--- a/src/test/java/com/readum/model/book/repository/UserBookRepositoryTest.java
+++ b/src/test/java/com/readum/model/book/repository/UserBookRepositoryTest.java
@@ -1,0 +1,55 @@
+package com.readum.model.book.repository;
+
+import com.readum.model.book.entity.UserBook;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class UserBookRepositoryTest {
+
+    @Autowired
+    private UserBookRepository userBookRepository;
+
+    @Test
+    @DisplayName("동일한 userId 로 조회하면 present")
+    void findByIdAndUserId_매칭시_present() {
+        Long userId = nextUserId();
+        Long bookId = 100L;
+
+        UserBook saved = userBookRepository.save(UserBook.create(userId, bookId));
+
+        Optional<UserBook> found = userBookRepository.findByIdAndUserId(saved.getId(), userId);
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getBookId()).isEqualTo(bookId);
+    }
+
+    @Test
+    @DisplayName("다른 userId 로 조회하면 empty")
+    void findByIdAndUserId_userId_불일치시_empty() {
+        Long userId = nextUserId();
+        Long otherUserId = nextUserId();
+        Long bookId = 100L;
+
+        UserBook saved = userBookRepository.save(UserBook.create(userId, bookId));
+
+        Optional<UserBook> found = userBookRepository.findByIdAndUserId(saved.getId(), otherUserId);
+
+        assertThat(found).isEmpty();
+    }
+
+    private static long userIdSeq = 800_000L;
+
+    private static synchronized Long nextUserId() {
+        userIdSeq += 1;
+        return userIdSeq;
+    }
+}

--- a/src/test/java/com/readum/presentation/controller/aiChat/AiChatControllerTest.java
+++ b/src/test/java/com/readum/presentation/controller/aiChat/AiChatControllerTest.java
@@ -1,0 +1,105 @@
+package com.readum.presentation.controller.aiChat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.readum.domain.aiChat.dto.AiChatSessionCreateResult;
+import com.readum.domain.aiChat.exception.AiChatErrorCode;
+import com.readum.domain.aiChat.service.AiChatSessionCreateService;
+import com.readum.domain.aiChat.service.AiStreamChatService;
+import com.readum.domain.exception.NotFoundException;
+import com.readum.presentation.common.GlobalExceptionHandler;
+import com.readum.presentation.controller.aiChat.dto.AiChatSessionCreateRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class AiChatControllerTest {
+
+    @Mock
+    private AiStreamChatService aiStreamChatService;
+
+    @Mock
+    private AiChatSessionCreateService aiChatSessionCreateService;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final Long AUTHENTICATED_USER_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        AiChatController controller = new AiChatController(aiStreamChatService, aiChatSessionCreateService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+                .build();
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(AUTHENTICATED_USER_ID, null, List.of())
+        );
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void 정상_요청시_201과_세션_id_를_반환한다() throws Exception {
+        given(aiChatSessionCreateService.execute(any())).willReturn(new AiChatSessionCreateResult(42L));
+
+        mockMvc.perform(post("/api/v1/ai-chat/sessions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new AiChatSessionCreateRequest(10L))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.sessionId").value(42));
+    }
+
+    @Test
+    void userBookId_누락시_400() throws Exception {
+        mockMvc.perform(post("/api/v1/ai-chat/sessions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.message", containsString("userBookId는 필수")));
+    }
+
+    @Test
+    void userBookId_가_음수면_400() throws Exception {
+        mockMvc.perform(post("/api/v1/ai-chat/sessions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new AiChatSessionCreateRequest(-1L))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.message", containsString("양수")));
+    }
+
+    @Test
+    void 소유권_없는_userBookId_는_404() throws Exception {
+        given(aiChatSessionCreateService.execute(any()))
+                .willThrow(new NotFoundException(AiChatErrorCode.USER_BOOK_NOT_FOUND));
+
+        mockMvc.perform(post("/api/v1/ai-chat/sessions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new AiChatSessionCreateRequest(999_999L))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.message").value("해당 도서를 찾을 수 없습니다."));
+    }
+}


### PR DESCRIPTION
## 작업 사항

issue #29 의 "사용자가 AI 채팅 세션을 시작할 수 있다" 를 구현했습니다. 사용자가 책장에 등록한 도서(`user_book` row)에 대해 채팅 세션 row 를 만들고 그 ID 를 반환받아 이후 메시지 스트리밍 시 사용합니다. 기획상 한 도서에 대해 여러 세션을 열 수 있어야 하므로 idempotency 없이 매 요청마다 새 row 를 생성합니다.

구현하면서 도메인 경계를 함께 정리했습니다. 기존 `domain/ai/` 와 `model/chat/` 는 사실상 AI 채팅 전용 코드인데 이름이 generic 해서, 향후 사용자 간 채팅이 도입되면 이름이 충돌합니다. AI 는 도메인이 아니라 LLM 호출이라는 infrastructure capability 이고, AI 채팅 / 요약 / (미래) 사용자 간 채팅은 각각 독립 도메인이라는 관점에서 패키지·엔티티·테이블·URL 모두 `Ai` prefix 를 명시하도록 정리했습니다. `Summary` 엔티티의 FK 컬럼(`chat_session_id` → `ai_chat_session_id`)도 함께 갱신했습니다.

소유권 검증은 `findByIdAndUserId` 단일 쿼리로 처리해, "userBook 이 없음" 과 "다른 사용자 소유" 를 동일한 404 (`USER_BOOK_NOT_FOUND`) 로 응답합니다. 어느 쪽인지 구분하지 않아 정보 누설을 방지합니다.

인증 사용자 식별은 컨트롤러에서 처음으로 SecurityContext 의 userId 를 꺼내 쓰는 사례라 `@AuthenticationPrincipal Long userId` 패턴을 신규 컨벤션으로 도입했습니다. `JwtAuthenticationFilter` 가 principal 자리에 `Long` 을 직접 박아두기 때문에 그대로 주입됩니다. 이후 모든 컨트롤러는 동일 패턴으로 통일합니다.

### 기능

**AI 채팅 세션 생성**
- 등록된 책 1권에 대한 새 채팅 세션 row 생성, `sessionId` 반환
- 한 책에 여러 세션 허용 (idempotency 없음)
- 인증 사용자 본인 소유 도서만 세션 생성 가능

**입력 검증**
- `userBookId` 필수 (`@NotNull`), 양수 (`@Positive`)
- 위반 시 400 + 안내 메시지

**소유권 / 존재 검증**
- userBook 부재 또는 다른 사용자 소유 → 동일하게 404 ("해당 도서를 찾을 수 없습니다.")

**도메인 경계 정리**
- AI 채팅 코드 패키지/엔티티/테이블에 `Ai` prefix 명시 → 향후 사용자 간 채팅과 이름 충돌 방지
- 기존 `/api/v1/ai/chat/stream` → `/api/v1/ai-chat/stream` 로 URL 도 일관 변경
- `Summary` FK 컬럼명도 함께 정합

### API 스펙

| 항목 | 값 |
|---|---|
| Method | `POST` |
| Path | `/api/v1/ai-chat/sessions` |
| 인증 | `@AuthenticationPrincipal Long userId` (현 MVP 단계는 `SecurityConfig` permitAll 유지) |
| `userBookId` | Long, 필수, 양수 |

### 시나리오별 응답

**정상** — `POST /api/v1/ai-chat/sessions { "userBookId": 1 }`
```json
HTTP 201
{ "data": { "sessionId": 42 } }
```

**검증 실패 (필수 누락)** — `POST /api/v1/ai-chat/sessions {}`
```json
HTTP 400
{ "error": { "message": "userBookId: userBookId는 필수입니다." } }
```

**검증 실패 (음수)** — `POST /api/v1/ai-chat/sessions { "userBookId": -1 }`
```json
HTTP 400
{ "error": { "message": "userBookId: userBookId는 양수여야 합니다." } }
```

**소유권 / 존재 실패** — `POST /api/v1/ai-chat/sessions { "userBookId": 999999 }`
```json
HTTP 404
{ "error": { "message": "해당 도서를 찾을 수 없습니다." } }
```

## 테스트 결과
- [x] `./gradlew test` 전체 통과
- [x] Service 단위 테스트 (`AiChatSessionCreateServiceTest`) 3 케이스 — 정상 생성 / 다른 사용자 소유 → 404 + `save` 미호출 / 존재 안 함 → 동일 404
- [x] Controller MockMvc 테스트 (`AiChatControllerTest`) 4 케이스 — 201, `@NotNull` 400, `@Positive` 400, 404 propagation
- [x] 기존 `AiStreamChatServiceTest` 패키지 이동 후 통과 (회귀 없음)
- [ ] Repository 통합 테스트 (`UserBookRepositoryTest`) — `MYSQL_PASSWORD` 환경변수 보유 환경에서만 자동 수행
- [ ] 수동 통합 테스트 (curl) — `JwtAuthenticationFilter` 가 비활성 상태라 보류 (인증 구현 후 별도 검증 예정)

## 관련 이슈
- closes #29

## 참고 사항

### DB 스키마 변경

테이블명이랑 컬럼명좀 수정하고 적용하느라 DB를 한 번 드롭하고 재생성했습니다.

### URL Breaking Change

기존 `/api/v1/ai/chat/stream` → `/api/v1/ai-chat/stream` 로 변경됐습니다. 호출하던 클라이언트가 있다면 함께 갱신 필요.

### 인증 비활성화 상태

현재 `SecurityConfig` 가 MVP 모드라 `JwtAuthenticationFilter` 가 비활성입니다. 단위 테스트는 `SecurityContextHolder` 를 직접 세팅해 검증되며, 실제 서버에 curl 로 호출 시에는 `@AuthenticationPrincipal` 이 null 이라 회원 가입/로그인 구현 이후 후속 PR 에서 수동 통합 검증을 다룰 예정입니다.

### 로컬 테스트 보조

- `db/seed/book.sql`: 로컬 통합 테스트용 `book` 더미(id=1) 1 row 삽입 스크립트