### PR TITLE
feat(user): 사용자 세션 발급 / 조회 / 온보딩 완료 API 추가

### DIFF
--- a/src/main/java/com/readum/domain/user/dto/CompleteOnboardingResult.java
+++ b/src/main/java/com/readum/domain/user/dto/CompleteOnboardingResult.java
@@ -1,0 +1,4 @@
+package com.readum.domain.user.dto;
+
+public record CompleteOnboardingResult(boolean onboardingCompleted) {
+}

--- a/src/main/java/com/readum/domain/user/dto/CreateUserSessionResult.java
+++ b/src/main/java/com/readum/domain/user/dto/CreateUserSessionResult.java
@@ -1,0 +1,11 @@
+package com.readum.domain.user.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CreateUserSessionResult(
+        Long userId,
+        UUID sessionId,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/readum/domain/user/dto/UserSessionInfoResult.java
+++ b/src/main/java/com/readum/domain/user/dto/UserSessionInfoResult.java
@@ -1,0 +1,8 @@
+package com.readum.domain.user.dto;
+
+public record UserSessionInfoResult(
+        Long lastSelectedUserBookId,
+        boolean hasRegisteredBooks,
+        boolean onboardingCompleted
+) {
+}

--- a/src/main/java/com/readum/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/readum/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,19 @@
+package com.readum.domain.user.exception;
+
+import com.readum.domain.exception.ErrorCode;
+
+public enum UserErrorCode implements ErrorCode {
+
+    INVALID_SESSION("유효하지 않은 세션입니다.");
+
+    private final String message;
+
+    UserErrorCode(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/readum/domain/user/service/CompleteOnboardingService.java
+++ b/src/main/java/com/readum/domain/user/service/CompleteOnboardingService.java
@@ -1,0 +1,29 @@
+package com.readum.domain.user.service;
+
+import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.dto.CompleteOnboardingResult;
+import com.readum.domain.user.exception.UserErrorCode;
+import com.readum.model.user.entity.User;
+import com.readum.model.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CompleteOnboardingService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public CompleteOnboardingResult execute(String sessionId) {
+        User user = userRepository.findBySessionId(sessionId)
+                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
+
+        if (!user.isOnboardingCompleted()) {
+            user.completeOnboarding();
+        }
+
+        return new CompleteOnboardingResult(user.isOnboardingCompleted());
+    }
+}

--- a/src/main/java/com/readum/domain/user/service/CreateUserSessionService.java
+++ b/src/main/java/com/readum/domain/user/service/CreateUserSessionService.java
@@ -1,0 +1,24 @@
+package com.readum.domain.user.service;
+
+import com.readum.domain.user.dto.CreateUserSessionResult;
+import com.readum.model.user.entity.User;
+import com.readum.model.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CreateUserSessionService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public CreateUserSessionResult execute() {
+        UUID sessionId = UUID.randomUUID();
+        User saved = userRepository.save(User.create(sessionId));
+        return new CreateUserSessionResult(saved.getId(), sessionId, saved.getCreatedAt());
+    }
+}

--- a/src/main/java/com/readum/domain/user/service/UserSearchService.java
+++ b/src/main/java/com/readum/domain/user/service/UserSearchService.java
@@ -1,0 +1,33 @@
+package com.readum.domain.user.service;
+
+import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.dto.UserSessionInfoResult;
+import com.readum.domain.user.exception.UserErrorCode;
+import com.readum.model.book.repository.UserBookRepository;
+import com.readum.model.user.entity.User;
+import com.readum.model.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserSearchService {
+
+    private final UserRepository userRepository;
+    private final UserBookRepository userBookRepository;
+
+    @Transactional(readOnly = true)
+    public UserSessionInfoResult findSessionInfo(String sessionId) {
+        User user = userRepository.findBySessionId(sessionId)
+                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
+
+        boolean hasRegisteredBooks = userBookRepository.existsByUserId(user.getId());
+
+        return new UserSessionInfoResult(
+                user.getLastSelectedUserBookId(),
+                hasRegisteredBooks,
+                user.isOnboardingCompleted()
+        );
+    }
+}

--- a/src/main/java/com/readum/model/book/repository/UserBookRepository.java
+++ b/src/main/java/com/readum/model/book/repository/UserBookRepository.java
@@ -1,0 +1,9 @@
+package com.readum.model.book.repository;
+
+import com.readum.model.book.entity.UserBook;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserBookRepository extends JpaRepository<UserBook, Long> {
+
+    boolean existsByUserId(Long userId);
+}

--- a/src/main/java/com/readum/model/user/entity/User.java
+++ b/src/main/java/com/readum/model/user/entity/User.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Getter
 @Entity
@@ -24,8 +25,17 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "device_id", nullable = false, unique = true, length = 255)
+    @Column(name = "device_id", unique = true, length = 255)
     private String deviceId;
