### PR TITLE
도서 삭제 API

### DIFF
--- a/src/main/java/com/readum/domain/user/userbook/dto/UserBookDeleteCommand.java
+++ b/src/main/java/com/readum/domain/user/userbook/dto/UserBookDeleteCommand.java
@@ -1,0 +1,7 @@
+package com.readum.domain.user.userbook.dto;
+
+public record UserBookDeleteCommand(
+        String userSessionId,
+        Long userBookId
+) {
+}

--- a/src/main/java/com/readum/domain/user/userbook/dto/UserBookDeleteResult.java
+++ b/src/main/java/com/readum/domain/user/userbook/dto/UserBookDeleteResult.java
@@ -1,0 +1,13 @@
+package com.readum.domain.user.userbook.dto;
+
+/**
+ * 등록 도서 삭제 결과. 응답 바디로 직렬화하지 않고(삭제 응답은 204 No Content),
+ * 서비스의 관찰성 로그(삭제된 세션/메시지/감상 행 수)용으로만 사용한다.
+ */
+public record UserBookDeleteResult(
+        Long userBookId,
+        int deletedSessions,
+        int deletedMessages,
+        int deletedSummaries
+) {
+}

--- a/src/main/java/com/readum/domain/user/userbook/exception/UserBookErrorCode.java
+++ b/src/main/java/com/readum/domain/user/userbook/exception/UserBookErrorCode.java
@@ -4,7 +4,8 @@ import com.readum.domain.exception.ErrorCode;
 
 public enum UserBookErrorCode implements ErrorCode {
 
-    ALREADY_EXISTS("이미 책장에 등록된 도서입니다.");
+    ALREADY_EXISTS("이미 책장에 등록된 도서입니다."),
+    NOT_FOUND("등록되지 않은 도서입니다.");
 
     private final String message;
 

--- a/src/main/java/com/readum/domain/user/userbook/service/UserBookDeleteService.java
+++ b/src/main/java/com/readum/domain/user/userbook/service/UserBookDeleteService.java
@@ -1,0 +1,65 @@
+package com.readum.domain.user.userbook.service;
+
+import com.readum.domain.exception.NotFoundException;
+import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.exception.UserErrorCode;
+import com.readum.domain.user.userbook.dto.UserBookDeleteCommand;
+import com.readum.domain.user.userbook.dto.UserBookDeleteResult;
+import com.readum.domain.user.userbook.exception.UserBookErrorCode;
+import com.readum.model.aiChat.repository.AiChatMessageRepository;
+import com.readum.model.aiChat.repository.AiChatSessionRepository;
+import com.readum.model.summary.repository.SummaryRepository;
+import com.readum.model.user.entity.User;
+import com.readum.model.user.repository.UserBookRepository;
+import com.readum.model.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 등록 도서(UserBook) 삭제 + 연관 데이터 cascade 삭제.
+ * <p>
+ * 프로젝트가 의도적으로 DB FK / JPA cascade 를 두지 않고 느슨한 Long id 참조로 설계했으므로,
+ * UserBook 을 가리키는 모든 데이터(대화 세션·메시지·감상·사용자 마지막선택 참조)를
+ * 서비스 계층에서 한 트랜잭션으로 명시 삭제한다.
+ * <p>
+ * 삭제 순서가 중요하다 — 메시지는 session_id 를 통해 세션을 거쳐 좁혀지므로
+ * 반드시 메시지 → 세션 순으로 삭제한다 (세션이 먼저 사라지면 메시지가 고아로 남는다).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserBookDeleteService {
+
+    private final UserRepository userRepository;
+    private final UserBookRepository userBookRepository;
+    private final AiChatMessageRepository aiChatMessageRepository;
+    private final AiChatSessionRepository aiChatSessionRepository;
+    private final SummaryRepository summaryRepository;
+
+    @Transactional
+    public UserBookDeleteResult execute(UserBookDeleteCommand command) {
+        User user = userRepository.findBySessionId(command.userSessionId())
+                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
+
+        // 소유권 검증. 미소유/미존재를 구분하지 않고 404 로 응답해 타인 도서의 존재 여부를 누설하지 않는다.
+        // 여기서 로드한 엔티티는 인가 판정·로깅에만 쓴다 — 첫 벌크 삭제(clearAutomatically) 시점에
+        // 영속성 컨텍스트가 비워져 detached 가 되므로, 실제 부모 삭제는 deleteById(id) 로 수행한다.
+        userBookRepository.findByIdAndUserId(command.userBookId(), user.getId())
+                .orElseThrow(() -> new NotFoundException(UserBookErrorCode.NOT_FOUND));
+
+        Long userBookId = command.userBookId();
+
+        int deletedMessages = aiChatMessageRepository.deleteAllByUserBookId(userBookId);
+        int deletedSessions = aiChatSessionRepository.deleteAllByUserBookId(userBookId);
+        int deletedSummaries = summaryRepository.deleteAllByUserBookId(userBookId);
+        userRepository.clearLastSelectedUserBook(userBookId);
+        userBookRepository.deleteById(userBookId);
+
+        log.info("등록 도서 삭제 완료 - userId={}, userBookId={}, deletedSessions={}, deletedMessages={}, deletedSummaries={}",
+                user.getId(), userBookId, deletedSessions, deletedMessages, deletedSummaries);
+
+        return new UserBookDeleteResult(userBookId, deletedSessions, deletedMessages, deletedSummaries);
+    }
+}

--- a/src/main/java/com/readum/model/aiChat/repository/AiChatMessageRepository.java
+++ b/src/main/java/com/readum/model/aiChat/repository/AiChatMessageRepository.java
@@ -4,6 +4,7 @@ import com.readum.model.aiChat.entity.AiChatMessage;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -105,4 +106,22 @@ public interface AiChatMessageRepository extends JpaRepository<AiChatMessage, Lo
         return countRecentMessagesByRoleStatusAndOwner(
                 AiChatMessage.Role.USER, AiChatMessage.Status.REJECTED, userId, since);
     }
