### PR TITLE
feat(user-book): 내 책장 등록 도서 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/readum/domain/user/userbook/dto/UserBookSearchItemResult.java
+++ b/src/main/java/com/readum/domain/user/userbook/dto/UserBookSearchItemResult.java
@@ -1,0 +1,22 @@
+package com.readum.domain.user.userbook.dto;
+
+import com.readum.model.user.repository.projection.UserBookListItemProjection;
+
+public record UserBookSearchItemResult(
+        Long id,
+        String title,
+        String publisher,
+        Integer publishedYear,
+        String coverUrl
+) {
+
+    public static UserBookSearchItemResult from(UserBookListItemProjection projection) {
+        return new UserBookSearchItemResult(
+                projection.id(),
+                projection.title(),
+                projection.publisher(),
+                projection.publishedYear(),
+                projection.coverUrl()
+        );
+    }
+}

--- a/src/main/java/com/readum/domain/user/userbook/dto/UserBookSearchResult.java
+++ b/src/main/java/com/readum/domain/user/userbook/dto/UserBookSearchResult.java
@@ -1,0 +1,8 @@
+package com.readum.domain.user.userbook.dto;
+
+import java.util.List;
+
+public record UserBookSearchResult(
+        List<UserBookSearchItemResult> books
+) {
+}

--- a/src/main/java/com/readum/domain/user/userbook/service/UserBookSearchService.java
+++ b/src/main/java/com/readum/domain/user/userbook/service/UserBookSearchService.java
@@ -1,0 +1,34 @@
+package com.readum.domain.user.userbook.service;
+
+import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.exception.UserErrorCode;
+import com.readum.domain.user.userbook.dto.UserBookSearchItemResult;
+import com.readum.domain.user.userbook.dto.UserBookSearchResult;
+import com.readum.model.user.entity.User;
+import com.readum.model.user.repository.UserBookRepository;
+import com.readum.model.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserBookSearchService {
+
+    private final UserRepository userRepository;
+    private final UserBookRepository userBookRepository;
+
+    public UserBookSearchResult findMyBooks(String userSessionId) {
+        User user = userRepository.findBySessionId(userSessionId)
+                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
+
+        List<UserBookSearchItemResult> books = userBookRepository
+                .findAllByUserIdOrderByCreatedAtDescIdDesc(user.getId())
+                .stream()
+                .map(UserBookSearchItemResult::from)
+                .toList();
+
+        return new UserBookSearchResult(books);
+    }
+}

--- a/src/main/java/com/readum/model/user/repository/UserBookRepository.java
+++ b/src/main/java/com/readum/model/user/repository/UserBookRepository.java
@@ -1,7 +1,12 @@
 package com.readum.model.user.repository;
 
 import com.readum.model.user.entity.UserBook;
+import com.readum.model.user.repository.projection.UserBookListItemProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface UserBookRepository extends JpaRepository<UserBook, Long> {
@@ -12,4 +17,21 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
     boolean existsByUserIdAndBookId(Long userId, Long bookId);
 
     Optional<UserBook> findByUserIdAndBookId(Long userId, Long bookId);
+
+    @Query("""
+            select new com.readum.model.user.repository.projection.UserBookListItemProjection(
+                       book.id
+                     , book.title
+                     , book.publisher
+                     , book.publishedYear
+                     , book.coverUrl
+                   )
+              from UserBook userBook
+              join Book book
+                on book.id = userBook.bookId
+             where userBook.userId = :userId
+             order by userBook.createdAt desc
+                    , userBook.id desc
+            """)
+    List<UserBookListItemProjection> findAllByUserIdOrderByCreatedAtDescIdDesc(@Param("userId") Long userId);
 }

--- a/src/main/java/com/readum/model/user/repository/projection/UserBookListItemProjection.java
+++ b/src/main/java/com/readum/model/user/repository/projection/UserBookListItemProjection.java
@@ -1,0 +1,10 @@
+package com.readum.model.user.repository.projection;
+
+public record UserBookListItemProjection(
+        Long id,
+        String title,
+        String publisher,
+        Integer publishedYear,
+        String coverUrl
+) {
+}

--- a/src/main/java/com/readum/presentation/controller/user/UserBookController.java
+++ b/src/main/java/com/readum/presentation/controller/user/UserBookController.java
@@ -1,9 +1,12 @@
 package com.readum.presentation.controller.user;
 
 import com.readum.domain.user.userbook.dto.UserBookCreateResult;
