### PR TITLE
사용자 감상 기록 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/readum/domain/summary/dto/SummaryHistoryItemResult.java
+++ b/src/main/java/com/readum/domain/summary/dto/SummaryHistoryItemResult.java
@@ -1,0 +1,35 @@
+package com.readum.domain.summary.dto;
+
+import com.readum.model.summary.repository.projection.SummaryHistoryProjection;
+
+import java.time.LocalDateTime;
+
+/**
+ * 감상 기록 1건. "감상문 내용"의 정의 자체가 미리보기이므로,
+ * 본문을 100자까지만 노출하고 초과분은 "..." 로 줄이는 책임을 이 Result 가 갖는다.
+ */
+public record SummaryHistoryItemResult(
+        String bookTitle,
+        String content,
+        LocalDateTime createdAt
+) {
+
+    private static final int MAX_CONTENT_PREVIEW_LENGTH = 100;
+
+    public static SummaryHistoryItemResult from(SummaryHistoryProjection projection) {
+        return new SummaryHistoryItemResult(
+                projection.bookTitle(),
+                preview(projection.body()),
+                projection.createdAt()
+        );
+    }
+
+    private static String preview(String body) {
+        if (body == null) {
+            return null;
+        }
+        return body.length() <= MAX_CONTENT_PREVIEW_LENGTH
+                ? body
+                : body.substring(0, MAX_CONTENT_PREVIEW_LENGTH) + "...";
+    }
+}

--- a/src/main/java/com/readum/domain/summary/dto/SummaryHistoryListCommand.java
+++ b/src/main/java/com/readum/domain/summary/dto/SummaryHistoryListCommand.java
@@ -1,0 +1,7 @@
+package com.readum.domain.summary.dto;
+
+public record SummaryHistoryListCommand(
+        String userSessionId,
+        int page
+) {
+}

--- a/src/main/java/com/readum/domain/summary/dto/SummaryHistoryListResult.java
+++ b/src/main/java/com/readum/domain/summary/dto/SummaryHistoryListResult.java
@@ -1,0 +1,11 @@
+package com.readum.domain.summary.dto;
+
+import java.util.List;
+
+public record SummaryHistoryListResult(
+        List<SummaryHistoryItemResult> summaries,
+        int page,
+        int size,
+        boolean hasNext
+) {
+}

--- a/src/main/java/com/readum/domain/summary/service/SummaryHistorySearchService.java
+++ b/src/main/java/com/readum/domain/summary/service/SummaryHistorySearchService.java
@@ -1,0 +1,48 @@
+package com.readum.domain.summary.service;
+
+import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.summary.dto.SummaryHistoryItemResult;
+import com.readum.domain.summary.dto.SummaryHistoryListCommand;
+import com.readum.domain.summary.dto.SummaryHistoryListResult;
+import com.readum.domain.user.exception.UserErrorCode;
+import com.readum.model.summary.repository.SummaryRepository;
+import com.readum.model.summary.repository.projection.SummaryHistoryProjection;
+import com.readum.model.user.entity.User;
+import com.readum.model.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+/**
+ * 사용자 본인의 감상 기록(종료된 세션 + 완성된 감상문) 목록을 최신순으로 Slice 조회한다.
+ * 페이지 크기는 20개로 고정한다.
+ *
+ * 형제 조회 서비스(AiChatSessionSearchService 등)와 동일하게 @Transactional(readOnly) 를 붙이지 않는다.
+ * 인증 조회와 목록 조회가 한 트랜잭션의 일관성을 요구하지 않기 때문이다.
+ */
+@Service
+@RequiredArgsConstructor
+public class SummaryHistorySearchService {
+
+    private static final int PAGE_SIZE = 20;
+
+    private final UserRepository userRepository;
+    private final SummaryRepository summaryRepository;
+
+    public SummaryHistoryListResult findMyHistory(SummaryHistoryListCommand command) {
+        User user = userRepository.findBySessionId(command.userSessionId())
+                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
+
+        int pageIndex = Math.max(0, command.page() - 1);
+        Slice<SummaryHistoryProjection> slice = summaryRepository.findCompletedHistoryByUserId(
+                user.getId(), PageRequest.of(pageIndex, PAGE_SIZE));
+
+        return new SummaryHistoryListResult(
+                slice.getContent().stream().map(SummaryHistoryItemResult::from).toList(),
+                command.page(),
+                PAGE_SIZE,
+                slice.hasNext()
+        );
+    }
+}