+
+    /**
+     * 등록 도서(UserBook) 삭제 cascade 용 — 그 도서의 모든 세션에 속한 메시지를 일괄 삭제한다.
+     * AiChatMessage 는 userBookId 를 직접 갖지 않으므로 session_id 를 통해 세션을 거치는 서브쿼리로 좁힌다.
+     * 삭제 대상 테이블(ai_chat_message) 과 서브쿼리 테이블(ai_chat_session) 이 달라 MySQL 8.4 의
+     * "삭제 대상 테이블 자기참조 서브쿼리 금지" 제약에 걸리지 않는다.
+     * 반드시 세션 삭제보다 먼저 호출해야 한다 (세션이 사라지면 이 서브쿼리가 메시지를 찾지 못한다).
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from AiChatMessage aiChatMessage
+             where aiChatMessage.sessionId in (
+                   select aiChatSession.id
+                     from AiChatSession aiChatSession
+                    where aiChatSession.userBookId = :userBookId
+                 )
+            """)
+    int deleteAllByUserBookId(@Param("userBookId") Long userBookId);
 }

--- a/src/main/java/com/readum/model/aiChat/repository/AiChatSessionRepository.java
+++ b/src/main/java/com/readum/model/aiChat/repository/AiChatSessionRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -130,4 +131,12 @@ public interface AiChatSessionRepository extends JpaRepository<AiChatSession, Lo
             @Param("messageCompletedStatus") AiChatMessage.Status messageCompletedStatus,
             Pageable pageable
     );
+
+    /**
+     * 등록 도서(UserBook) 삭제 cascade 용 — 그 도서의 모든 채팅 세션을 일괄 삭제한다.
+     * 세션에 속한 메시지(AiChatMessage) 를 먼저 삭제한 뒤 호출해야 메시지 고아가 남지 않는다.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from AiChatSession aiChatSession where aiChatSession.userBookId = :userBookId")
+    int deleteAllByUserBookId(@Param("userBookId") Long userBookId);
 }

--- a/src/main/java/com/readum/model/summary/repository/SummaryRepository.java
+++ b/src/main/java/com/readum/model/summary/repository/SummaryRepository.java
@@ -2,10 +2,21 @@ package com.readum.model.summary.repository;
 
 import com.readum.model.summary.entity.Summary;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface SummaryRepository extends JpaRepository<Summary, Long> {
 
     Optional<Summary> findByAiChatSessionId(Long aiChatSessionId);
+
+    /**
+     * 등록 도서(UserBook) 삭제 cascade 용 — 그 도서에 속한 감상 기록을 일괄 삭제한다.
+     * Summary 는 userBookId 를 직접 보유하므로 단순 조건으로 좁힌다.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Summary summary where summary.userBookId = :userBookId")
+    int deleteAllByUserBookId(@Param("userBookId") Long userBookId);
 }

--- a/src/main/java/com/readum/model/user/repository/UserRepository.java
+++ b/src/main/java/com/readum/model/user/repository/UserRepository.java
@@ -2,10 +2,25 @@ package com.readum.model.user.repository;
 
 import com.readum.model.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findBySessionId(String sessionId);
+
+    /**
+     * 등록 도서(UserBook) 삭제 cascade 용 — 삭제되는 도서를 "마지막 선택 도서" 로 가리키던
+     * 사용자들의 참조를 null 로 정리한다 (사라진 userBookId 를 가리키는 dangling 참조 방지).
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update User user
+               set user.lastSelectedUserBookId = null
+             where user.lastSelectedUserBookId = :userBookId
+            """)
+    int clearLastSelectedUserBook(@Param("userBookId") Long userBookId);
 }

--- a/src/main/java/com/readum/presentation/controller/user/UserBookController.java
+++ b/src/main/java/com/readum/presentation/controller/user/UserBookController.java
@@ -1,8 +1,10 @@
 package com.readum.presentation.controller.user;
 
 import com.readum.domain.user.userbook.dto.UserBookCreateResult;
+import com.readum.domain.user.userbook.dto.UserBookDeleteCommand;
 import com.readum.domain.user.userbook.dto.UserBookSearchResult;
 import com.readum.domain.user.userbook.service.UserBookCreateService;
+import com.readum.domain.user.userbook.service.UserBookDeleteService;
 import com.readum.domain.user.userbook.service.UserBookSearchService;
 import com.readum.presentation.common.GlobalApiResponse;
 import com.readum.presentation.controller.user.dto.UserBookCreateRequest;
@@ -17,7 +19,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +36,7 @@ public class UserBookController {
 
     private final UserBookCreateService userBookCreateService;
     private final UserBookSearchService userBookSearchService;
+    private final UserBookDeleteService userBookDeleteService;
 
     @Operation(
             summary = "내 책장 도서 추가",
@@ -73,5 +78,25 @@ public class UserBookController {
             @CookieValue(name = "user_session") String userSessionId) {
         UserBookSearchResult result = userBookSearchService.findMyBooks(userSessionId);
         return GlobalApiResponse.ok(UserBookListResponse.from(result));
+    }
+
+    @Operation(
+            summary = "내 책장 도서 삭제",
+            description = "로그인한 사용자가 자신의 책장에 등록한 도서를 삭제합니다. " +
+                    "삭제 시 그 도서에 연결된 모든 AI 대화 세션·메시지와 감상 기록도 함께 영구 삭제됩니다. " +
+                    "여러 사용자가 공유하는 Book 마스터 정보는 삭제되지 않습니다. " +
+                    "본인이 등록하지 않았거나 존재하지 않는 도서면 404 를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공 (응답 본문 없음)"),
+            @ApiResponse(responseCode = "401", description = "user_session 쿠키 누락 또는 유효하지 않은 세션"),
+            @ApiResponse(responseCode = "404", description = "본인 책장에 등록되지 않은 도서")
+    })
+    @DeleteMapping("/{userBookId}")
+    public ResponseEntity<Void> delete(
+            @CookieValue(name = "user_session") String userSessionId,
+            @PathVariable Long userBookId) {
+        userBookDeleteService.execute(new UserBookDeleteCommand(userSessionId, userBookId));
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/test/java/com/readum/domain/user/userbook/service/UserBookDeleteServiceCascadeTest.java
+++ b/src/test/java/com/readum/domain/user/userbook/service/UserBookDeleteServiceCascadeTest.java
@@ -1,0 +1,191 @@
+package com.readum.domain.user.userbook.service;
+
+import com.readum.domain.user.userbook.dto.UserBookDeleteCommand;
+import com.readum.domain.user.userbook.dto.UserBookDeleteResult;
+import com.readum.model.aiChat.entity.AiChatMessage;
+import com.readum.model.aiChat.entity.AiChatSession;
+import com.readum.model.aiChat.repository.AiChatMessageRepository;
+import com.readum.model.aiChat.repository.AiChatSessionRepository;
+import com.readum.model.book.entity.Book;
+import com.readum.model.book.repository.BookRepository;
+import com.readum.model.summary.entity.Summary;
+import com.readum.model.summary.repository.SummaryRepository;
+import com.readum.model.user.entity.User;
+import com.readum.model.user.entity.UserBook;
+import com.readum.model.user.repository.UserBookRepository;
+import com.readum.model.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 등록 도서(UserBook) 삭제의 cascade 동작을 실제 DB(H2 MySQL 모드) 에 적용해 검증한다.
+ * <p>
+ * 단위 테스트(UserBookDeleteServiceTest)가 "어떤 순서로 무엇을 호출하는가" 를 본다면,
+ * 이 통합 테스트는 "실제로 어떤 행이 사라지고 어떤 행이 남는가" 를 본다 —
+ * FK/JPA cascade 없이 서비스가 명시 삭제하므로, 연관 데이터 제거와 격리(다른 도서·다른 사용자·공유 Book 마스터)를
+ * 끝까지 확인해야 회귀를 잡을 수 있다.
+ */
+@SpringBootTest
+@Transactional
+class UserBookDeleteServiceCascadeTest {
+
+    @Autowired
+    private UserBookDeleteService userBookDeleteService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserBookRepository userBookRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private AiChatSessionRepository aiChatSessionRepository;
+
+    @Autowired
+    private AiChatMessageRepository aiChatMessageRepository;
+
+    @Autowired
+    private SummaryRepository summaryRepository;
+
+    @Test
+    void 도서를_삭제하면_그_도서의_세션_메시지_감상은_모두_사라지고_다른_도서_데이터와_Book_마스터는_보존된다() {
+        User user = persistUser();
+        Book bookMaster1 = persistBook("ext-cascade-1");
+        Book bookMaster2 = persistBook("ext-cascade-2");
+
+        UserBook userBook1 = persistUserBook(user.getId(), bookMaster1.getId());
+        UserBook userBook2 = persistUserBook(user.getId(), bookMaster2.getId());
+
+        // 삭제 대상 도서를 "마지막 선택 도서" 로 지정 → 삭제 후 null 로 정리되는지 확인
+        user.selectBook(userBook1.getId());
+        userRepository.saveAndFlush(user);
+
+        // userBook1: 세션 2개 + 각 세션의 메시지 + 감상 1개
+        AiChatSession session1a = persistSession(userBook1.getId());
+        AiChatSession session1b = persistSession(userBook1.getId());
+        AiChatMessage message1a = persistUserMessage(session1a.getId(), "책1 첫 질문");
+        AiChatMessage message1b = persistUserMessage(session1b.getId(), "책1 다른 세션 질문");
+        Summary summary1 = persistSummary(userBook1.getId(), session1a.getId());
+
+        // userBook2: 세션 1개 + 메시지 + 감상 1개 (모두 보존되어야 함)
+        AiChatSession session2 = persistSession(userBook2.getId());
+        AiChatMessage message2 = persistUserMessage(session2.getId(), "책2 질문");
+        Summary summary2 = persistSummary(userBook2.getId(), session2.getId());
+
+        long bookMasterCountBefore = bookRepository.count();
+
+        UserBookDeleteResult result = userBookDeleteService.execute(
+                new UserBookDeleteCommand(user.getSessionId(), userBook1.getId()));
+
+        // 삭제 카운트가 실제 삭제된 행 수와 일치
+        assertThat(result.userBookId()).isEqualTo(userBook1.getId());
+        assertThat(result.deletedSessions()).isEqualTo(2);
+        assertThat(result.deletedMessages()).isEqualTo(2);
+        assertThat(result.deletedSummaries()).isEqualTo(1);
+
+        // 삭제 대상 도서와 그 도서에 매달린 데이터는 전부 사라짐
+        assertThat(userBookRepository.findById(userBook1.getId())).isEmpty();
+        assertThat(aiChatSessionRepository.findById(session1a.getId())).isEmpty();
+        assertThat(aiChatSessionRepository.findById(session1b.getId())).isEmpty();
+        assertThat(aiChatMessageRepository.findById(message1a.getId())).isEmpty();
+        assertThat(aiChatMessageRepository.findById(message1b.getId())).isEmpty();
+        assertThat(summaryRepository.findById(summary1.getId())).isEmpty();
+
+        // 다른 도서(userBook2) 의 데이터는 전부 보존
+        assertThat(userBookRepository.findById(userBook2.getId())).isPresent();
+        assertThat(aiChatSessionRepository.findById(session2.getId())).isPresent();
+        assertThat(aiChatMessageRepository.findById(message2.getId())).isPresent();
+        assertThat(summaryRepository.findById(summary2.getId())).isPresent();
+
+        // 여러 사용자가 공유하는 Book 마스터는 한 행도 삭제되지 않음
+        assertThat(bookRepository.count()).isEqualTo(bookMasterCountBefore);
+        assertThat(bookRepository.findById(bookMaster1.getId())).isPresent();
+        assertThat(bookRepository.findById(bookMaster2.getId())).isPresent();
+
+        // 삭제된 도서를 가리키던 마지막 선택 참조는 null 로 정리됨 (dangling 참조 방지)
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(reloaded.getLastSelectedUserBookId()).isNull();
+    }
+
+    @Test
+    void 같은_Book_을_공유하는_다른_사용자의_도서_데이터와_공유_Book_마스터는_삭제에_영향받지_않는다() {
+        Book sharedBook = persistBook("ext-shared");
+        User userA = persistUser();
+        User userB = persistUser();
+
+        // 두 사용자가 같은 Book 마스터를 각자의 책장에 등록 (uk 는 user_id+book_id 라 사용자별로 허용)
+        UserBook userBookA = persistUserBook(userA.getId(), sharedBook.getId());
+        UserBook userBookB = persistUserBook(userB.getId(), sharedBook.getId());
+
+        userA.selectBook(userBookA.getId());
+        userB.selectBook(userBookB.getId());
+        userRepository.saveAndFlush(userA);
+        userRepository.saveAndFlush(userB);
+
+        AiChatSession sessionA = persistSession(userBookA.getId());
+        AiChatMessage messageA = persistUserMessage(sessionA.getId(), "A 의 질문");
+        Summary summaryA = persistSummary(userBookA.getId(), sessionA.getId());
+
+        AiChatSession sessionB = persistSession(userBookB.getId());
+        AiChatMessage messageB = persistUserMessage(sessionB.getId(), "B 의 질문");
+        Summary summaryB = persistSummary(userBookB.getId(), sessionB.getId());
+
+        userBookDeleteService.execute(
+                new UserBookDeleteCommand(userA.getSessionId(), userBookA.getId()));
+
+        // A 의 도서와 연관 데이터는 사라짐
+        assertThat(userBookRepository.findById(userBookA.getId())).isEmpty();
+        assertThat(aiChatSessionRepository.findById(sessionA.getId())).isEmpty();
+        assertThat(aiChatMessageRepository.findById(messageA.getId())).isEmpty();
+        assertThat(summaryRepository.findById(summaryA.getId())).isEmpty();
+
+        // B 의 도서와 연관 데이터는 전부 보존 (같은 Book 을 공유해도 격리됨)
+        assertThat(userBookRepository.findById(userBookB.getId())).isPresent();
+        assertThat(aiChatSessionRepository.findById(sessionB.getId())).isPresent();
+        assertThat(aiChatMessageRepository.findById(messageB.getId())).isPresent();
+        assertThat(summaryRepository.findById(summaryB.getId())).isPresent();
+
+        // 공유 Book 마스터 보존
+        assertThat(bookRepository.findById(sharedBook.getId())).isPresent();
+
+        // A 의 마지막 선택만 null 로 정리되고, B 의 마지막 선택은 그대로
+        User reloadedA = userRepository.findById(userA.getId()).orElseThrow();
+        User reloadedB = userRepository.findById(userB.getId()).orElseThrow();
+        assertThat(reloadedA.getLastSelectedUserBookId()).isNull();
+        assertThat(reloadedB.getLastSelectedUserBookId()).isEqualTo(userBookB.getId());
+    }
+
+    private User persistUser() {
+        return userRepository.saveAndFlush(User.create(UUID.randomUUID()));
+    }
+
+    private Book persistBook(String externalId) {
+        return bookRepository.saveAndFlush(
+                Book.create(externalId, "제목-" + externalId, "저자", "출판사", 2024, "http://cover/" + externalId));
+    }
+
+    private UserBook persistUserBook(Long userId, Long bookId) {
+        return userBookRepository.saveAndFlush(UserBook.create(userId, bookId));
+    }
+
+    private AiChatSession persistSession(Long userBookId) {
+        return aiChatSessionRepository.saveAndFlush(AiChatSession.create(userBookId));
+    }
+
+    private AiChatMessage persistUserMessage(Long sessionId, String content) {
+        return aiChatMessageRepository.saveAndFlush(AiChatMessage.createUserMessage(sessionId, content));
+    }
+
+    private Summary persistSummary(Long userBookId, Long sessionId) {
+        return summaryRepository.saveAndFlush(Summary.createInProgress(userBookId, sessionId));
+    }
+}

