### PR TITLE
등록한 내 도서 목록 조회 시, 도서 별 채팅 세션 개수 필드 추가

### DIFF
--- a/src/main/java/com/readum/domain/user/userbook/dto/UserBookSearchItemResult.java
+++ b/src/main/java/com/readum/domain/user/userbook/dto/UserBookSearchItemResult.java
@@ -8,7 +8,8 @@ public record UserBookSearchItemResult(
         String title,
         String publisher,
         Integer publishedYear,
-        String coverUrl
+        String coverUrl,
+        long chatSessionCount
 ) {
 
     public static UserBookSearchItemResult from(UserBookListItemProjection projection) {
@@ -18,7 +19,8 @@ public record UserBookSearchItemResult(
                 projection.title(),
                 projection.publisher(),
                 projection.publishedYear(),
-                projection.coverUrl()
+                projection.coverUrl(),
+                projection.chatSessionCount()
         );
     }
 }

--- a/src/main/java/com/readum/model/user/repository/UserBookRepository.java
+++ b/src/main/java/com/readum/model/user/repository/UserBookRepository.java
@@ -26,6 +26,9 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
                      , book.publisher
                      , book.publishedYear
                      , book.coverUrl
+                     , (select count(aiChatSession.id)
+                          from AiChatSession aiChatSession
+                         where aiChatSession.userBookId = userBook.id)
                    )
               from UserBook userBook
               join Book book

--- a/src/main/java/com/readum/model/user/repository/projection/UserBookListItemProjection.java
+++ b/src/main/java/com/readum/model/user/repository/projection/UserBookListItemProjection.java
@@ -6,6 +6,7 @@ public record UserBookListItemProjection(
         String title,
         String publisher,
         Integer publishedYear,
-        String coverUrl
+        String coverUrl,
+        Long chatSessionCount
 ) {
 }

--- a/src/main/java/com/readum/presentation/controller/user/dto/UserBookListItemResponse.java
+++ b/src/main/java/com/readum/presentation/controller/user/dto/UserBookListItemResponse.java
@@ -8,7 +8,8 @@ public record UserBookListItemResponse(
         String title,
         String publisher,
         Integer publishedYear,
-        String coverUrl
+        String coverUrl,
+        long chatSessionCount
 ) {
 
     public static UserBookListItemResponse from(UserBookSearchItemResult item) {
@@ -18,7 +19,8 @@ public record UserBookListItemResponse(
                 item.title(),
                 item.publisher(),
                 item.publishedYear(),
-                item.coverUrl()
+                item.coverUrl(),
+                item.chatSessionCount()
         );
     }
 }