+
+    @Column(name = "session_id", nullable = false, unique = true, length = 36)
+    private String sessionId;
+
+    @Column(name = "last_selected_user_book_id")
+    private Long lastSelectedUserBookId;
+
+    @Column(name = "onboarding_completed", nullable = false)
+    private boolean onboardingCompleted;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -33,12 +43,30 @@ public class User {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    public static User create(String deviceId) {
+    public static User create(UUID sessionId) {
         LocalDateTime now = LocalDateTime.now();
-        return new User(null, deviceId, now, now);
+        return new User(null, null, sessionId.toString(), null, false, now, now);
     }
 
-    public static User of(Long id, String deviceId, LocalDateTime createdAt, LocalDateTime updatedAt) {
-        return new User(id, deviceId, createdAt, updatedAt);
+    public static User of(
+            Long id,
+            String deviceId,
+            String sessionId,
+            Long lastSelectedUserBookId,
+            boolean onboardingCompleted,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        return new User(id, deviceId, sessionId, lastSelectedUserBookId, onboardingCompleted, createdAt, updatedAt);
+    }
+
+    public void completeOnboarding() {
+        this.onboardingCompleted = true;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void selectBook(Long userBookId) {
+        this.lastSelectedUserBookId = userBookId;
+        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/readum/model/user/repository/UserRepository.java
+++ b/src/main/java/com/readum/model/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.readum.model.user.repository;
+
+import com.readum.model.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findBySessionId(String sessionId);
+}

--- a/src/main/java/com/readum/presentation/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/readum/presentation/common/GlobalExceptionHandler.java
@@ -17,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -100,6 +101,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<?>> handleIllegalArgument(IllegalArgumentException ex) {
         log.warn("Illegal argument: {}", ex.getMessage());
         return ApiResponse.error(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    // @CookieValue(required = true) 로 선언된 쿠키가 요청에 없을 때
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ResponseEntity<ApiResponse<?>> handleMissingCookie(MissingRequestCookieException ex) {
+        log.debug("Missing cookie: {}", ex.getCookieName());
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, "필수 쿠키가 없습니다: " + ex.getCookieName());
     }
 
     // @Valid 어노테이션 검증 실패 (필드 제약 조건 위반)

--- a/src/main/java/com/readum/presentation/controller/user/UserController.java
+++ b/src/main/java/com/readum/presentation/controller/user/UserController.java
@@ -1,0 +1,51 @@
+package com.readum.presentation.controller.user;
+
+import com.readum.domain.user.dto.CreateUserSessionResult;
+import com.readum.domain.user.service.CreateUserSessionService;
+import com.readum.presentation.common.ApiResponse;
+import com.readum.presentation.controller.user.dto.CreateUserSessionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    static final String USER_SESSION_COOKIE = "user_session";
+    private static final long SESSION_COOKIE_MAX_AGE_SECONDS = Duration.ofDays(365).toSeconds();
+
+    private final CreateUserSessionService createUserSessionService;
+
+    @Value("${user.session-cookie-secure:true}")
+    private boolean sessionCookieSecure;
+
+    @PostMapping("/sessions")
+    public ResponseEntity<ApiResponse<CreateUserSessionResponse>> createSession() {
+        CreateUserSessionResult result = createUserSessionService.execute();
+
+        ResponseCookie cookie = buildSessionCookie(result.sessionId().toString(), SESSION_COOKIE_MAX_AGE_SECONDS);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(new ApiResponse<>(CreateUserSessionResponse.from(result), null));
+    }
+
+    private ResponseCookie buildSessionCookie(String value, long maxAgeSeconds) {
+        return ResponseCookie.from(USER_SESSION_COOKIE, value)
+                .httpOnly(true)
+                .secure(sessionCookieSecure)
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(maxAgeSeconds)
+                .build();
+    }
+}

--- a/src/main/java/com/readum/presentation/controller/user/UserController.java
+++ b/src/main/java/com/readum/presentation/controller/user/UserController.java
@@ -1,15 +1,22 @@
 package com.readum.presentation.controller.user;
 
+import com.readum.domain.exception.UnauthorizedException;
 import com.readum.domain.user.dto.CreateUserSessionResult;
+import com.readum.domain.user.dto.UserSessionInfoResult;
+import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.domain.user.service.CreateUserSessionService;
+import com.readum.domain.user.service.UserSearchService;
 import com.readum.presentation.common.ApiResponse;
 import com.readum.presentation.controller.user.dto.CreateUserSessionResponse;
+import com.readum.presentation.controller.user.dto.UserSessionInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,6 +32,7 @@ public class UserController {
     private static final long SESSION_COOKIE_MAX_AGE_SECONDS = Duration.ofDays(365).toSeconds();
 
     private final CreateUserSessionService createUserSessionService;
+    private final UserSearchService userSearchService;
 
     @Value("${user.session-cookie-secure:true}")
     private boolean sessionCookieSecure;
@@ -37,6 +45,21 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
                 .body(new ApiResponse<>(CreateUserSessionResponse.from(result), null));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserSessionInfoResponse>> getSessionInfo(
+            @CookieValue(name = USER_SESSION_COOKIE, required = false) String sessionId) {
+        String resolvedSessionId = requireSessionId(sessionId);
+        UserSessionInfoResult result = userSearchService.findSessionInfo(resolvedSessionId);
+        return ApiResponse.ok(UserSessionInfoResponse.from(result));
+    }
+
+    private String requireSessionId(String sessionId) {
+        if (sessionId == null || sessionId.isBlank()) {
+            throw new UnauthorizedException(UserErrorCode.INVALID_SESSION);
+        }
+        return sessionId;
     }
 
     private ResponseCookie buildSessionCookie(String value, long maxAgeSeconds) {

--- a/src/main/java/com/readum/presentation/controller/user/UserController.java
+++ b/src/main/java/com/readum/presentation/controller/user/UserController.java
@@ -1,10 +1,8 @@
 package com.readum.presentation.controller.user;
 
-import com.readum.domain.exception.UnauthorizedException;
 import com.readum.domain.user.dto.CompleteOnboardingResult;
 import com.readum.domain.user.dto.CreateUserSessionResult;
 import com.readum.domain.user.dto.UserSessionInfoResult;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.domain.user.service.CompleteOnboardingService;
 import com.readum.domain.user.service.CreateUserSessionService;
 import com.readum.domain.user.service.UserSearchService;
@@ -53,25 +51,16 @@ public class UserController {
 
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<UserSessionInfoResponse>> getSessionInfo(
-            @CookieValue(name = USER_SESSION_COOKIE, required = false) String sessionId) {
-        String resolvedSessionId = requireSessionId(sessionId);
-        UserSessionInfoResult result = userSearchService.findSessionInfo(resolvedSessionId);
+            @CookieValue(name = USER_SESSION_COOKIE, required = true) String sessionId) {
+        UserSessionInfoResult result = userSearchService.findSessionInfo(sessionId);
         return ApiResponse.ok(UserSessionInfoResponse.from(result));
     }
 
     @PostMapping("/me/onboarding")
     public ResponseEntity<ApiResponse<CompleteOnboardingResponse>> completeOnboarding(
-            @CookieValue(name = USER_SESSION_COOKIE, required = false) String sessionId) {
-        String resolvedSessionId = requireSessionId(sessionId);
-        CompleteOnboardingResult result = completeOnboardingService.execute(resolvedSessionId);
+            @CookieValue(name = USER_SESSION_COOKIE, required = true) String sessionId) {
+        CompleteOnboardingResult result = completeOnboardingService.execute(sessionId);
         return ApiResponse.ok(CompleteOnboardingResponse.from(result));
-    }
-
-    private String requireSessionId(String sessionId) {
-        if (sessionId == null || sessionId.isBlank()) {
-            throw new UnauthorizedException(UserErrorCode.INVALID_SESSION);
-        }
-        return sessionId;
     }
 
     private ResponseCookie buildSessionCookie(String value, long maxAgeSeconds) {

--- a/src/main/java/com/readum/presentation/controller/user/UserController.java
+++ b/src/main/java/com/readum/presentation/controller/user/UserController.java
@@ -1,12 +1,15 @@
 package com.readum.presentation.controller.user;
 
 import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.dto.CompleteOnboardingResult;
 import com.readum.domain.user.dto.CreateUserSessionResult;
 import com.readum.domain.user.dto.UserSessionInfoResult;
 import com.readum.domain.user.exception.UserErrorCode;
+import com.readum.domain.user.service.CompleteOnboardingService;
 import com.readum.domain.user.service.CreateUserSessionService;
 import com.readum.domain.user.service.UserSearchService;
 import com.readum.presentation.common.ApiResponse;
+import com.readum.presentation.controller.user.dto.CompleteOnboardingResponse;
 import com.readum.presentation.controller.user.dto.CreateUserSessionResponse;
 import com.readum.presentation.controller.user.dto.UserSessionInfoResponse;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +36,7 @@ public class UserController {
 
     private final CreateUserSessionService createUserSessionService;
     private final UserSearchService userSearchService;
+    private final CompleteOnboardingService completeOnboardingService;
 
     @Value("${user.session-cookie-secure:true}")
     private boolean sessionCookieSecure;
@@ -53,6 +57,14 @@ public class UserController {
         String resolvedSessionId = requireSessionId(sessionId);
         UserSessionInfoResult result = userSearchService.findSessionInfo(resolvedSessionId);
         return ApiResponse.ok(UserSessionInfoResponse.from(result));
+    }
+
+    @PostMapping("/me/onboarding")
+    public ResponseEntity<ApiResponse<CompleteOnboardingResponse>> completeOnboarding(
+            @CookieValue(name = USER_SESSION_COOKIE, required = false) String sessionId) {
+        String resolvedSessionId = requireSessionId(sessionId);
+        CompleteOnboardingResult result = completeOnboardingService.execute(resolvedSessionId);
+        return ApiResponse.ok(CompleteOnboardingResponse.from(result));
     }
 
     private String requireSessionId(String sessionId) {

--- a/src/main/java/com/readum/presentation/controller/user/dto/CompleteOnboardingResponse.java
+++ b/src/main/java/com/readum/presentation/controller/user/dto/CompleteOnboardingResponse.java
@@ -1,0 +1,12 @@
+package com.readum.presentation.controller.user.dto;
+
+import com.readum.domain.user.dto.CompleteOnboardingResult;
+
+public record CompleteOnboardingResponse(User user) {
+
+    public record User(boolean onboardingCompleted) {}
+
+    public static CompleteOnboardingResponse from(CompleteOnboardingResult result) {
+        return new CompleteOnboardingResponse(new User(result.onboardingCompleted()));
+    }
+}

--- a/src/main/java/com/readum/presentation/controller/user/dto/CreateUserSessionResponse.java
+++ b/src/main/java/com/readum/presentation/controller/user/dto/CreateUserSessionResponse.java
@@ -1,0 +1,14 @@
+package com.readum.presentation.controller.user.dto;
+
+import com.readum.domain.user.dto.CreateUserSessionResult;
+
+import java.time.LocalDateTime;
+
+public record CreateUserSessionResponse(User user) {
+
+    public record User(Long id, LocalDateTime createdAt) {}
+
+    public static CreateUserSessionResponse from(CreateUserSessionResult result) {
+        return new CreateUserSessionResponse(new User(result.userId(), result.createdAt()));
+    }
+}

--- a/src/main/java/com/readum/presentation/controller/user/dto/UserSessionInfoResponse.java
+++ b/src/main/java/com/readum/presentation/controller/user/dto/UserSessionInfoResponse.java
@@ -1,0 +1,21 @@
+package com.readum.presentation.controller.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.readum.domain.user.dto.UserSessionInfoResult;
+
+public record UserSessionInfoResponse(Session session) {
+
+    public record Session(
+            @JsonInclude(JsonInclude.Include.ALWAYS) Long lastSelectedUserBookId,
+            boolean hasRegisteredBooks,
+            boolean onboardingCompleted
+    ) {}
+
+    public static UserSessionInfoResponse from(UserSessionInfoResult result) {
+        return new UserSessionInfoResponse(new Session(
+                result.lastSelectedUserBookId(),
+                result.hasRegisteredBooks(),
+                result.onboardingCompleted()
+        ));
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,7 +13,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,7 +13,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,9 @@ jwt:
   refresh-cookie-secure: true
   blacklist-max-size: 10000
 
+user:
+  session-cookie-secure: true
+
 springdoc:
   api-docs:
     enabled: false

--- a/src/test/java/com/readum/domain/user/service/CompleteOnboardingServiceTest.java
+++ b/src/test/java/com/readum/domain/user/service/CompleteOnboardingServiceTest.java
@@ -1,0 +1,72 @@
+package com.readum.domain.user.service;
+
+import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.dto.CompleteOnboardingResult;
+import com.readum.domain.user.exception.UserErrorCode;
+import com.readum.model.user.entity.User;
+import com.readum.model.user.repository.UserRepository;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CompleteOnboardingServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private CompleteOnboardingService completeOnboardingService;
+
+    @Test
+    void 미완료_사용자에_대해_온보딩을_완료_상태로_변경한다() {
+        UUID sessionId = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.now();
+        User user = User.of(1L, null, sessionId.toString(), null, false, now, now);
+
+        given(userRepository.findBySessionId(sessionId.toString())).willReturn(Optional.of(user));
+
+        CompleteOnboardingResult result = completeOnboardingService.execute(sessionId.toString());
+
+        assertThat(result.onboardingCompleted()).isTrue();
+        assertThat(user.isOnboardingCompleted()).isTrue();
+    }
+
+    @Test
+    void 이미_완료된_사용자에_대해_멱등하게_true_를_반환한다() {
+        UUID sessionId = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.now();
+        User user = User.of(2L, null, sessionId.toString(), null, true, now, now);
+        LocalDateTime previousUpdatedAt = user.getUpdatedAt();
+
+        given(userRepository.findBySessionId(sessionId.toString())).willReturn(Optional.of(user));
+
+        CompleteOnboardingResult result = completeOnboardingService.execute(sessionId.toString());
+
+        assertThat(result.onboardingCompleted()).isTrue();
+        assertThat(user.isOnboardingCompleted()).isTrue();
+        assertThat(user.getUpdatedAt()).isEqualTo(previousUpdatedAt);
+    }
+
+    @Test
+    void 존재하지_않는_세션이면_INVALID_SESSION_예외가_발생한다() {
+        String unknown = UUID.randomUUID().toString();
+        given(userRepository.findBySessionId(unknown)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> completeOnboardingService.execute(unknown))
+                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
+                .extracting(UnauthorizedException::getErrorCode)
+                .isEqualTo(UserErrorCode.INVALID_SESSION);
+    }
+}

--- a/src/test/java/com/readum/domain/user/service/CreateUserSessionServiceTest.java
+++ b/src/test/java/com/readum/domain/user/service/CreateUserSessionServiceTest.java
@@ -1,0 +1,57 @@
+package com.readum.domain.user.service;
+
+import com.readum.domain.user.dto.CreateUserSessionResult;
+import com.readum.model.user.entity.User;
+import com.readum.model.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CreateUserSessionServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private CreateUserSessionService createUserSessionService;
+
+    @Test
+    void 신규_사용자를_저장하고_세션_식별자를_반환한다() {
+        given(userRepository.save(org.mockito.ArgumentMatchers.any(User.class))).willAnswer(invocation -> {
+            User input = invocation.getArgument(0);
+            LocalDateTime now = LocalDateTime.now();
+            return User.of(
+                    1L,
+                    null,
+                    input.getSessionId(),
+                    null,
+                    false,
+                    now,
+                    now
+            );
+        });
+
+        CreateUserSessionResult result = createUserSessionService.execute();
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+
+        User savedArg = captor.getValue();
+        assertThat(savedArg.getSessionId()).isEqualTo(result.sessionId().toString());
+        assertThat(savedArg.isOnboardingCompleted()).isFalse();
+        assertThat(result.userId()).isEqualTo(1L);
+        assertThat(result.sessionId()).isInstanceOf(UUID.class);
+        assertThat(result.createdAt()).isNotNull();
+    }
+}

--- a/src/test/java/com/readum/domain/user/service/UserSearchServiceTest.java
+++ b/src/test/java/com/readum/domain/user/service/UserSearchServiceTest.java
@@ -1,0 +1,78 @@
+package com.readum.domain.user.service;
+
+import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.dto.UserSessionInfoResult;
+import com.readum.domain.user.exception.UserErrorCode;
+import com.readum.model.book.repository.UserBookRepository;
+import com.readum.model.user.entity.User;
+import com.readum.model.user.repository.UserRepository;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class UserSearchServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserBookRepository userBookRepository;
+
+    @InjectMocks
+    private UserSearchService userSearchService;
+
+    @Test
+    void 유효한_세션이면_세션_정보를_반환한다() {
+        UUID sessionId = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.now();
+        User user = User.of(10L, null, sessionId.toString(), 7L, false, now, now);
+
+        given(userRepository.findBySessionId(sessionId.toString())).willReturn(Optional.of(user));
+        given(userBookRepository.existsByUserId(10L)).willReturn(true);
+
+        UserSessionInfoResult result = userSearchService.findSessionInfo(sessionId.toString());
+
+        assertThat(result.lastSelectedUserBookId()).isEqualTo(7L);
+        assertThat(result.hasRegisteredBooks()).isTrue();
+        assertThat(result.onboardingCompleted()).isFalse();
+    }
+
+    @Test
+    void 등록된_도서가_없으면_hasRegisteredBooks_가_false_이다() {
+        UUID sessionId = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.now();
+        User user = User.of(11L, null, sessionId.toString(), null, true, now, now);
+
+        given(userRepository.findBySessionId(sessionId.toString())).willReturn(Optional.of(user));
+        given(userBookRepository.existsByUserId(11L)).willReturn(false);
+
+        UserSessionInfoResult result = userSearchService.findSessionInfo(sessionId.toString());
+
+        assertThat(result.lastSelectedUserBookId()).isNull();
+        assertThat(result.hasRegisteredBooks()).isFalse();
+        assertThat(result.onboardingCompleted()).isTrue();
+    }
+
+    @Test
+    void 존재하지_않는_세션이면_INVALID_SESSION_예외가_발생한다() {
+        String unknown = UUID.randomUUID().toString();
+        given(userRepository.findBySessionId(unknown)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userSearchService.findSessionInfo(unknown))
+                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
+                .extracting(UnauthorizedException::getErrorCode)
+                .isEqualTo(UserErrorCode.INVALID_SESSION);
+    }
+}

--- a/src/test/java/com/readum/model/book/repository/UserBookRepositoryTest.java
+++ b/src/test/java/com/readum/model/book/repository/UserBookRepositoryTest.java
@@ -45,6 +45,7 @@ class UserBookRepositoryTest {
     private static long userIdSeq = 800_000L;
     private static long bookIdSeq = 800_000L;
 
+    @Test
     @DisplayName("동일한 userId 로 조회하면 present")
     void findByIdAndUserId_매칭시_present() {
         Long userId = nextUserId();
@@ -71,8 +72,6 @@ class UserBookRepositoryTest {
 
         assertThat(found).isEmpty();
     }
-
-    private static long userIdSeq = 800_000L;
 
     private static synchronized Long nextUserId() {
         userIdSeq += 1;

--- a/src/test/java/com/readum/model/book/repository/UserBookRepositoryTest.java
+++ b/src/test/java/com/readum/model/book/repository/UserBookRepositoryTest.java
@@ -1,0 +1,57 @@
+package com.readum.model.book.repository;
+
+import com.readum.model.book.entity.UserBook;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("local")
+@Transactional
+@EnabledIfEnvironmentVariable(named = "MYSQL_PASSWORD", matches = ".+")
+class UserBookRepositoryTest {
+
+    @Autowired
+    private UserBookRepository userBookRepository;
+
+    @Test
+    @DisplayName("등록된 도서가 있으면 existsByUserId 가 true 를 반환한다")
+    void existsByUserId_등록된_경우() {
+        Long userId = nextUserId();
+        Long bookId = nextBookId();
+        userBookRepository.save(UserBook.create(userId, bookId));
+
+        boolean exists = userBookRepository.existsByUserId(userId);
+
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("등록된 도서가 없으면 existsByUserId 가 false 를 반환한다")
+    void existsByUserId_미등록_경우() {
+        Long userId = nextUserId();
+
+        boolean exists = userBookRepository.existsByUserId(userId);
+
+        assertThat(exists).isFalse();
+    }
+
+    private static long userIdSeq = 800_000L;
+    private static long bookIdSeq = 800_000L;
+
+    private static synchronized Long nextUserId() {
+        userIdSeq += 1;
+        return userIdSeq;
+    }
+
+    private static synchronized Long nextBookId() {
+        bookIdSeq += 1;
+        return bookIdSeq;
+    }
+}

--- a/src/test/java/com/readum/model/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/readum/model/user/repository/UserRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.readum.model.user.repository;
+
+import com.readum.model.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("local")
+@Transactional
+@EnabledIfEnvironmentVariable(named = "MYSQL_PASSWORD", matches = ".+")
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("sessionId 로 저장한 사용자를 조회할 수 있다")
+    void sessionId_로_조회() {
+        UUID sessionId = UUID.randomUUID();
+        User saved = userRepository.save(User.create(sessionId));
+
+        Optional<User> found = userRepository.findBySessionId(sessionId.toString());
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(saved.getId());
+        assertThat(found.get().getSessionId()).isEqualTo(sessionId.toString());
+        assertThat(found.get().isOnboardingCompleted()).isFalse();
+        assertThat(found.get().getLastSelectedUserBookId()).isNull();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 sessionId 로 조회하면 빈 Optional 을 반환한다")
+    void 존재하지_않는_sessionId_조회() {
+        Optional<User> found = userRepository.findBySessionId(UUID.randomUUID().toString());
+
+        assertThat(found).isEmpty();
+    }
+}


### PR DESCRIPTION
## 작업 사항

- 서비스 진입 직후 익명 사용자를 식별하기 위한 세션 발급 / 조회 / 온보딩 완료 3종 API 신규 추가
- 세션 식별자는 서버에서 발급한 UUID 를 httpOnly 쿠키(`user_session`, 365일, `SameSite=Lax`, `Path=/`) 로만 전달. 응답 본문에는 UUID 를 싣지 않아 XSS 로 인한 세션 탈취 경로 차단
- 쿠키 secure 옵션은 기존 `jwt.refresh-cookie-secure` 패턴을 따라 `user.session-cookie-secure` 프로퍼티로 분리(로컬에서 secure off 가능)
- 세션 검증은 Service 레이어 한 곳에서만 수행. 컨트롤러는 `@CookieValue(required = true)` 로 쿠키 존재만 보장하고, "쿠키 값이 실제 사용자에 매칭되는가" 는 `UserSearchService` / `CompleteOnboardingService` 가 `UserErrorCode.INVALID_SESSION` 으로 통일 처리
- `User` 엔티티에 `sessionId`(UUID, unique) / `lastSelectedUserBookId`(UserBook.id 참조, 연관관계 매핑 X) / `onboardingCompleted`(boolean) 컬럼 추가. 미사용 상태인 `deviceId` 는 nullable 로 완화하고 컬럼은 보존
- `UserRepository` / `UserBookRepository` 는 본 기능에 필요한 만큼만 노출(`findBySessionId`, `existsByUserId`). 도서 등록 여부는 `existsByUserId` 한 번 호출로 판단
- 스키마 적용은 운영자 수동 ALTER 흐름 유지. dev 프로파일도 `ddl-auto: validate` 그대로(임시 `update` 변경분은 동일 PR 안에서 원복)

### 기능

**사용자 세션 발급**
- 최초 진입 시 서버가 UUID 를 생성해 사용자 row 생성 후 httpOnly 쿠키로 응답
- 쿠키 365일 / SameSite=Lax / Path=/
- 응답 본문에 UUID 미노출

**세션 정보 조회**
- 쿠키 한 번으로 (1) 마지막 선택 도서 ID, (2) 도서 등록 여부, (3) 온보딩 완료 여부 동시 응답
- 첫 화면 분기를 한 번의 호출로 처리

**온보딩 완료**
- 온보딩 종료 시점에 완료 상태 영속화
- 이미 완료된 사용자가 다시 호출해도 멱등(updatedAt 변경 없음)

**세션 유효성 검증 일원화**
- 쿠키 부재는 `@CookieValue(required = true)` 가 차단
- 매칭 사용자 부재는 Service 레이어가 `UserErrorCode.INVALID_SESSION` 으로 통일 처리

### API 스펙

**1) POST /api/v1/users/sessions**

| 항목 | 값 |
|---|---|
| Method | `POST` |
| Path | `/api/v1/users/sessions` |
| Request body | 없음 |
| Cookie | 불필요 (있어도 무시하고 신규 발급) |
| Response | `201 Created`, `Set-Cookie: user_session=<uuid>; Max-Age=31536000; HttpOnly; SameSite=Lax; Secure; Path=/` |

**2) GET /api/v1/users/me**

| 항목 | 값 |
|---|---|
| Method | `GET` |
| Path | `/api/v1/users/me` |
| Cookie | `user_session` 필수 |

**3) POST /api/v1/users/me/onboarding**

| 항목 | 값 |
|---|---|
| Method | `POST` |
| Path | `/api/v1/users/me/onboarding` |
| Request body | 없음 |
| Cookie | `user_session` 필수 |

### 시나리오별 응답

**세션 발급 정상** — `POST /api/v1/users/sessions`
```json
HTTP 201
Set-Cookie: user_session=8e3b...; Max-Age=31536000; HttpOnly; SameSite=Lax; Secure; Path=/
{
  "data": {
    "user": {
      "id": 1,
      "createdAt": "2026-04-26T12:34:56"
    }
  }
}
```

**세션 조회 정상 (도서 등록·미온보딩)** — `GET /api/v1/users/me`
```json
HTTP 200
{
  "data": {
    "session": {
      "lastSelectedUserBookId": 12,
      "hasRegisteredBooks": true,
      "onboardingCompleted": false
    }
  }
}
```

**세션 조회 정상 (도서 미등록)** — `GET /api/v1/users/me`
```json
HTTP 200
{
  "data": {
    "session": {
      "lastSelectedUserBookId": null,
      "hasRegisteredBooks": false,
      "onboardingCompleted": false
    }
  }
}
```

**온보딩 완료 정상** — `POST /api/v1/users/me/onboarding`
```json
HTTP 200
{
  "data": {
    "user": {
      "onboardingCompleted": true
    }
  }
}
```

**쿠키 부재** — `GET /api/v1/users/me`
```json
HTTP 400
{ "error": { "message": "..." } }
```
(Spring `MissingRequestCookieException` 의 기본 매핑)

**쿠키 값이 매칭 사용자 없음** — `GET /api/v1/users/me`
```json
HTTP 401
{ "error": { "message": "유효하지 않은 세션입니다." } }
```

## 테스트 결과
- [x] `./gradlew build` 통과
- [x] `CreateUserSessionService` 단위 테스트: UUID 발급 + 저장 호출 검증
- [x] `UserSearchService` 단위 테스트: 정상 / 도서 미등록 / 세션 미존재(INVALID_SESSION)
- [x] `CompleteOnboardingService` 단위 테스트: 정상 / 멱등 / 세션 미존재
- [ ] `UserRepository` / `UserBookRepository` 통합 테스트 — `MYSQL_PASSWORD` 환경 필요 (기존 `RefreshTokenRepositoryTest` 패턴 동일)
- [ ] 리뷰어가 검증할 수동 시나리오: `POST .../sessions` → cookie 저장 → `GET .../me` → `POST .../me/onboarding` → 다시 `GET .../me` 에서 `onboardingCompleted: true` 확인

## 참고 사항

`User` 테이블에 컬럼 3개가 추가되고 `device_id` 의 NOT NULL 제약이 완화됩니다. 운영 적용 시 다음 ALTER 가 선행되어야 합니다.

```sql
ALTER TABLE `user`
  ADD COLUMN session_id VARCHAR(36) NOT NULL,
  ADD COLUMN last_selected_user_book_id BIGINT NULL,
  ADD COLUMN onboarding_completed BOOLEAN NOT NULL DEFAULT FALSE,
  ADD UNIQUE KEY uk_user_session_id (session_id),
  MODIFY COLUMN device_id VARCHAR(255) NULL;
```

dev 프로파일은 `ddl-auto: validate` 그대로이며, 별도 마이그레이션 도구(Flyway 등) 도입은 후속 이슈로 분리할 예정입니다.

`lastSelectedUserBookId` 갱신 API 는 본 PR 범위에 포함하지 않았습니다. 도서 선택 기능 PR 에서 `User.selectBook(userBookId)` 도메인 메서드를 호출해 갱신할 예정입니다(엔티티 메서드는 본 PR 에 미리 두었습니다).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 세션 기반 사용자 관리(세션 생성·조회) 및 세션 쿠키 제공
  * 온보딩 완료 상태 저장 및 완료 처리 API 추가
  * 사용자별 마지막 선택 도서 정보 조회 기능 추가

* **Bug Fixes**
  * 누락된 세션 쿠키 요청에 대해 명확한 400 응답 처리 추가

* **Chores**
  * 세션 쿠키 보안 설정 구성 옵션 추가

* **Tests**
  * 세션·온보딩 관련 단위 및 통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->