--- a/src/test/java/com/readum/domain/user/userbook/service/UserBookDeleteServiceTest.java
+++ b/src/test/java/com/readum/domain/user/userbook/service/UserBookDeleteServiceTest.java
@@ -1,0 +1,133 @@
+package com.readum.domain.user.userbook.service;
+
+import com.readum.domain.exception.NotFoundException;
+import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.exception.UserErrorCode;
+import com.readum.domain.user.userbook.dto.UserBookDeleteCommand;
+import com.readum.domain.user.userbook.dto.UserBookDeleteResult;
+import com.readum.domain.user.userbook.exception.UserBookErrorCode;
+import com.readum.model.aiChat.repository.AiChatMessageRepository;
+import com.readum.model.aiChat.repository.AiChatSessionRepository;
+import com.readum.model.summary.repository.SummaryRepository;
+import com.readum.model.user.entity.User;
+import com.readum.model.user.entity.UserBook;
+import com.readum.model.user.entity.UserBookFixture;
+import com.readum.model.user.entity.UserFixture;
+import com.readum.model.user.repository.UserBookRepository;
+import com.readum.model.user.repository.UserRepository;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserBookDeleteServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserBookRepository userBookRepository;
+
+    @Mock
+    private AiChatMessageRepository aiChatMessageRepository;
+
+    @Mock
+    private AiChatSessionRepository aiChatSessionRepository;
+
+    @Mock
+    private SummaryRepository summaryRepository;
+
+    @InjectMocks
+    private UserBookDeleteService userBookDeleteService;
+
+    private static final Long USER_ID = 1L;
+    private static final String USER_SESSION_ID = "test-session-id";
+    private static final Long BOOK_ID = 10L;
+    private static final Long USER_BOOK_ID = 100L;
+
+    private UserBookDeleteCommand command() {
+        return new UserBookDeleteCommand(USER_SESSION_ID, USER_BOOK_ID);
+    }
+
+    @BeforeEach
+    void setUp() {
+        User user = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
+        org.mockito.Mockito.lenient().when(userRepository.findBySessionId(USER_SESSION_ID))
+                .thenReturn(Optional.of(user));
+    }
+
+    @Test
+    void 소유자_요청_시_메시지_세션_요약_사용자참조_userBook_순서로_삭제하고_삭제_카운트를_반환한다() {
+        UserBook userBook = UserBookFixture.persistedUserBook(USER_BOOK_ID, USER_ID, BOOK_ID);
+        given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID))
+                .willReturn(Optional.of(userBook));
+        given(aiChatMessageRepository.deleteAllByUserBookId(USER_BOOK_ID)).willReturn(7);
+        given(aiChatSessionRepository.deleteAllByUserBookId(USER_BOOK_ID)).willReturn(3);
+        given(summaryRepository.deleteAllByUserBookId(USER_BOOK_ID)).willReturn(2);
+
+        UserBookDeleteResult result = userBookDeleteService.execute(command());
+
+        // 메시지 → 세션 → 요약 → 사용자 마지막선택 정리 → deleteById(부모) 순서.
+        // 마지막 단계가 delete(엔티티) 가 아니라 deleteById(id) 임을 단언 — detached 엔티티 삭제 회귀 방지.
+        InOrder inOrder = inOrder(
+                aiChatMessageRepository, aiChatSessionRepository,
+                summaryRepository, userRepository, userBookRepository);
+        inOrder.verify(aiChatMessageRepository).deleteAllByUserBookId(USER_BOOK_ID);
+        inOrder.verify(aiChatSessionRepository).deleteAllByUserBookId(USER_BOOK_ID);
+        inOrder.verify(summaryRepository).deleteAllByUserBookId(USER_BOOK_ID);
+        inOrder.verify(userRepository).clearLastSelectedUserBook(USER_BOOK_ID);
+        inOrder.verify(userBookRepository).deleteById(USER_BOOK_ID);
+
+        assertThat(result.userBookId()).isEqualTo(USER_BOOK_ID);
+        assertThat(result.deletedMessages()).isEqualTo(7);
+        assertThat(result.deletedSessions()).isEqualTo(3);
+        assertThat(result.deletedSummaries()).isEqualTo(2);
+    }
+
+    @Test
+    void 유효하지_않은_세션이면_UnauthorizedException_이_발생하고_어떤_삭제도_실행되지_않는다() {
+        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userBookDeleteService.execute(command()))
+                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
+                .satisfies(ex -> assertThat(ex.getErrorCode()).isEqualTo(UserErrorCode.INVALID_SESSION));
+
+        verify(userBookRepository, never()).findByIdAndUserId(anyLong(), anyLong());
+        verifyNoDeletes();
+    }
+
+    @Test
+    void 본인이_등록하지_않았거나_존재하지_않는_도서면_NotFoundException_이_발생하고_어떤_삭제도_실행되지_않는다() {
+        given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userBookDeleteService.execute(command()))
+                .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
+                .satisfies(ex -> assertThat(ex.getErrorCode()).isEqualTo(UserBookErrorCode.NOT_FOUND));
+
+        verifyNoDeletes();
+    }
+
+    private void verifyNoDeletes() {
+        verify(aiChatMessageRepository, never()).deleteAllByUserBookId(anyLong());
+        verify(aiChatSessionRepository, never()).deleteAllByUserBookId(anyLong());
+        verify(summaryRepository, never()).deleteAllByUserBookId(anyLong());
+        verify(userRepository, never()).clearLastSelectedUserBook(anyLong());
+        verify(userBookRepository, never()).deleteById(anyLong());
+    }
+}