+import com.readum.domain.user.userbook.dto.UserBookSearchResult;
 import com.readum.domain.user.userbook.service.UserBookCreateService;
+import com.readum.domain.user.userbook.service.UserBookSearchService;
 import com.readum.presentation.common.GlobalApiResponse;
 import com.readum.presentation.controller.user.dto.UserBookCreateRequest;
+import com.readum.presentation.controller.user.dto.UserBookListResponse;
 import com.readum.presentation.controller.user.dto.UserBookResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -14,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,6 +31,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 public class UserBookController {
 
     private final UserBookCreateService userBookCreateService;
+    private final UserBookSearchService userBookSearchService;
 
     @Operation(
             summary = "내 책장 도서 추가",
@@ -53,5 +58,20 @@ public class UserBookController {
                         .buildAndExpand(result.id())
                         .toUri())
                 .body(new GlobalApiResponse<>(response, null));
+    }
+
+    @Operation(
+            summary = "내 책장 도서 목록 조회",
+            description = "현재 user_session 쿠키로 식별된 사용자가 책장에 등록한 도서 목록을 최근 등록순(user_book.createdAt desc, id desc)으로 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공 (등록 도서 0건이면 빈 배열)"),
+            @ApiResponse(responseCode = "401", description = "user_session 쿠키 누락 또는 유효하지 않은 세션")
+    })
+    @GetMapping
+    public ResponseEntity<GlobalApiResponse<UserBookListResponse>> list(
+            @CookieValue(name = "user_session") String userSessionId) {
+        UserBookSearchResult result = userBookSearchService.findMyBooks(userSessionId);
+        return GlobalApiResponse.ok(UserBookListResponse.from(result));
     }
 }

--- a/src/main/java/com/readum/presentation/controller/user/dto/UserBookListItemResponse.java
+++ b/src/main/java/com/readum/presentation/controller/user/dto/UserBookListItemResponse.java
@@ -1,0 +1,22 @@
+package com.readum.presentation.controller.user.dto;
+
+import com.readum.domain.user.userbook.dto.UserBookSearchItemResult;
+
+public record UserBookListItemResponse(
+        Long id,
+        String title,
+        String publisher,
+        Integer publishedYear,
+        String coverUrl
+) {
+
+    public static UserBookListItemResponse from(UserBookSearchItemResult item) {
+        return new UserBookListItemResponse(
+                item.id(),
+                item.title(),
+                item.publisher(),
+                item.publishedYear(),
+                item.coverUrl()
+        );
+    }
+}