--- a/src/test/java/com/readum/domain/user/userbook/service/UserBookSearchServiceTest.java
+++ b/src/test/java/com/readum/domain/user/userbook/service/UserBookSearchServiceTest.java
@@ -46,8 +46,8 @@ class UserBookSearchServiceTest {
         given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(userBookRepository.findAllByUserIdOrderByCreatedAtDescIdDesc(USER_ID))
                 .willReturn(List.of(
-                        new UserBookListItemProjection(20L, 2L, "최근 등록한 책", "출판사B", 2025, "http://example.com/b.jpg"),
-                        new UserBookListItemProjection(10L, 1L, "이전에 등록한 책", "출판사A", 2024, "http://example.com/a.jpg")
+                        new UserBookListItemProjection(20L, 2L, "최근 등록한 책", "출판사B", 2025, "http://example.com/b.jpg", 3L),
+                        new UserBookListItemProjection(10L, 1L, "이전에 등록한 책", "출판사A", 2024, "http://example.com/a.jpg", 0L)
                 ));
 
         UserBookSearchResult result = userBookSearchService.findMyBooks(USER_SESSION_ID);
@@ -59,9 +59,11 @@ class UserBookSearchServiceTest {
         assertThat(result.books().get(0).publisher()).isEqualTo("출판사B");
         assertThat(result.books().get(0).publishedYear()).isEqualTo(2025);
         assertThat(result.books().get(0).coverUrl()).isEqualTo("http://example.com/b.jpg");
+        assertThat(result.books().get(0).chatSessionCount()).isEqualTo(3L);
         assertThat(result.books().get(1).userBookId()).isEqualTo(10L);
         assertThat(result.books().get(1).bookId()).isEqualTo(1L);
         assertThat(result.books().get(1).title()).isEqualTo("이전에 등록한 책");
+        assertThat(result.books().get(1).chatSessionCount()).isEqualTo(0L);
     }
 
     @Test

--- a/src/test/java/com/readum/model/user/repository/UserBookRepositoryTest.java
+++ b/src/test/java/com/readum/model/user/repository/UserBookRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.readum.model.user.repository;
 
+import com.readum.model.aiChat.entity.AiChatSession;
+import com.readum.model.aiChat.repository.AiChatSessionRepository;
 import com.readum.model.book.entity.Book;
 import com.readum.model.book.repository.BookRepository;
 import com.readum.model.user.entity.UserBook;
@@ -27,6 +29,9 @@ class UserBookRepositoryTest {
 
     @Autowired
     private BookRepository bookRepository;
+
+    @Autowired
+    private AiChatSessionRepository aiChatSessionRepository;
 
     @Test
     @DisplayName("등록된 도서가 있으면 existsByUserId 가 true 를 반환한다")
@@ -156,6 +161,106 @@ class UserBookRepositoryTest {
                 userBookRepository.findAllByUserIdOrderByCreatedAtDescIdDesc(userId);
 
         assertThat(projections).isEmpty();
+    }
+
+    @Test
+    @DisplayName("chatSessionCount 는 세션 상태(ACTIVE/CLOSED)와 무관하게 해당 도서의 전체 채팅 세션 수를 센다")
+    void chatSessionCount_상태_무관_전체_세션_수를_센다() {
+        Long userId = nextUserId();
+        Book book = bookRepository.save(Book.create(
+                uniqueExternalId(), "채팅한 책", "저자", "출판사", 2024, "http://example.com/x.jpg"));
+        UserBook userBook = userBookRepository.save(UserBook.create(userId, book.getId()));
+
+        persistActiveSession(userBook.getId());
+        persistActiveSession(userBook.getId());
+        persistClosedSession(userBook.getId());
+
+        List<UserBookListItemProjection> projections =
+                userBookRepository.findAllByUserIdOrderByCreatedAtDescIdDesc(userId);
+
+        assertThat(projections).hasSize(1);
+        assertThat(projections.get(0).userBookId()).isEqualTo(userBook.getId());
+        assertThat(projections.get(0).chatSessionCount()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("chatSessionCount 는 채팅 세션이 없는 도서에 대해 0 을 반환한다")
+    void chatSessionCount_세션_없으면_0() {
+        Long userId = nextUserId();
+        Book book = bookRepository.save(Book.create(
+                uniqueExternalId(), "대화 없는 책", "저자", "출판사", 2024, "http://example.com/y.jpg"));
+        userBookRepository.save(UserBook.create(userId, book.getId()));
+
+        List<UserBookListItemProjection> projections =
+                userBookRepository.findAllByUserIdOrderByCreatedAtDescIdDesc(userId);
+
+        assertThat(projections).hasSize(1);
+        assertThat(projections.get(0).chatSessionCount()).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("chatSessionCount 는 다른 사용자의 userBook 에 달린 세션을 포함하지 않는다")
+    void chatSessionCount_다른_사용자_세션_격리() {
+        Long userId = nextUserId();
+        Long otherUserId = nextUserId();
+
+        Book myBook = bookRepository.save(Book.create(
+                uniqueExternalId(), "내 책", "저자", "출판사", 2024, "http://example.com/m.jpg"));
+        Book otherBook = bookRepository.save(Book.create(
+                uniqueExternalId(), "남의 책", "저자", "출판사", 2023, "http://example.com/o.jpg"));
+
+        UserBook myUserBook = userBookRepository.save(UserBook.create(userId, myBook.getId()));
+        UserBook otherUserBook = userBookRepository.save(UserBook.create(otherUserId, otherBook.getId()));
+
+        persistActiveSession(myUserBook.getId());
+        persistActiveSession(otherUserBook.getId());
+        persistActiveSession(otherUserBook.getId());
+
+        List<UserBookListItemProjection> projections =
+                userBookRepository.findAllByUserIdOrderByCreatedAtDescIdDesc(userId);
+
+        assertThat(projections).hasSize(1);
+        assertThat(projections.get(0).userBookId()).isEqualTo(myUserBook.getId());
+        assertThat(projections.get(0).chatSessionCount()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("chatSessionCount 는 한 사용자의 도서마다 자신의 세션 수를 독립적으로 세고, 기존 정렬을 유지한다")
+    void chatSessionCount_도서별_독립_카운트와_정렬_유지() {
+        Long userId = nextUserId();
+
+        Book olderBook = bookRepository.save(Book.create(
+                uniqueExternalId(), "이전에 등록한 책", "저자", "출판사", 2024, "http://example.com/a.jpg"));
+        Book newerBook = bookRepository.save(Book.create(
+                uniqueExternalId(), "최근 등록한 책", "저자", "출판사", 2025, "http://example.com/b.jpg"));
+
+        LocalDateTime baseTime = LocalDateTime.of(2025, 1, 1, 0, 0);
+        UserBook olderUserBook = userBookRepository.save(
+                UserBookFixture.userBookRegisteredAt(userId, olderBook.getId(), baseTime));
+        UserBook newerUserBook = userBookRepository.save(
+                UserBookFixture.userBookRegisteredAt(userId, newerBook.getId(), baseTime.plusMinutes(1)));
+
+        persistActiveSession(newerUserBook.getId());
+        persistActiveSession(newerUserBook.getId());
+
+        List<UserBookListItemProjection> projections =
+                userBookRepository.findAllByUserIdOrderByCreatedAtDescIdDesc(userId);
+
+        assertThat(projections).hasSize(2);
+        assertThat(projections.get(0).userBookId()).isEqualTo(newerUserBook.getId());
+        assertThat(projections.get(0).chatSessionCount()).isEqualTo(2L);
+        assertThat(projections.get(1).userBookId()).isEqualTo(olderUserBook.getId());
+        assertThat(projections.get(1).chatSessionCount()).isEqualTo(0L);
+    }
+
+    private void persistActiveSession(Long userBookId) {
+        aiChatSessionRepository.save(AiChatSession.create(userBookId));
+    }
+
+    private void persistClosedSession(Long userBookId) {
+        AiChatSession session = AiChatSession.create(userBookId);
+        session.close();
+        aiChatSessionRepository.save(session);
     }
 
     private static synchronized Long nextUserId() {

--- a/src/test/java/com/readum/presentation/controller/user/UserBookControllerTest.java
+++ b/src/test/java/com/readum/presentation/controller/user/UserBookControllerTest.java
@@ -127,8 +127,8 @@ class UserBookControllerTest {
     @Test
     void 유효한_user_session_쿠키로_GET_요청시_200과_등록_도서_목록을_반환한다() throws Exception {
         UserBookSearchResult searchResult = new UserBookSearchResult(List.of(
-                new UserBookSearchItemResult(20L, 2L, "최근 등록한 책", "출판사B", 2025, "http://example.com/b.jpg"),
-                new UserBookSearchItemResult(10L, 1L, "이전에 등록한 책", "출판사A", 2024, "http://example.com/a.jpg")
+                new UserBookSearchItemResult(20L, 2L, "최근 등록한 책", "출판사B", 2025, "http://example.com/b.jpg", 3L),
+                new UserBookSearchItemResult(10L, 1L, "이전에 등록한 책", "출판사A", 2024, "http://example.com/a.jpg", 0L)
         ));
         given(userBookSearchService.findMyBooks("test-session-id")).willReturn(searchResult);
 
@@ -141,9 +141,11 @@ class UserBookControllerTest {
                 .andExpect(jsonPath("$.data.books[0].publisher").value("출판사B"))
                 .andExpect(jsonPath("$.data.books[0].publishedYear").value(2025))
                 .andExpect(jsonPath("$.data.books[0].coverUrl").value("http://example.com/b.jpg"))
+                .andExpect(jsonPath("$.data.books[0].chatSessionCount").value(3))
                 .andExpect(jsonPath("$.data.books[1].userBookId").value(10))
                 .andExpect(jsonPath("$.data.books[1].bookId").value(1))
                 .andExpect(jsonPath("$.data.books[1].title").value("이전에 등록한 책"))
+                .andExpect(jsonPath("$.data.books[1].chatSessionCount").value(0))
                 .andExpect(jsonPath("$.error").doesNotExist());
     }
 


### PR DESCRIPTION
GET /api/v1/user-books 응답의 각 도서에 chatSessionCount 필드를 추가한다. 값은 해당 userBook 에 연결된 AiChatSession 의 전체 개수로, 세션 상태(ACTIVE/CLOSED)나 감상문 요약 여부와 무관하게 모두 센다.

- 목록 조회 @Query 에 userBookId 기준 상관 count 서브쿼리 컬럼 추가 (기존 join/where/order by 는 그대로 유지해 회귀 표면 최소화)
- Projection -> Result -> Response DTO 사슬에 필드 전파
- 세션 수 검증 DAO 통합 테스트 및 service/controller 단위 테스트 보강


close #67 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 도서 목록 조회 시 각 도서별 채팅 세션 수 정보 추가

* **테스트**
  * 채팅 세션 개수 추적 기능에 대한 테스트 코드 추가 및 기존 테스트 코드 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->