--- a/src/main/java/com/readum/model/summary/repository/SummaryRepository.java
+++ b/src/main/java/com/readum/model/summary/repository/SummaryRepository.java
@@ -1,7 +1,13 @@
 package com.readum.model.summary.repository;
 
+import com.readum.model.aiChat.entity.AiChatSession;
 import com.readum.model.summary.entity.Summary;
+import com.readum.model.summary.repository.projection.SummaryHistoryProjection;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -16,4 +22,46 @@ public interface SummaryRepository extends JpaRepository<Summary, Long> {
     Optional<Summary> findFirstByAiChatSessionIdOrderByCreatedAtDesc(Long aiChatSessionId);
 
     List<Summary> findByStatusAndRetryCountLessThan(Summary.Status status, int retryCount);
+
+    /**
+     * 사용자 본인의 감상 기록 목록을 최신순(createdAt DESC, id DESC) 으로 Slice 조회한다.
+     * 종료(CLOSED)된 세션의 완성(COMPLETED)된 감상문만 포함한다 —
+     * 스케줄러가 ACTIVE 세션에 자동 생성한 COMPLETED 감상문은 sessionStatus=CLOSED 필터로 제외된다.
+     *
+     * 호출자 시그니처를 단순하게 유지하기 위해 default 메서드로 감싸고, 내부 @Query 에 enum 파라미터를 바인딩한다.
+     */
+    default Slice<SummaryHistoryProjection> findCompletedHistoryByUserId(Long userId, Pageable pageable) {
+        return findCompletedHistoryByUserIdInternal(
+                userId, Summary.Status.COMPLETED, AiChatSession.Status.CLOSED, pageable);
+    }
+
+    /**
+     * Summary / AiChatSession / UserBook / Book 사이에 JPA 연관관계가 없어 on 절로 직접 join 한다 (Hibernate 6+).
+     * 소유권 확인을 EXISTS 서브쿼리가 아니라 inner join 으로 하는 이유 — book.title 컬럼을 실제로 투영해야 하므로
+     * UserBook/Book join 이 불가피하고, userBook.userId 필터가 곧 소유권 검증을 겸한다.
+     */
+    @Query("""
+            select new com.readum.model.summary.repository.projection.SummaryHistoryProjection(
+                       book.title
+                     , summary.body
+                     , summary.createdAt
+                   )
+              from Summary summary
+              join AiChatSession aiChatSession
+                on aiChatSession.id = summary.aiChatSessionId
+              join UserBook userBook
+                on userBook.id = summary.userBookId
+              join Book book
+                on book.id = userBook.bookId
+             where userBook.userId = :userId
+               and summary.status = :summaryStatus
+               and aiChatSession.status = :sessionStatus
+             order by summary.createdAt desc
+                    , summary.id desc
+            """)
+    Slice<SummaryHistoryProjection> findCompletedHistoryByUserIdInternal(
+            @Param("userId") Long userId,
+            @Param("summaryStatus") Summary.Status summaryStatus,
+            @Param("sessionStatus") AiChatSession.Status sessionStatus,
+            Pageable pageable);
 }