--- a/src/main/java/com/readum/presentation/controller/user/dto/UserBookListResponse.java
+++ b/src/main/java/com/readum/presentation/controller/user/dto/UserBookListResponse.java
@@ -1,0 +1,18 @@
+package com.readum.presentation.controller.user.dto;
+
+import com.readum.domain.user.userbook.dto.UserBookSearchResult;
+
+import java.util.List;
+
+public record UserBookListResponse(
+        List<UserBookListItemResponse> books
+) {
+
+    public static UserBookListResponse from(UserBookSearchResult result) {
+        return new UserBookListResponse(
+                result.books().stream()
+                        .map(UserBookListItemResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/test/java/com/readum/domain/user/userbook/service/UserBookSearchServiceTest.java
+++ b/src/test/java/com/readum/domain/user/userbook/service/UserBookSearchServiceTest.java
@@ -1,0 +1,85 @@
+package com.readum.domain.user.userbook.service;
+
+import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.exception.UserErrorCode;
+import com.readum.domain.user.userbook.dto.UserBookSearchResult;
+import com.readum.model.user.entity.User;
+import com.readum.model.user.repository.UserBookRepository;
+import com.readum.model.user.repository.UserRepository;
+import com.readum.model.user.repository.projection.UserBookListItemProjection;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class UserBookSearchServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserBookRepository userBookRepository;
+
+    @InjectMocks
+    private UserBookSearchService userBookSearchService;
+
+    private static final Long USER_ID = 1L;
+    private static final String USER_SESSION_ID = "test-session-id";
+
+    private User stubUser() {
+        return User.of(USER_ID, null, USER_SESSION_ID, null, false,
+                LocalDateTime.now(), LocalDateTime.now());
+    }
+
+    @Test
+    void 유효한_user_session_으로_조회하면_등록한_도서_목록을_반환한다() {
+        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
+        given(userBookRepository.findAllByUserIdOrderByCreatedAtDescIdDesc(USER_ID))
+                .willReturn(List.of(
+                        new UserBookListItemProjection(2L, "최근 등록한 책", "출판사B", 2025, "http://example.com/b.jpg"),
+                        new UserBookListItemProjection(1L, "이전에 등록한 책", "출판사A", 2024, "http://example.com/a.jpg")
+                ));
+
+        UserBookSearchResult result = userBookSearchService.findMyBooks(USER_SESSION_ID);
+
+        assertThat(result.books()).hasSize(2);
+        assertThat(result.books().get(0).id()).isEqualTo(2L);
+        assertThat(result.books().get(0).title()).isEqualTo("최근 등록한 책");
+        assertThat(result.books().get(0).publisher()).isEqualTo("출판사B");
+        assertThat(result.books().get(0).publishedYear()).isEqualTo(2025);
+        assertThat(result.books().get(0).coverUrl()).isEqualTo("http://example.com/b.jpg");
+        assertThat(result.books().get(1).id()).isEqualTo(1L);
+        assertThat(result.books().get(1).title()).isEqualTo("이전에 등록한 책");
+    }
+
+    @Test
+    void 등록된_도서가_없으면_빈_books_리스트를_반환한다() {
+        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
+        given(userBookRepository.findAllByUserIdOrderByCreatedAtDescIdDesc(USER_ID))
+                .willReturn(List.of());
+
+        UserBookSearchResult result = userBookSearchService.findMyBooks(USER_SESSION_ID);
+
+        assertThat(result.books()).isEmpty();
+    }
+
+    @Test
+    void 세션이_유효하지_않으면_UnauthorizedException_을_던진다() {
+        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userBookSearchService.findMyBooks(USER_SESSION_ID))
+                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
+                .satisfies(ex -> assertThat(ex.getErrorCode()).isEqualTo(UserErrorCode.INVALID_SESSION));
+    }
+}

--- a/src/test/java/com/readum/model/user/repository/UserBookRepositoryTest.java
+++ b/src/test/java/com/readum/model/user/repository/UserBookRepositoryTest.java
@@ -1,13 +1,19 @@
 package com.readum.model.user.repository;
 
+import com.readum.model.book.entity.Book;
+import com.readum.model.book.repository.BookRepository;
 import com.readum.model.user.entity.UserBook;
+import com.readum.model.user.repository.projection.UserBookListItemProjection;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,6 +23,9 @@ class UserBookRepositoryTest {
 
     @Autowired
     private UserBookRepository userBookRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
 
     @Test
     @DisplayName("등록된 도서가 있으면 existsByUserId 가 true 를 반환한다")
@@ -71,6 +80,74 @@ class UserBookRepositoryTest {
         assertThat(found).isEmpty();
     }
 
+    @Test
+    @DisplayName("findAllByUserIdOrderByCreatedAtDescIdDesc 는 본인이 등록한 도서만 createdAt DESC, id DESC 순으로 Book 정보와 조인해 반환한다")
+    void 등록도서_목록_조회_정렬과_조인() {
+        Long userId = nextUserId();
+        Long otherUserId = nextUserId();
+
+        Book older = bookRepository.save(Book.create(
+                uniqueExternalId(), "이전에 등록한 책", "저자A", "출판사A", 2024, "http://example.com/a.jpg"));
+        Book newer = bookRepository.save(Book.create(
+                uniqueExternalId(), "최근 등록한 책", "저자B", "출판사B", 2025, "http://example.com/b.jpg"));
+        Book otherUserBook = bookRepository.save(Book.create(
+                uniqueExternalId(), "남의 책", "저자C", "출판사C", 2023, "http://example.com/c.jpg"));
+
+        LocalDateTime baseTime = LocalDateTime.of(2025, 1, 1, 0, 0);
+        userBookRepository.save(UserBook.of(null, userId, older.getId(), baseTime));
+        userBookRepository.save(UserBook.of(null, userId, newer.getId(), baseTime.plusMinutes(1)));
+        userBookRepository.save(UserBook.of(null, otherUserId, otherUserBook.getId(), baseTime.plusMinutes(2)));
+
+        List<UserBookListItemProjection> projections =
+                userBookRepository.findAllByUserIdOrderByCreatedAtDescIdDesc(userId);
+
+        assertThat(projections).hasSize(2);
+        assertThat(projections.get(0).id()).isEqualTo(newer.getId());
+        assertThat(projections.get(0).title()).isEqualTo("최근 등록한 책");
+        assertThat(projections.get(0).publisher()).isEqualTo("출판사B");
+        assertThat(projections.get(0).publishedYear()).isEqualTo(2025);
+        assertThat(projections.get(0).coverUrl()).isEqualTo("http://example.com/b.jpg");
+        assertThat(projections.get(1).id()).isEqualTo(older.getId());
+        assertThat(projections.get(1).title()).isEqualTo("이전에 등록한 책");
+        assertThat(projections)
+                .extracting(UserBookListItemProjection::id)
+                .doesNotContain(otherUserBook.getId());
+    }
+
+    @Test
+    @DisplayName("findAllByUserIdOrderByCreatedAtDescIdDesc 는 createdAt 이 동일하면 user_book.id DESC 로 정렬한다")
+    void 등록도서_목록_조회_createdAt_동일시_id_DESC() {
+        Long userId = nextUserId();
+
+        Book book1 = bookRepository.save(Book.create(
+                uniqueExternalId(), "책1", "저자1", "출판사1", 2024, "http://example.com/1.jpg"));
+        Book book2 = bookRepository.save(Book.create(
+                uniqueExternalId(), "책2", "저자2", "출판사2", 2024, "http://example.com/2.jpg"));
+
+        LocalDateTime sameTime = LocalDateTime.of(2025, 1, 1, 0, 0);
+        UserBook first = userBookRepository.save(UserBook.of(null, userId, book1.getId(), sameTime));
+        UserBook second = userBookRepository.save(UserBook.of(null, userId, book2.getId(), sameTime));
+
+        List<UserBookListItemProjection> projections =
+                userBookRepository.findAllByUserIdOrderByCreatedAtDescIdDesc(userId);
+
+        assertThat(projections).hasSize(2);
+        assertThat(second.getId()).isGreaterThan(first.getId());
+        assertThat(projections.get(0).id()).isEqualTo(book2.getId());
+        assertThat(projections.get(1).id()).isEqualTo(book1.getId());
+    }
+
+    @Test
+    @DisplayName("등록한 도서가 없으면 빈 리스트를 반환한다")
+    void 등록도서_없으면_빈_리스트() {
+        Long userId = nextUserId();
+
+        List<UserBookListItemProjection> projections =
+                userBookRepository.findAllByUserIdOrderByCreatedAtDescIdDesc(userId);
+
+        assertThat(projections).isEmpty();
+    }
+
     private static synchronized Long nextUserId() {
         userIdSeq += 1;
         return userIdSeq;
@@ -79,5 +156,9 @@ class UserBookRepositoryTest {
     private static synchronized Long nextBookId() {
         bookIdSeq += 1;
         return bookIdSeq;
+    }
+
+    private static String uniqueExternalId() {
+        return "ext-" + UUID.randomUUID();
     }
 }

--- a/src/test/java/com/readum/presentation/controller/user/UserBookControllerTest.java
+++ b/src/test/java/com/readum/presentation/controller/user/UserBookControllerTest.java
@@ -2,9 +2,14 @@ package com.readum.presentation.controller.user;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.readum.domain.exception.ConflictException;
+import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.domain.user.userbook.dto.UserBookCreateResult;
+import com.readum.domain.user.userbook.dto.UserBookSearchItemResult;
+import com.readum.domain.user.userbook.dto.UserBookSearchResult;
 import com.readum.domain.user.userbook.exception.UserBookErrorCode;
 import com.readum.domain.user.userbook.service.UserBookCreateService;
+import com.readum.domain.user.userbook.service.UserBookSearchService;
 import com.readum.presentation.common.GlobalExceptionHandler;
 import com.readum.presentation.controller.user.dto.UserBookCreateRequest;
 import jakarta.servlet.http.Cookie;
@@ -19,9 +24,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -35,12 +42,15 @@ class UserBookControllerTest {
     @Mock
     private UserBookCreateService userBookCreateService;
 
+    @Mock
+    private UserBookSearchService userBookSearchService;
+
     private MockMvc mockMvc;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        UserBookController controller = new UserBookController(userBookCreateService);
+        UserBookController controller = new UserBookController(userBookCreateService, userBookSearchService);
         mockMvc = MockMvcBuilders.standaloneSetup(controller)
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .build();
@@ -112,5 +122,54 @@ class UserBookControllerTest {
                 .andExpect(jsonPath("$.error.message").value("이미 책장에 등록된 도서입니다."))
                 .andExpect(jsonPath("$.data.id").value(100))
                 .andExpect(jsonPath("$.data.bookExternalId").value("9788965700807"));
+    }
+
+    @Test
+    void 유효한_user_session_쿠키로_GET_요청시_200과_등록_도서_목록을_반환한다() throws Exception {
+        UserBookSearchResult searchResult = new UserBookSearchResult(List.of(
+                new UserBookSearchItemResult(2L, "최근 등록한 책", "출판사B", 2025, "http://example.com/b.jpg"),
+                new UserBookSearchItemResult(1L, "이전에 등록한 책", "출판사A", 2024, "http://example.com/a.jpg")
+        ));
+        given(userBookSearchService.findMyBooks("test-session-id")).willReturn(searchResult);
+
+        mockMvc.perform(get("/api/v1/user-books").cookie(USER_SESSION_COOKIE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.books.length()").value(2))
+                .andExpect(jsonPath("$.data.books[0].id").value(2))
+                .andExpect(jsonPath("$.data.books[0].title").value("최근 등록한 책"))
+                .andExpect(jsonPath("$.data.books[0].publisher").value("출판사B"))
+                .andExpect(jsonPath("$.data.books[0].publishedYear").value(2025))
+                .andExpect(jsonPath("$.data.books[0].coverUrl").value("http://example.com/b.jpg"))
+                .andExpect(jsonPath("$.data.books[1].id").value(1))
+                .andExpect(jsonPath("$.data.books[1].title").value("이전에 등록한 책"))
+                .andExpect(jsonPath("$.error").doesNotExist());
+    }
+
+    @Test
+    void 등록_도서가_없으면_빈_books_배열을_200과_함께_반환한다() throws Exception {
+        given(userBookSearchService.findMyBooks("test-session-id"))
+                .willReturn(new UserBookSearchResult(List.of()));
+
+        mockMvc.perform(get("/api/v1/user-books").cookie(USER_SESSION_COOKIE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.books.length()").value(0))
+                .andExpect(jsonPath("$.error").doesNotExist());
+    }
+
+    @Test
+    void GET_요청에_user_session_쿠키가_없으면_401을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/v1/user-books"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.message").exists());
+    }
+
+    @Test
+    void GET_요청에_유효하지_않은_user_session_이면_401을_반환한다() throws Exception {
+        given(userBookSearchService.findMyBooks(any()))
+                .willThrow(new UnauthorizedException(UserErrorCode.INVALID_SESSION));
+
+        mockMvc.perform(get("/api/v1/user-books").cookie(USER_SESSION_COOKIE))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.message").value("유효하지 않은 세션입니다."));
     }
 }


### PR DESCRIPTION
## 작업 사항

`POST /api/v1/user-books` 로 등록한 도서 목록을 사용자가 책장 화면에서 다시 볼 수 있도록 조회 API 를 채웠다. 등록은 #26 에서 이미 들어갔지만 그 짝인 목록 조회가 비어 있어 책장 진입점에서 등록 결과를 확인할 수 없는 상태였다.

조회는 `UserBook` + `Book` 두 엔티티의 컬럼을 합쳐 한 응답으로 내려야 한다. `userId` 필터링은 `UserBook` 쪽 컬럼이고 화면 표시용 `title`, `publisher`, `publishedYear`, `coverUrl` 은 `Book` 쪽이라 한쪽 엔티티만으로 끝나지 않는다. 엔티티 fetch 후 lazy 로딩에 맡기면 N+1 이 나기 쉬워서, JPQL constructor expression 으로 두 엔티티를 join 해 필요한 5개 컬럼만 한 SQL 로 SELECT 하고 `UserBookListItemProjection` (record) 에 직접 매핑하는 방식을 골랐다.

projection record 는 `model/user/repository/projection/` 에 두었다 — AI 채팅 세션 목록 조회 (#44) 에서 같은 위치에 `AiChatSessionListProjection` 을 둔 것과 일관된 배치다. projection 은 "DB row 모양", 도메인 Result DTO 는 "비즈니스 표현" 으로 역할을 분리해, service 레이어에서 `UserBookSearchItemResult.from(projection)` 으로 한 번 변환해 도메인으로 끌어올린다.

정렬은 `user_book.createdAt DESC, user_book.id DESC` 로 최신 등록순. `createdAt` 이 동일한 케이스 (같은 트랜잭션에서 연속 등록 등) 의 결정성을 위해 `id DESC` 를 보조 키로 둔다.

페이지네이션은 도입하지 않았다. MVP 단계에서 한 사용자가 등록하는 도서 수가 한 자릿수~수십 권 수준이라 전체 반환으로 충분하고, 무한 스크롤 같은 클라이언트 요구도 현재 없다. 사용자별 도서 수가 늘어나는 시점에 `Slice` 기반으로 전환하면 된다.

### 기능

**내 책장 도서 목록 조회**
- `user_session` 쿠키로 식별된 사용자가 등록한 도서를 최근 등록순으로 전체 반환
- 응답 항목: 도서 ID, 제목, 출판사, 출판연도, 표지 URL
- 등록 도서가 0건이면 빈 배열로 200 응답
- 다른 사용자의 도서는 `userId` 필터로 자동 분리
- `user_session` 쿠키 누락 또는 유효하지 않은 세션은 401

### API 스펙

| 항목 | 값 |
|---|---|
| Method | `GET` |
| Path | `/api/v1/user-books` |
| Cookie | `user_session=<UUID>` (필수) — 임시 인증 쿠키, 소셜 로그인 도입 시 재마이그레이션 예정 |

### 시나리오별 응답

**정상 — 등록 도서 있음** — `GET /api/v1/user-books`
```json
HTTP 200
{
  "data": {
    "books": [
      {
        "id": 2,
        "title": "최근 등록한 책",
        "publisher": "출판사B",
        "publishedYear": 2025,
        "coverUrl": "http://example.com/b.jpg"
      },
      {
        "id": 1,
        "title": "이전에 등록한 책",
        "publisher": "출판사A",
        "publishedYear": 2024,
        "coverUrl": "http://example.com/a.jpg"
      }
    ]
  }
}
```

**정상 — 등록 도서 없음**
```json
HTTP 200
{
  "data": { "books": [] }
}
```

**user_session 쿠키 누락**
```json
HTTP 401
{ "error": { "message": "필수 쿠키가 없습니다: user_session" } }
```

**유효하지 않은 user_session**
```json
HTTP 401
{ "error": { "message": "유효하지 않은 세션입니다." } }
```

### 테스트 결과

- ./gradlew test 전체 통과 (회귀 없음)
- UserBookSearchServiceTest — 정상 / 빈 결과 / 유효하지 않은 세션 (3 케이스)
- UserBookRepositoryTest — DAO 통합 테스트 추가: createdAt DESC + id DESC 정렬 / 다른 사용자 도서 분리 / createdAt 동일 시 id DESC tiebreaker / 빈 결과 (3 케이스)
- UserBookControllerTest — 정상 / 빈 배열 / 쿠키 누락 401 / 유효하지 않은 세션 401 (4 케이스)
- 로컬 Swagger UI 에서 POST /api/v1/users/sessions → POST /api/v1/user-books → GET /api/v1/user-books 수동 검증

### 관련 이슈

- closes #26

### 참고 사항

- DDL 변경 없음. 기존 user_book / book 테이블 그대로 사용.
- projection 위치 컨벤션: model/{도메인}/repository/projection/ — AiChatSessionListProjection 과 동일한 위치 규칙. JPQL constructor expression 의 FQCN 타겟을 한 디렉토리에 모아 분기점을 일관되게 둔다.
- 페이지네이션 부재: MVP 단계에서 의도적으로 미도입. 한 사용자의 도서 수가 늘어나면 Slice 기반으로 전환 예정.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자의 등록된 책 목록을 조회하는 새로운 API 엔드포인트가 추가되었습니다. 인증된 사용자는 본인의 책 목록을 최신순으로 조회할 수 있습니다.

* **Tests**
  * 책 목록 조회 서비스 및 컨트롤러의 동작을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->