### PR TITLE
fix(user-book): 등록 도서 목록 응답에 userBookId/bookId 분리 노출

### DIFF
--- a/src/main/java/com/readum/domain/aiChat/exception/AiChatErrorCode.java
+++ b/src/main/java/com/readum/domain/aiChat/exception/AiChatErrorCode.java
@@ -4,7 +4,7 @@ import com.readum.domain.exception.ErrorCode;
 
 public enum AiChatErrorCode implements ErrorCode {
 
-    USER_BOOK_NOT_FOUND("해당 도서를 찾을 수 없습니다."),
+    USER_BOOK_NOT_FOUND("등록된 도서가 아닙니다."),
     SESSION_NOT_FOUND("세션을 찾을 수 없습니다."),
     SESSION_CLOSED("종료된 세션에는 메시지를 보낼 수 없습니다."),
     SESSION_ALREADY_CLOSED("이미 감상문이 작성된 세션입니다."),

--- a/src/main/java/com/readum/domain/user/userbook/dto/UserBookSearchItemResult.java
+++ b/src/main/java/com/readum/domain/user/userbook/dto/UserBookSearchItemResult.java
@@ -3,7 +3,8 @@ package com.readum.domain.user.userbook.dto;
 import com.readum.model.user.repository.projection.UserBookListItemProjection;
 
 public record UserBookSearchItemResult(
-        Long id,
+        Long userBookId,
+        Long bookId,
         String title,
         String publisher,
         Integer publishedYear,
@@ -12,7 +13,8 @@ public record UserBookSearchItemResult(
 
     public static UserBookSearchItemResult from(UserBookListItemProjection projection) {
         return new UserBookSearchItemResult(
-                projection.id(),
+                projection.userBookId(),
+                projection.bookId(),
                 projection.title(),
                 projection.publisher(),
                 projection.publishedYear(),

--- a/src/main/java/com/readum/model/user/repository/UserBookRepository.java
+++ b/src/main/java/com/readum/model/user/repository/UserBookRepository.java
@@ -20,7 +20,8 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
 
     @Query("""
             select new com.readum.model.user.repository.projection.UserBookListItemProjection(
-                       book.id
+                       userBook.id
+                     , book.id
                      , book.title
                      , book.publisher
                      , book.publishedYear

--- a/src/main/java/com/readum/model/user/repository/projection/UserBookListItemProjection.java
+++ b/src/main/java/com/readum/model/user/repository/projection/UserBookListItemProjection.java
@@ -1,7 +1,8 @@
 package com.readum.model.user.repository.projection;
 
 public record UserBookListItemProjection(
-        Long id,
+        Long userBookId,
+        Long bookId,
         String title,
         String publisher,
         Integer publishedYear,

--- a/src/main/java/com/readum/presentation/controller/user/dto/UserBookListItemResponse.java
+++ b/src/main/java/com/readum/presentation/controller/user/dto/UserBookListItemResponse.java
@@ -3,7 +3,8 @@ package com.readum.presentation.controller.user.dto;
 import com.readum.domain.user.userbook.dto.UserBookSearchItemResult;
 
 public record UserBookListItemResponse(
-        Long id,
+        Long userBookId,
+        Long bookId,
         String title,
         String publisher,
         Integer publishedYear,
@@ -12,7 +13,8 @@ public record UserBookListItemResponse(
 
     public static UserBookListItemResponse from(UserBookSearchItemResult item) {
         return new UserBookListItemResponse(
-                item.id(),
+                item.userBookId(),
+                item.bookId(),
                 item.title(),
                 item.publisher(),
                 item.publishedYear(),

--- a/src/test/java/com/readum/domain/user/userbook/service/UserBookSearchServiceTest.java
+++ b/src/test/java/com/readum/domain/user/userbook/service/UserBookSearchServiceTest.java
@@ -47,19 +47,21 @@ class UserBookSearchServiceTest {
         given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(userBookRepository.findAllByUserIdOrderByCreatedAtDescIdDesc(USER_ID))
                 .willReturn(List.of(
-                        new UserBookListItemProjection(2L, "최근 등록한 책", "출판사B", 2025, "http://example.com/b.jpg"),
-                        new UserBookListItemProjection(1L, "이전에 등록한 책", "출판사A", 2024, "http://example.com/a.jpg")
+                        new UserBookListItemProjection(20L, 2L, "최근 등록한 책", "출판사B", 2025, "http://example.com/b.jpg"),
+                        new UserBookListItemProjection(10L, 1L, "이전에 등록한 책", "출판사A", 2024, "http://example.com/a.jpg")
                 ));
 
         UserBookSearchResult result = userBookSearchService.findMyBooks(USER_SESSION_ID);
 
         assertThat(result.books()).hasSize(2);
-        assertThat(result.books().get(0).id()).isEqualTo(2L);
+        assertThat(result.books().get(0).userBookId()).isEqualTo(20L);
+        assertThat(result.books().get(0).bookId()).isEqualTo(2L);
         assertThat(result.books().get(0).title()).isEqualTo("최근 등록한 책");
         assertThat(result.books().get(0).publisher()).isEqualTo("출판사B");
         assertThat(result.books().get(0).publishedYear()).isEqualTo(2025);
         assertThat(result.books().get(0).coverUrl()).isEqualTo("http://example.com/b.jpg");
-        assertThat(result.books().get(1).id()).isEqualTo(1L);
+        assertThat(result.books().get(1).userBookId()).isEqualTo(10L);
+        assertThat(result.books().get(1).bookId()).isEqualTo(1L);
         assertThat(result.books().get(1).title()).isEqualTo("이전에 등록한 책");
     }
 

--- a/src/test/java/com/readum/model/user/repository/UserBookRepositoryTest.java
+++ b/src/test/java/com/readum/model/user/repository/UserBookRepositoryTest.java
@@ -94,23 +94,25 @@ class UserBookRepositoryTest {
                 uniqueExternalId(), "남의 책", "저자C", "출판사C", 2023, "http://example.com/c.jpg"));
 
         LocalDateTime baseTime = LocalDateTime.of(2025, 1, 1, 0, 0);
-        userBookRepository.save(UserBook.of(null, userId, older.getId(), baseTime));
-        userBookRepository.save(UserBook.of(null, userId, newer.getId(), baseTime.plusMinutes(1)));
+        UserBook olderUserBook = userBookRepository.save(UserBook.of(null, userId, older.getId(), baseTime));
+        UserBook newerUserBook = userBookRepository.save(UserBook.of(null, userId, newer.getId(), baseTime.plusMinutes(1)));
         userBookRepository.save(UserBook.of(null, otherUserId, otherUserBook.getId(), baseTime.plusMinutes(2)));
 
         List<UserBookListItemProjection> projections =
                 userBookRepository.findAllByUserIdOrderByCreatedAtDescIdDesc(userId);
 
         assertThat(projections).hasSize(2);
-        assertThat(projections.get(0).id()).isEqualTo(newer.getId());
+        assertThat(projections.get(0).userBookId()).isEqualTo(newerUserBook.getId());
+        assertThat(projections.get(0).bookId()).isEqualTo(newer.getId());
         assertThat(projections.get(0).title()).isEqualTo("최근 등록한 책");
         assertThat(projections.get(0).publisher()).isEqualTo("출판사B");
         assertThat(projections.get(0).publishedYear()).isEqualTo(2025);
         assertThat(projections.get(0).coverUrl()).isEqualTo("http://example.com/b.jpg");
-        assertThat(projections.get(1).id()).isEqualTo(older.getId());
+        assertThat(projections.get(1).userBookId()).isEqualTo(olderUserBook.getId());
+        assertThat(projections.get(1).bookId()).isEqualTo(older.getId());
         assertThat(projections.get(1).title()).isEqualTo("이전에 등록한 책");
         assertThat(projections)
-                .extracting(UserBookListItemProjection::id)
+                .extracting(UserBookListItemProjection::bookId)
                 .doesNotContain(otherUserBook.getId());
     }
 
@@ -133,8 +135,10 @@ class UserBookRepositoryTest {
 
         assertThat(projections).hasSize(2);
         assertThat(second.getId()).isGreaterThan(first.getId());
-        assertThat(projections.get(0).id()).isEqualTo(book2.getId());
-        assertThat(projections.get(1).id()).isEqualTo(book1.getId());
+        assertThat(projections.get(0).userBookId()).isEqualTo(second.getId());
+        assertThat(projections.get(0).bookId()).isEqualTo(book2.getId());
+        assertThat(projections.get(1).userBookId()).isEqualTo(first.getId());
+        assertThat(projections.get(1).bookId()).isEqualTo(book1.getId());
     }
 
     @Test

--- a/src/test/java/com/readum/presentation/controller/aiChat/AiChatControllerTest.java
+++ b/src/test/java/com/readum/presentation/controller/aiChat/AiChatControllerTest.java
@@ -150,7 +150,7 @@ class AiChatControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new AiChatSessionCreateRequest(999_999L))))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error.message").value("해당 도서를 찾을 수 없습니다."));
+                .andExpect(jsonPath("$.error.message").value("등록된 도서가 아닙니다."));
     }
 
     // ── 세션 목록 조회 ──────────────────────────────────────────────────────
@@ -251,7 +251,7 @@ class AiChatControllerTest {
                         .param("page", "1")
                         .param("size", "20"))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error.message").value("해당 도서를 찾을 수 없습니다."));
+                .andExpect(jsonPath("$.error.message").value("등록된 도서가 아닙니다."));
     }
 
     // ── 메시지 전송 ──────────────────────────────────────────────────────

--- a/src/test/java/com/readum/presentation/controller/user/UserBookControllerTest.java
+++ b/src/test/java/com/readum/presentation/controller/user/UserBookControllerTest.java
@@ -127,20 +127,22 @@ class UserBookControllerTest {
     @Test
     void 유효한_user_session_쿠키로_GET_요청시_200과_등록_도서_목록을_반환한다() throws Exception {
         UserBookSearchResult searchResult = new UserBookSearchResult(List.of(
-                new UserBookSearchItemResult(2L, "최근 등록한 책", "출판사B", 2025, "http://example.com/b.jpg"),
-                new UserBookSearchItemResult(1L, "이전에 등록한 책", "출판사A", 2024, "http://example.com/a.jpg")
+                new UserBookSearchItemResult(20L, 2L, "최근 등록한 책", "출판사B", 2025, "http://example.com/b.jpg"),
+                new UserBookSearchItemResult(10L, 1L, "이전에 등록한 책", "출판사A", 2024, "http://example.com/a.jpg")
         ));
         given(userBookSearchService.findMyBooks("test-session-id")).willReturn(searchResult);
 
         mockMvc.perform(get("/api/v1/user-books").cookie(USER_SESSION_COOKIE))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.books.length()").value(2))
-                .andExpect(jsonPath("$.data.books[0].id").value(2))
+                .andExpect(jsonPath("$.data.books[0].userBookId").value(20))
+                .andExpect(jsonPath("$.data.books[0].bookId").value(2))
                 .andExpect(jsonPath("$.data.books[0].title").value("최근 등록한 책"))
                 .andExpect(jsonPath("$.data.books[0].publisher").value("출판사B"))
                 .andExpect(jsonPath("$.data.books[0].publishedYear").value(2025))
                 .andExpect(jsonPath("$.data.books[0].coverUrl").value("http://example.com/b.jpg"))
-                .andExpect(jsonPath("$.data.books[1].id").value(1))
+                .andExpect(jsonPath("$.data.books[1].userBookId").value(10))
+                .andExpect(jsonPath("$.data.books[1].bookId").value(1))
                 .andExpect(jsonPath("$.data.books[1].title").value("이전에 등록한 책"))
                 .andExpect(jsonPath("$.error").doesNotExist());
     }


### PR DESCRIPTION
## 작업 사항

PR #46 으로 들어간 `GET /api/v1/user-books` 응답에서 `id` 필드가 `book.id` 만 노출되고 `user_book.id` 가 빠져 있어 클라이언트가 user_book row 를 식별·조작할 수 없는 상태였다. 도서 단건 삭제·수정 같은 후속 동작은 user_book row 에 걸려 있는데, 응답만 보고는 어느 user_book 인지 판별이 불가능했다.

projection / Result / Response 세 레이어 모두 단일 `id` 를 `userBookId` + `bookId` 두 필드로 분리하고, JPQL 의 select 절에 `userBook.id` 를 함께 끌어오도록 수정했다. 두 ID 모두 클라이언트에 의미가 있어 (user_book row 식별 ↔ 도서 메타 식별) 한쪽으로 압축하지 않고 평탄하게 둘 다 내린다.

부가로, AI 채팅 세션 생성 시 미등록 도서를 가리키는 `USER_BOOK_NOT_FOUND` 의 메시지를 "해당 도서를 찾을 수 없습니다." → "등록된 도서가 아닙니다." 로 다듬었다. 도서 자체를 못 찾았다는 인상보다 책장에 등록되지 않았다는 의미가 더 명확하다는 판단.

### 기능

**내 책장 도서 목록 응답 식별자 분리**
- `userBookId`, `bookId` 두 필드를 응답 항목에 평탄하게 노출
- 후속 user_book 단건 동작(삭제 등)을 클라이언트가 응답만으로 수행 가능

**AI 채팅 세션 생성 에러 메시지 정비**
- 미등록 도서 케이스의 메시지를 "등록된 도서가 아닙니다." 로 변경
- HTTP 상태(404), ErrorCode(`USER_BOOK_NOT_FOUND`) 는 동일

### 응답 변경 (Before / After)

**Before**
```json
{
  "data": {
    "books": [
      { "id": 2, "title": "...", "publisher": "...", "publishedYear": 2025, "coverUrl": "..." }
    ]
  }
}
```

**After**
```json
{
  "data": {
    "books": [
      { "userBookId": 20, "bookId": 2, "title": "...", "publisher": "...", "publishedYear": 2025, "coverUrl": "..." }
    ]
  }
}
```

## 테스트 결과
- [x] `./gradlew test` 전체 통과 (회귀 없음)
- [x] `UserBookRepositoryTest` — projection 의 `userBookId` / `bookId` 동시 검증으로 갱신
- [x] `UserBookSearchServiceTest`, `UserBookControllerTest` — 두 ID 필드 모두 assertion
- [x] `AiChatControllerTest` — 변경된 에러 메시지 assertion

## 관련 이슈
- closes #26

## 참고 사항

- **응답 호환성 깨짐**: 기존 `id` 필드를 제거하고 `userBookId` / `bookId` 로 대체했다. PR #46 머지 직후라 클라이언트 사용처가 없어 deprecated 별칭 없이 바로 교체. 클라이언트 통합 시점에 새 필드명을 사용하면 된다.
- **DDL 변경 없음**: 기존 user_book / book 테이블 그대로, JPQL select 절만 한 컬럼 추가.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 등록되지 않은 도서 관련 오류 메시지 내용 업데이트

* **개선 사항**
  * 사용자 도서 목록 조회 API 응답에서 도서 ID를 두 개의 별도 필드로 제공하도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->