--- a/src/main/java/com/readum/model/summary/repository/projection/SummaryHistoryProjection.java
+++ b/src/main/java/com/readum/model/summary/repository/projection/SummaryHistoryProjection.java
@@ -1,0 +1,14 @@
+package com.readum.model.summary.repository.projection;
+
+import java.time.LocalDateTime;
+
+/**
+ * 사용자 본인의 감상 기록(완성된 감상문) 목록 조회용 projection.
+ * Summary / AiChatSession / UserBook / Book 사이에 JPA 연관관계가 없어 @Query 의 on 절로 직접 join 한 결과를 담는다.
+ */
+public record SummaryHistoryProjection(
+        String bookTitle,
+        String body,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/readum/presentation/controller/summary/SummaryController.java
+++ b/src/main/java/com/readum/presentation/controller/summary/SummaryController.java
@@ -1,0 +1,50 @@
+package com.readum.presentation.controller.summary;
+
+import com.readum.domain.summary.dto.SummaryHistoryListResult;
+import com.readum.domain.summary.service.SummaryHistorySearchService;
+import com.readum.presentation.common.GlobalApiResponse;
+import com.readum.presentation.controller.summary.dto.SummaryHistoryListRequest;
+import com.readum.presentation.controller.summary.dto.SummaryHistoryListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "감상 기록", description = "사용자 본인의 완성된 감상문(종료된 세션) 목록 조회")
+@RestController
+@RequestMapping("/api/v1/summaries")
+@RequiredArgsConstructor
+public class SummaryController {
+
+    private final SummaryHistorySearchService summaryHistorySearchService;
+
+    @Operation(
+            summary = "내 감상 기록 목록 조회",
+            description = "로그인한 사용자 본인의 감상 기록을 생성일 내림차순(최신순)으로 페이지네이션 조회한다. " +
+                    "채팅 세션이 종료(CLOSED)되었고 감상문이 완성(COMPLETED)된 기록만 포함한다 — " +
+                    "아직 대화 중인 세션에 자동 생성된 감상문은 제외된다. " +
+                    "감상문 내용은 100자까지만 노출하고 초과분은 \"...\" 로 줄여 응답한다. " +
+                    "한 번에 20개씩 조회하며, 기록이 없으면 빈 배열로 200 응답한다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "page 검증 실패"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
+    })
+    @GetMapping
+    public ResponseEntity<GlobalApiResponse<SummaryHistoryListResponse>> getMyHistory(
+            @CookieValue(name = "user_session") String userSessionId,
+            @Valid @ModelAttribute SummaryHistoryListRequest request
+    ) {
+        SummaryHistoryListResult result = summaryHistorySearchService.findMyHistory(request.toCommand(userSessionId));
+        return GlobalApiResponse.ok(SummaryHistoryListResponse.from(result));
+    }
+}