--- a/src/test/java/com/readum/presentation/controller/user/UserBookControllerTest.java
+++ b/src/test/java/com/readum/presentation/controller/user/UserBookControllerTest.java
@@ -2,13 +2,16 @@ package com.readum.presentation.controller.user;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.readum.domain.exception.ConflictException;
+import com.readum.domain.exception.NotFoundException;
 import com.readum.domain.exception.UnauthorizedException;
 import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.domain.user.userbook.dto.UserBookCreateResult;
+import com.readum.domain.user.userbook.dto.UserBookDeleteResult;
 import com.readum.domain.user.userbook.dto.UserBookSearchItemResult;
 import com.readum.domain.user.userbook.dto.UserBookSearchResult;
 import com.readum.domain.user.userbook.exception.UserBookErrorCode;
 import com.readum.domain.user.userbook.service.UserBookCreateService;
+import com.readum.domain.user.userbook.service.UserBookDeleteService;
 import com.readum.domain.user.userbook.service.UserBookSearchService;
 import com.readum.presentation.common.GlobalExceptionHandler;
 import com.readum.presentation.controller.user.dto.UserBookCreateRequest;
@@ -27,7 +30,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -45,12 +52,16 @@ class UserBookControllerTest {
     @Mock
     private UserBookSearchService userBookSearchService;
 
+    @Mock
+    private UserBookDeleteService userBookDeleteService;
+
     private MockMvc mockMvc;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        UserBookController controller = new UserBookController(userBookCreateService, userBookSearchService);
+        UserBookController controller =
+                new UserBookController(userBookCreateService, userBookSearchService, userBookDeleteService);
         mockMvc = MockMvcBuilders.standaloneSetup(controller)
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .build();
@@ -173,5 +184,48 @@ class UserBookControllerTest {
         mockMvc.perform(get("/api/v1/user-books").cookie(USER_SESSION_COOKIE))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.error.message").value("유효하지 않은 세션입니다."));
+    }
+
+    @Test
+    void DELETE_요청_시_204를_본문_없이_반환하고_경로의_userBookId와_쿠키_세션으로_삭제를_위임한다() throws Exception {
+        given(userBookDeleteService.execute(any()))
+                .willReturn(new UserBookDeleteResult(100L, 3, 7, 2));
+
+        mockMvc.perform(delete("/api/v1/user-books/100").cookie(USER_SESSION_COOKIE))
+                .andExpect(status().isNoContent())
+                .andExpect(jsonPath("$").doesNotExist());
+
+        verify(userBookDeleteService).execute(argThat(command ->
+                command.userSessionId().equals("test-session-id")
+                        && command.userBookId().equals(100L)));
+    }
+
+    @Test
+    void DELETE_요청에_user_session_쿠키가_없으면_401을_반환하고_삭제를_위임하지_않는다() throws Exception {
+        mockMvc.perform(delete("/api/v1/user-books/100"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.message").exists());
+
+        verify(userBookDeleteService, never()).execute(any());
+    }
+
+    @Test
+    void DELETE_요청에_유효하지_않은_user_session_이면_401을_반환한다() throws Exception {
+        given(userBookDeleteService.execute(any()))
+                .willThrow(new UnauthorizedException(UserErrorCode.INVALID_SESSION));
+
+        mockMvc.perform(delete("/api/v1/user-books/100").cookie(USER_SESSION_COOKIE))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.message").value("유효하지 않은 세션입니다."));
+    }
+
+    @Test
+    void DELETE_요청에_본인_책장에_없는_도서면_404를_반환한다() throws Exception {
+        given(userBookDeleteService.execute(any()))
+                .willThrow(new NotFoundException(UserBookErrorCode.NOT_FOUND));
+
+        mockMvc.perform(delete("/api/v1/user-books/100").cookie(USER_SESSION_COOKIE))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.message").value("등록되지 않은 도서입니다."));
     }
 }


### PR DESCRIPTION
일단 빠르게 book만 soft delete 처리해서 커밋하고 백그라운드에서 벌크 삭제할까 싶었는데, 토큰이 없어서 그냥 무식하게 해치움.  

- DELETE /api/v1/user-books/{userBookId} 추가, 성공 시 204 No Content
- 도서 삭제 시 연관 데이터를 한 트랜잭션에서 명시 삭제: 메시지 → 세션 → 감상 → 사용자 마지막선택 참조 정리 → 도서 순서 (DB 외래키/JPA cascade 없는 느슨한 id 참조 설계라 서비스 계층에서 직접 삭제)
- 메시지는 세션을 거치는 서브쿼리로 좁히므로 반드시 세션보다 먼저 삭제
- 첫 벌크 삭제 후 영속성 컨텍스트가 비워져 엔티티가 detached 되므로 부모 삭제는 delete(entity) 가 아닌 deleteById(id) 로 수행
- 소유권 검증 실패는 미소유/미존재를 구분하지 않고 404 (타인 도서 존재 여부 누출 차단)
- 단위 테스트(삭제 순서·카운트, 401/404 시 미삭제) + 실제 DB 통합 테스트(전체 cascade, 공유 Book·다른 사용자·다른 도서 격리)


close #70 