--- a/src/main/java/com/readum/presentation/controller/summary/dto/SummaryHistoryItemResponse.java
+++ b/src/main/java/com/readum/presentation/controller/summary/dto/SummaryHistoryItemResponse.java
@@ -1,0 +1,20 @@
+package com.readum.presentation.controller.summary.dto;
+
+import com.readum.domain.summary.dto.SummaryHistoryItemResult;
+
+import java.time.LocalDateTime;
+
+public record SummaryHistoryItemResponse(
+        String bookTitle,
+        String content,
+        LocalDateTime createdAt
+) {
+
+    public static SummaryHistoryItemResponse from(SummaryHistoryItemResult result) {
+        return new SummaryHistoryItemResponse(
+                result.bookTitle(),
+                result.content(),
+                result.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/readum/presentation/controller/summary/dto/SummaryHistoryListRequest.java
+++ b/src/main/java/com/readum/presentation/controller/summary/dto/SummaryHistoryListRequest.java
@@ -1,0 +1,14 @@
+package com.readum.presentation.controller.summary.dto;
+
+import com.readum.domain.summary.dto.SummaryHistoryListCommand;
+import jakarta.validation.constraints.Min;
+
+public record SummaryHistoryListRequest(
+        @Min(value = 1, message = "page는 1 이상이어야 합니다.")
+        int page
+) {
+
+    public SummaryHistoryListCommand toCommand(String userSessionId) {
+        return new SummaryHistoryListCommand(userSessionId, page);
+    }
+}

--- a/src/main/java/com/readum/presentation/controller/summary/dto/SummaryHistoryListResponse.java
+++ b/src/main/java/com/readum/presentation/controller/summary/dto/SummaryHistoryListResponse.java
@@ -1,0 +1,22 @@
+package com.readum.presentation.controller.summary.dto;
+
+import com.readum.domain.summary.dto.SummaryHistoryListResult;
+
+import java.util.List;
+
+public record SummaryHistoryListResponse(
+        List<SummaryHistoryItemResponse> summaries,
+        int page,
+        int size,
+        boolean hasNext
+) {
+
+    public static SummaryHistoryListResponse from(SummaryHistoryListResult result) {
+        return new SummaryHistoryListResponse(
+                result.summaries().stream().map(SummaryHistoryItemResponse::from).toList(),
+                result.page(),
+                result.size(),
+                result.hasNext()
+        );
+    }
+}

--- a/src/test/java/com/readum/domain/summary/dto/SummaryHistoryItemResultTest.java
+++ b/src/test/java/com/readum/domain/summary/dto/SummaryHistoryItemResultTest.java
@@ -1,0 +1,62 @@
+package com.readum.domain.summary.dto;
+
+import com.readum.model.summary.repository.projection.SummaryHistoryProjection;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SummaryHistoryItemResultTest {
+
+    @Test
+    void 본문이_100자_이하면_원문_그대로_노출한다() {
+        String body = "가".repeat(50);
+
+        SummaryHistoryItemResult result = SummaryHistoryItemResult.from(
+                new SummaryHistoryProjection("책", body, LocalDateTime.now()));
+
+        assertThat(result.content()).isEqualTo(body);
+    }
+
+    @Test
+    void 본문이_정확히_100자면_말줄임표_없이_원문_그대로_노출한다() {
+        String body = "가".repeat(100);
+
+        SummaryHistoryItemResult result = SummaryHistoryItemResult.from(
+                new SummaryHistoryProjection("책", body, LocalDateTime.now()));
+
+        assertThat(result.content()).isEqualTo(body);
+        assertThat(result.content()).doesNotEndWith("...");
+    }
+
+    @Test
+    void 본문이_100자를_초과하면_앞_100자만_노출하고_말줄임표를_붙인다() {
+        String body = "가".repeat(101);
+
+        SummaryHistoryItemResult result = SummaryHistoryItemResult.from(
+                new SummaryHistoryProjection("책", body, LocalDateTime.now()));
+
+        assertThat(result.content()).isEqualTo("가".repeat(100) + "...");
+        assertThat(result.content()).hasSize(103);
+    }
+
+    @Test
+    void 본문이_null_이면_content_도_null_이다() {
+        SummaryHistoryItemResult result = SummaryHistoryItemResult.from(
+                new SummaryHistoryProjection("책", null, LocalDateTime.now()));
+
+        assertThat(result.content()).isNull();
+    }
+
+    @Test
+    void 책_제목과_생성일은_변형_없이_그대로_전달된다() {
+        LocalDateTime createdAt = LocalDateTime.of(2026, 5, 7, 9, 0, 0);
+
+        SummaryHistoryItemResult result = SummaryHistoryItemResult.from(
+                new SummaryHistoryProjection("데미안", "본문", createdAt));
+
+        assertThat(result.bookTitle()).isEqualTo("데미안");
+        assertThat(result.createdAt()).isEqualTo(createdAt);
+    }
+}

--- a/src/test/java/com/readum/domain/summary/service/SummaryHistorySearchServiceTest.java
+++ b/src/test/java/com/readum/domain/summary/service/SummaryHistorySearchServiceTest.java
@@ -1,0 +1,126 @@
+package com.readum.domain.summary.service;
+
+import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.summary.dto.SummaryHistoryItemResult;
+import com.readum.domain.summary.dto.SummaryHistoryListCommand;
+import com.readum.domain.summary.dto.SummaryHistoryListResult;
+import com.readum.domain.user.exception.UserErrorCode;
+import com.readum.model.summary.repository.SummaryRepository;
+import com.readum.model.summary.repository.projection.SummaryHistoryProjection;
+import com.readum.model.user.entity.User;
+import com.readum.model.user.entity.UserFixture;
+import com.readum.model.user.repository.UserRepository;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class SummaryHistorySearchServiceTest {
+
+    private static final String USER_SESSION_ID = "test-session-id";
+    private static final Long USER_ID = 1L;
+    private static final int PAGE_SIZE = 20;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SummaryRepository summaryRepository;
+
+    @InjectMocks
+    private SummaryHistorySearchService summaryHistorySearchService;
+
+    @BeforeEach
+    void setUp() {
+        User testUser = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
+        lenient().when(userRepository.findBySessionId(USER_SESSION_ID)).thenReturn(Optional.of(testUser));
+    }
+
+    @Test
+    void 유효하지_않은_user_session_쿠키면_UnauthorizedException() {
+        given(userRepository.findBySessionId("invalid")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> summaryHistorySearchService.findMyHistory(
+                new SummaryHistoryListCommand("invalid", 1)
+        ))
+                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
+                .extracting(UnauthorizedException::getErrorCode)
+                .isEqualTo(UserErrorCode.INVALID_SESSION);
+    }
+
+    @Test
+    void 감상_기록이_없으면_빈_배열과_hasNext_false_를_반환한다() {
+        given(summaryRepository.findCompletedHistoryByUserId(USER_ID, PageRequest.of(0, PAGE_SIZE)))
+                .willReturn(new SliceImpl<>(List.of(), PageRequest.of(0, PAGE_SIZE), false));
+
+        SummaryHistoryListResult result = summaryHistorySearchService.findMyHistory(
+                new SummaryHistoryListCommand(USER_SESSION_ID, 1)
+        );
+
+        assertThat(result.summaries()).isEmpty();
+        assertThat(result.page()).isEqualTo(1);
+        assertThat(result.size()).isEqualTo(PAGE_SIZE);
+        assertThat(result.hasNext()).isFalse();
+    }
+
+    @Test
+    void projection_이_응답용_Result_로_변환된다() {
+        LocalDateTime createdAt = LocalDateTime.of(2026, 5, 7, 9, 0, 0);
+        given(summaryRepository.findCompletedHistoryByUserId(USER_ID, PageRequest.of(0, PAGE_SIZE)))
+                .willReturn(new SliceImpl<>(List.of(
+                        new SummaryHistoryProjection("데미안", "내 안에서 솟아 나오려는 것", createdAt)
+                ), PageRequest.of(0, PAGE_SIZE), false));
+
+        SummaryHistoryListResult result = summaryHistorySearchService.findMyHistory(
+                new SummaryHistoryListCommand(USER_SESSION_ID, 1)
+        );
+
+        assertThat(result.summaries()).hasSize(1);
+        SummaryHistoryItemResult item = result.summaries().get(0);
+        assertThat(item.bookTitle()).isEqualTo("데미안");
+        assertThat(item.content()).isEqualTo("내 안에서 솟아 나오려는 것");
+        assertThat(item.createdAt()).isEqualTo(createdAt);
+    }
+
+    @Test
+    void page_파라미터는_1_indexed_에서_0_indexed_로_변환되고_size_는_20_고정이다() {
+        given(summaryRepository.findCompletedHistoryByUserId(USER_ID, PageRequest.of(2, PAGE_SIZE)))
+                .willReturn(new SliceImpl<>(List.of(), PageRequest.of(2, PAGE_SIZE), false));
+
+        SummaryHistoryListResult result = summaryHistorySearchService.findMyHistory(
+                new SummaryHistoryListCommand(USER_SESSION_ID, 3)
+        );
+
+        assertThat(result.page()).isEqualTo(3);
+        assertThat(result.size()).isEqualTo(PAGE_SIZE);
+    }
+
+    @Test
+    void 다음_페이지가_있으면_hasNext_true_를_반환한다() {
+        given(summaryRepository.findCompletedHistoryByUserId(USER_ID, PageRequest.of(0, PAGE_SIZE)))
+                .willReturn(new SliceImpl<>(List.of(
+                        new SummaryHistoryProjection("책", "본문", LocalDateTime.now())
+                ), PageRequest.of(0, PAGE_SIZE), true));
+
+        SummaryHistoryListResult result = summaryHistorySearchService.findMyHistory(
+                new SummaryHistoryListCommand(USER_SESSION_ID, 1)
+        );
+
+        assertThat(result.hasNext()).isTrue();
+    }
+}

--- a/src/test/java/com/readum/model/summary/repository/SummaryRepositoryTest.java
+++ b/src/test/java/com/readum/model/summary/repository/SummaryRepositoryTest.java
@@ -1,0 +1,198 @@
+package com.readum.model.summary.repository;
+
+import com.readum.model.aiChat.entity.AiChatSession;
+import com.readum.model.aiChat.repository.AiChatSessionRepository;
+import com.readum.model.book.entity.Book;
+import com.readum.model.book.repository.BookRepository;
+import com.readum.model.summary.entity.Summary;
+import com.readum.model.summary.repository.projection.SummaryHistoryProjection;
+import com.readum.model.user.entity.UserBook;
+import com.readum.model.user.repository.UserBookRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class SummaryRepositoryTest {
+
+    @Autowired
+    private SummaryRepository summaryRepository;
+
+    @Autowired
+    private AiChatSessionRepository aiChatSessionRepository;
+
+    @Autowired
+    private UserBookRepository userBookRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    private static long userIdSeq = 9_200_000L;
+    private static long externalSeq = 9_200_000L;
+
+    private static synchronized Long nextUserId() {
+        userIdSeq += 1;
+        return userIdSeq;
+    }
+
+    private static synchronized String nextExternalId() {
+        externalSeq += 1;
+        return "ext-" + externalSeq;
+    }
+
+    @Test
+    @DisplayName("findCompletedHistoryByUserId: 종료된 세션의 완성된 감상문을 책 제목·본문·생성일과 함께 조회한다")
+    void 종료_세션의_완성_감상문을_조회한다() {
+        Long userId = nextUserId();
+        Long userBookId = persistUserBook(userId, "데미안");
+        AiChatSession session = persistSession(userBookId, AiChatSession.Status.CLOSED);
+        persistCompletedSummary(userBookId, session.getId(), "내 안에서 솟아 나오려는 것");
+
+        Slice<SummaryHistoryProjection> slice = summaryRepository
+                .findCompletedHistoryByUserId(userId, PageRequest.of(0, 20));
+
+        assertThat(slice.getContent()).hasSize(1);
+        SummaryHistoryProjection row = slice.getContent().get(0);
+        assertThat(row.bookTitle()).isEqualTo("데미안");
+        assertThat(row.body()).isEqualTo("내 안에서 솟아 나오려는 것");
+        assertThat(row.createdAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("findCompletedHistoryByUserId: 아직 대화 중(ACTIVE)인 세션에 자동 생성된 완성 감상문은 제외된다")
+    void 활성_세션의_완성_감상문은_제외된다() {
+        Long userId = nextUserId();
+        Long userBookId = persistUserBook(userId, "활성책");
+        // 스케줄러가 ACTIVE 세션에 미리 만들어 둔 COMPLETED 감상문 — 세션이 아직 안 닫혔으므로 기록에 노출되면 안 된다.
+        AiChatSession session = persistSession(userBookId, AiChatSession.Status.ACTIVE);
+        persistCompletedSummary(userBookId, session.getId(), "스케줄러 자동 생성 감상");
+
+        Slice<SummaryHistoryProjection> slice = summaryRepository
+                .findCompletedHistoryByUserId(userId, PageRequest.of(0, 20));
+
+        assertThat(slice.getContent()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findCompletedHistoryByUserId: 미완성(IN_PROGRESS)·실패(FAILED) 감상문은 제외된다")
+    void 미완성_실패_감상문은_제외된다() {
+        Long userId = nextUserId();
+        Long userBookId = persistUserBook(userId, "진행중책");
+
+        AiChatSession inProgressSession = persistSession(userBookId, AiChatSession.Status.CLOSED);
+        summaryRepository.save(Summary.createInProgress(userBookId, inProgressSession.getId(), LocalDate.now()));
+
+        AiChatSession failedSession = persistSession(userBookId, AiChatSession.Status.CLOSED);
+        Summary failed = summaryRepository.save(
+                Summary.createInProgress(userBookId, failedSession.getId(), LocalDate.now()));
+        failed.fail();
+        summaryRepository.saveAndFlush(failed);
+
+        Slice<SummaryHistoryProjection> slice = summaryRepository
+                .findCompletedHistoryByUserId(userId, PageRequest.of(0, 20));
+
+        assertThat(slice.getContent()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findCompletedHistoryByUserId: 다른 사용자의 감상문은 조회되지 않는다")
+    void 다른_사용자_감상문은_제외된다() {
+        Long owner = nextUserId();
+        Long other = nextUserId();
+        Long ownerBookId = persistUserBook(owner, "주인책");
+        AiChatSession session = persistSession(ownerBookId, AiChatSession.Status.CLOSED);
+        persistCompletedSummary(ownerBookId, session.getId(), "주인의 감상");
+
+        Slice<SummaryHistoryProjection> slice = summaryRepository
+                .findCompletedHistoryByUserId(other, PageRequest.of(0, 20));
+
+        assertThat(slice.getContent()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findCompletedHistoryByUserId: 최신순(생성일·id 내림차순)으로 정렬된다")
+    void 최신순으로_정렬된다() {
+        Long userId = nextUserId();
+        Long userBookId = persistUserBook(userId, "한권");
+
+        persistClosedCompletedSummary(userBookId, "첫번째");
+        persistClosedCompletedSummary(userBookId, "두번째");
+        persistClosedCompletedSummary(userBookId, "세번째");
+
+        Slice<SummaryHistoryProjection> slice = summaryRepository
+                .findCompletedHistoryByUserId(userId, PageRequest.of(0, 20));
+
+        assertThat(slice.getContent())
+                .extracting(SummaryHistoryProjection::body)
+                .containsExactly("세번째", "두번째", "첫번째");
+    }
+
+    @Test
+    @DisplayName("findCompletedHistoryByUserId: Slice 의 hasNext 가 페이지 size 와 비교해 반환된다")
+    void hasNext_페이지네이션() {
+        Long userId = nextUserId();
+        Long userBookId = persistUserBook(userId, "여러권");
+        for (int i = 0; i < 3; i++) {
+            persistClosedCompletedSummary(userBookId, "감상" + i);
+        }
+
+        Slice<SummaryHistoryProjection> firstPage = summaryRepository
+                .findCompletedHistoryByUserId(userId, PageRequest.of(0, 2));
+        assertThat(firstPage.getContent()).hasSize(2);
+        assertThat(firstPage.hasNext()).isTrue();
+
+        Slice<SummaryHistoryProjection> secondPage = summaryRepository
+                .findCompletedHistoryByUserId(userId, PageRequest.of(1, 2));
+        assertThat(secondPage.getContent()).hasSize(1);
+        assertThat(secondPage.hasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("findCompletedHistoryByUserId: 감상 기록이 없으면 빈 Slice 를 반환한다")
+    void 기록이_없으면_빈_Slice() {
+        Long userId = nextUserId();
+        persistUserBook(userId, "빈책");
+
+        Slice<SummaryHistoryProjection> slice = summaryRepository
+                .findCompletedHistoryByUserId(userId, PageRequest.of(0, 20));
+
+        assertThat(slice.getContent()).isEmpty();
+        assertThat(slice.hasNext()).isFalse();
+    }
+
+    private Long persistUserBook(Long userId, String bookTitle) {
+        Book book = bookRepository.save(
+                Book.create(nextExternalId(), bookTitle, null, null, null, null));
+        UserBook userBook = userBookRepository.save(UserBook.create(userId, book.getId()));
+        return userBook.getId();
+    }
+
+    private AiChatSession persistSession(Long userBookId, AiChatSession.Status status) {
+        AiChatSession session = AiChatSession.create(userBookId);
+        if (status == AiChatSession.Status.CLOSED) {
+            session.close();
+        }
+        return aiChatSessionRepository.save(session);
+    }
+
+    private Summary persistCompletedSummary(Long userBookId, Long sessionId, String body) {
+        Summary summary = summaryRepository.save(
+                Summary.createInProgress(userBookId, sessionId, LocalDate.now()));
+        summary.complete("제목", body, "인용");
+        return summaryRepository.saveAndFlush(summary);
+    }
+
+    private Summary persistClosedCompletedSummary(Long userBookId, String body) {
+        AiChatSession session = persistSession(userBookId, AiChatSession.Status.CLOSED);
+        return persistCompletedSummary(userBookId, session.getId(), body);
+    }
+}

--- a/src/test/java/com/readum/presentation/controller/summary/SummaryControllerTest.java
+++ b/src/test/java/com/readum/presentation/controller/summary/SummaryControllerTest.java
@@ -1,0 +1,93 @@
+package com.readum.presentation.controller.summary;
+
+import com.readum.domain.summary.dto.SummaryHistoryItemResult;
+import com.readum.domain.summary.dto.SummaryHistoryListResult;
+import com.readum.domain.summary.service.SummaryHistorySearchService;
+import com.readum.presentation.common.GlobalExceptionHandler;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class SummaryControllerTest {
+
+    private static final String USER_SESSION_ID = "test-session-id";
+    private static final Cookie USER_SESSION_COOKIE = new Cookie("user_session", USER_SESSION_ID);
+
+    @Mock
+    private SummaryHistorySearchService summaryHistorySearchService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        SummaryController controller = new SummaryController(summaryHistorySearchService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void 감상_기록_목록_조회_정상_응답() throws Exception {
+        LocalDateTime createdAt = LocalDateTime.of(2026, 5, 7, 9, 0, 0);
+        given(summaryHistorySearchService.findMyHistory(any()))
+                .willReturn(new SummaryHistoryListResult(
+                        List.of(
+                                new SummaryHistoryItemResult("데미안", "깊은 울림을 주는 책이었다.", createdAt),
+                                new SummaryHistoryItemResult("1984", "감시 사회의 공포.", createdAt.minusDays(1))
+                        ),
+                        1,
+                        20,
+                        false
+                ));
+
+        mockMvc.perform(get("/api/v1/summaries")
+                        .cookie(USER_SESSION_COOKIE)
+                        .param("page", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.summaries.length()").value(2))
+                .andExpect(jsonPath("$.data.summaries[0].bookTitle").value("데미안"))
+                .andExpect(jsonPath("$.data.summaries[0].content").value("깊은 울림을 주는 책이었다."))
+                .andExpect(jsonPath("$.data.summaries[1].bookTitle").value("1984"))
+                .andExpect(jsonPath("$.data.page").value(1))
+                .andExpect(jsonPath("$.data.size").value(20))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    @Test
+    void 감상_기록이_없으면_빈_배열을_반환한다() throws Exception {
+        given(summaryHistorySearchService.findMyHistory(any()))
+                .willReturn(new SummaryHistoryListResult(List.of(), 1, 20, false));
+
+        mockMvc.perform(get("/api/v1/summaries")
+                        .cookie(USER_SESSION_COOKIE)
+                        .param("page", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.summaries.length()").value(0))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    @Test
+    void 감상_기록_조회_page_가_0이면_400() throws Exception {
+        mockMvc.perform(get("/api/v1/summaries")
+                        .cookie(USER_SESSION_COOKIE)
+                        .param("page", "0"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.message", containsString("page는 1 이상")));
+    }
+}


### PR DESCRIPTION
브랜치를 실수로 이상한데서 따버렸다..  
그냥 #73 에 슛하겠습니다.  


로그인한 사용자 본인의 감상 기록을 최신순으로 페이지네이션 조회하는 GET /api/v1/summaries 추가.

- 채팅 세션이 종료(CLOSED)되고 감상문이 완성(COMPLETED)된 기록만 포함한다. 스케줄러가 아직 대화 중(ACTIVE)인 세션에 자동 생성해 둔 감상문은 제외된다.
- 감상문 내용은 앞 100자까지만 노출하고 초과분은 "..." 로 줄여 응답한다.
- 생성일·id 내림차순(최신순)으로 정렬하고, 한 번에 20개씩 Slice 로 조회한다.
- Summary·AiChatSession·UserBook·Book 에 JPA 연관관계가 없어 on 절 join 으로 책 제목을 함께 투영하며, userBook.userId 필터가 소유권 검증을 겸한다.

테스트: Repository(조회 조건·정렬·페이지네이션), Service(인증·페이지 변환· 변환 위임), 내용 미리보기 100자 절단, Controller(정상·빈 배열·검증 실패) 추가.

close #66 
