### PR TITLE
feat(user): 익명 가입 시 랜덤 닉네임 저장 및 프로필 조회 API 추가

### DIFF
--- a/src/main/java/com/readum/domain/user/dto/UserProfileResult.java
+++ b/src/main/java/com/readum/domain/user/dto/UserProfileResult.java
@@ -1,0 +1,10 @@
+package com.readum.domain.user.dto;
+
+import com.readum.model.user.entity.User;
+
+public record UserProfileResult(String nickname) {
+
+    public static UserProfileResult from(User user) {
+        return new UserProfileResult(user.getNickname());
+    }
+}

--- a/src/main/java/com/readum/domain/user/service/CreateUserSessionService.java
+++ b/src/main/java/com/readum/domain/user/service/CreateUserSessionService.java
@@ -14,11 +14,13 @@ import java.util.UUID;
 public class CreateUserSessionService {
 
     private final UserRepository userRepository;
+    private final NicknameGenerator nicknameGenerator;
 
     @Transactional
     public CreateUserSessionResult execute() {
         UUID sessionId = UUID.randomUUID();
-        User saved = userRepository.save(User.create(sessionId));
+        String nickname = nicknameGenerator.generate();
+        User saved = userRepository.save(User.create(sessionId, nickname));
         return CreateUserSessionResult.from(saved, sessionId);
     }
 }

--- a/src/main/java/com/readum/domain/user/service/NicknameGenerator.java
+++ b/src/main/java/com/readum/domain/user/service/NicknameGenerator.java
@@ -1,0 +1,36 @@
+package com.readum.domain.user.service;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * 신규 익명 사용자에게 배정할 닉네임을 임의로 고른다.
+ * 독서 서비스 컨셉의 한글 닉네임 후보를 정적 상수로 보유하며, 중복 배정을 허용한다.
+ * 후보는 모두 "영어 대/소문자 + 한글 + 숫자, 최대 10자" 제약(정규식 {@code ^[A-Za-z0-9가-힣]{1,10}$})을 만족한다.
+ *
+ * <p>정적 in-memory 상수에서 고르는 순수 도메인 빌딩 블록이라 외부 시스템도 교체 대상도 아니므로
+ * Port/Adapter 없이 {@code @Component} 로 둔다 (UserBookConflictReader 와 동일한 선례).
+ */
+@Component
+public class NicknameGenerator {
+
+    // package-private: 같은 패키지 테스트가 모든 후보의 제약 충족을 결정론적으로 검증한다.
+    static final List<String> NICKNAMES = List.of(
+            "책읽는여우",
+            "밤샘독서가",
+            "문장수집가",
+            "행간탐험가",
+            "책갈피요정",
+            "심야의서재",
+            "독서하는곰",
+            "글줄나그네",
+            "페이지여행",
+            "이야기사냥꾼"
+    );
+
+    public String generate() {
+        return NICKNAMES.get(ThreadLocalRandom.current().nextInt(NICKNAMES.size()));
+    }
+}

--- a/src/main/java/com/readum/domain/user/service/UserSearchService.java
+++ b/src/main/java/com/readum/domain/user/service/UserSearchService.java
@@ -1,6 +1,7 @@
 package com.readum.domain.user.service;
 
 import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.dto.UserProfileResult;
 import com.readum.domain.user.dto.UserSessionInfoResult;
 import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.user.repository.UserBookRepository;
@@ -17,11 +18,20 @@ public class UserSearchService {
     private final UserBookRepository userBookRepository;
 
     public UserSessionInfoResult findSessionInfo(String sessionId) {
-        User user = userRepository.findBySessionId(sessionId)
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
+        User user = getUserBySessionIdOrThrow(sessionId);
 
         boolean hasRegisteredBooks = userBookRepository.existsByUserId(user.getId());
 
         return UserSessionInfoResult.from(user, hasRegisteredBooks);
+    }
+
+    public UserProfileResult findProfile(String sessionId) {
+        User user = getUserBySessionIdOrThrow(sessionId);
+        return UserProfileResult.from(user);
+    }
+
+    private User getUserBySessionIdOrThrow(String sessionId) {
+        return userRepository.findBySessionId(sessionId)
+                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
     }
 }

--- a/src/main/java/com/readum/model/user/entity/User.java
+++ b/src/main/java/com/readum/model/user/entity/User.java
@@ -31,6 +31,10 @@ public class User {
     @Column(name = "session_id", nullable = false, unique = true, length = 36)
     private String sessionId;
 
+    // 기존 사용자 데이터에는 닉네임이 없을 수 있어 nullable 허용. 신규 가입부터 서버가 임의 배정한다.
+    @Column(name = "nickname", length = 10)
+    private String nickname;
+
     @Column(name = "last_selected_user_book_id")
     private Long lastSelectedUserBookId;
 
@@ -43,9 +47,9 @@ public class User {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    public static User create(UUID sessionId) {
+    public static User create(UUID sessionId, String nickname) {
         LocalDateTime now = LocalDateTime.now();
-        return new User(null, null, sessionId.toString(), null, false, now, now);
+        return new User(null, null, sessionId.toString(), nickname, null, false, now, now);
     }
 
     public void completeOnboarding() {

--- a/src/main/java/com/readum/presentation/controller/user/UserController.java
+++ b/src/main/java/com/readum/presentation/controller/user/UserController.java
@@ -2,6 +2,7 @@ package com.readum.presentation.controller.user;
 
 import com.readum.domain.user.dto.CompleteOnboardingResult;
 import com.readum.domain.user.dto.CreateUserSessionResult;
+import com.readum.domain.user.dto.UserProfileResult;
 import com.readum.domain.user.dto.UserSessionInfoResult;
 import com.readum.domain.user.service.CompleteOnboardingService;
 import com.readum.domain.user.service.CreateUserSessionService;
@@ -9,6 +10,7 @@ import com.readum.domain.user.service.UserSearchService;
 import com.readum.presentation.common.GlobalApiResponse;
 import com.readum.presentation.controller.user.dto.CompleteOnboardingResponse;
 import com.readum.presentation.controller.user.dto.CreateUserSessionResponse;
+import com.readum.presentation.controller.user.dto.UserProfileResponse;
 import com.readum.presentation.controller.user.dto.UserSessionInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -75,6 +77,21 @@ public class UserController {
             @CookieValue(name = USER_SESSION_COOKIE, required = true) String sessionId) {
         UserSessionInfoResult result = userSearchService.findSessionInfo(sessionId);
         return GlobalApiResponse.ok(UserSessionInfoResponse.from(result));
+    }
+
+    @Operation(
+            summary = "내 프로필 조회",
+            description = "user_session 쿠키로 현재 사용자의 프로필을 조회한다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "user_session 쿠키 누락 또는 유효하지 않은 세션")
+    })
+    @GetMapping("/me/profile")
+    public ResponseEntity<GlobalApiResponse<UserProfileResponse>> getProfile(
+            @CookieValue(name = USER_SESSION_COOKIE, required = true) String sessionId) {
+        UserProfileResult result = userSearchService.findProfile(sessionId);
+        return GlobalApiResponse.ok(UserProfileResponse.from(result));
     }
 
     @Operation(

--- a/src/main/java/com/readum/presentation/controller/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/readum/presentation/controller/user/dto/UserProfileResponse.java
@@ -1,0 +1,16 @@
+package com.readum.presentation.controller.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.readum.domain.user.dto.UserProfileResult;
+
+public record UserProfileResponse(Profile profile) {
+
+    public record Profile(
+            // 닉네임이 없는 기존 사용자도 키는 항상 노출(값은 null)되도록 강제한다.
+            @JsonInclude(JsonInclude.Include.ALWAYS) String nickname
+    ) {}
+
+    public static UserProfileResponse from(UserProfileResult result) {
+        return new UserProfileResponse(new Profile(result.nickname()));
+    }
+}

--- a/src/test/java/com/readum/domain/user/service/CompleteOnboardingServiceTest.java
+++ b/src/test/java/com/readum/domain/user/service/CompleteOnboardingServiceTest.java
@@ -32,7 +32,7 @@ class CompleteOnboardingServiceTest {
     @Test
     void 미완료_사용자에_대해_온보딩을_완료_상태로_변경한다() {
         UUID sessionId = UUID.randomUUID();
-        User user = User.create(sessionId);
+        User user = User.create(sessionId, "책읽는여우");
 
         given(userRepository.findBySessionId(sessionId.toString())).willReturn(Optional.of(user));
 
@@ -45,7 +45,7 @@ class CompleteOnboardingServiceTest {
     @Test
     void 이미_완료된_사용자에_대해_멱등하게_true_를_반환한다() {
         UUID sessionId = UUID.randomUUID();
-        User user = User.create(sessionId);
+        User user = User.create(sessionId, "책읽는여우");
         user.completeOnboarding();
         LocalDateTime previousUpdatedAt = user.getUpdatedAt();
 

--- a/src/test/java/com/readum/domain/user/service/CreateUserSessionServiceTest.java
+++ b/src/test/java/com/readum/domain/user/service/CreateUserSessionServiceTest.java
@@ -23,14 +23,18 @@ class CreateUserSessionServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private NicknameGenerator nicknameGenerator;
+
     @InjectMocks
     private CreateUserSessionService createUserSessionService;
 
     @Test
     void 신규_사용자를_저장하고_세션_식별자를_반환한다() {
+        given(nicknameGenerator.generate()).willReturn("책읽는여우");
         given(userRepository.save(org.mockito.ArgumentMatchers.any(User.class))).willAnswer(invocation -> {
             User input = invocation.getArgument(0);
-            return UserFixture.persistedUser(1L, input.getSessionId());
+            return UserFixture.persistedUser(1L, input.getSessionId(), input.getNickname());
         });
 
         CreateUserSessionResult result = createUserSessionService.execute();
@@ -40,6 +44,7 @@ class CreateUserSessionServiceTest {
 
         User savedArg = captor.getValue();
         assertThat(savedArg.getSessionId()).isEqualTo(result.sessionId().toString());
+        assertThat(savedArg.getNickname()).isEqualTo("책읽는여우");
         assertThat(savedArg.isOnboardingCompleted()).isFalse();
         assertThat(result.userId()).isEqualTo(1L);
         assertThat(result.sessionId()).isInstanceOf(UUID.class);

--- a/src/test/java/com/readum/domain/user/service/NicknameGeneratorTest.java
+++ b/src/test/java/com/readum/domain/user/service/NicknameGeneratorTest.java
@@ -1,0 +1,27 @@
+package com.readum.domain.user.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NicknameGeneratorTest {
+
+    // 닉네임 제약: 영어 대/소문자 + 한글 + 숫자, 최대 10자.
+    private static final String NICKNAME_PATTERN = "^[A-Za-z0-9가-힣]{1,10}$";
+
+    private final NicknameGenerator nicknameGenerator = new NicknameGenerator();
+
+    @Test
+    void 모든_후보_닉네임은_제약_정규식을_만족한다() {
+        assertThat(NicknameGenerator.NICKNAMES)
+                .isNotEmpty()
+                .allSatisfy(nickname -> assertThat(nickname).matches(NICKNAME_PATTERN));
+    }
+
+    @Test
+    void 생성된_닉네임은_후보_목록에_포함된다() {
+        for (int i = 0; i < 50; i++) {
+            assertThat(NicknameGenerator.NICKNAMES).contains(nicknameGenerator.generate());
+        }
+    }
+}

--- a/src/test/java/com/readum/domain/user/service/UserSearchServiceTest.java
+++ b/src/test/java/com/readum/domain/user/service/UserSearchServiceTest.java
@@ -1,6 +1,7 @@
 package com.readum.domain.user.service;
 
 import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.dto.UserProfileResult;
 import com.readum.domain.user.dto.UserSessionInfoResult;
 import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.user.repository.UserBookRepository;
@@ -69,6 +70,41 @@ class UserSearchServiceTest {
         given(userRepository.findBySessionId(unknown)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> userSearchService.findSessionInfo(unknown))
+                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
+                .extracting(UnauthorizedException::getErrorCode)
+                .isEqualTo(UserErrorCode.INVALID_SESSION);
+    }
+
+    @Test
+    void 유효한_세션이면_프로필_닉네임을_반환한다() {
+        UUID sessionId = UUID.randomUUID();
+        User user = UserFixture.persistedUser(20L, sessionId.toString(), "문장수집가");
+
+        given(userRepository.findBySessionId(sessionId.toString())).willReturn(Optional.of(user));
+
+        UserProfileResult result = userSearchService.findProfile(sessionId.toString());
+
+        assertThat(result.nickname()).isEqualTo("문장수집가");
+    }
+
+    @Test
+    void 닉네임이_없는_기존_사용자의_프로필은_닉네임이_null_이다() {
+        UUID sessionId = UUID.randomUUID();
+        User user = UserFixture.persistedUser(21L, sessionId.toString(), (String) null);
+
+        given(userRepository.findBySessionId(sessionId.toString())).willReturn(Optional.of(user));
+
+        UserProfileResult result = userSearchService.findProfile(sessionId.toString());
+
+        assertThat(result.nickname()).isNull();
+    }
+
+    @Test
+    void 존재하지_않는_세션으로_프로필을_조회하면_INVALID_SESSION_예외가_발생한다() {
+        String unknown = UUID.randomUUID().toString();
+        given(userRepository.findBySessionId(unknown)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userSearchService.findProfile(unknown))
                 .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
                 .extracting(UnauthorizedException::getErrorCode)
                 .isEqualTo(UserErrorCode.INVALID_SESSION);

--- a/src/test/java/com/readum/model/user/entity/UserFixture.java
+++ b/src/test/java/com/readum/model/user/entity/UserFixture.java
@@ -12,19 +12,28 @@ import java.time.LocalDateTime;
 @TestOnly
 public final class UserFixture {
 
+    private static final String DEFAULT_NICKNAME = "책읽는여우";
+
     private UserFixture() {
     }
 
     /**
      * 저장되어 id 가 부여된, 온보딩 미완료의 평범한 사용자.
-     * deviceId/lastSelectedUserBookId 는 없는 상태.
+     * deviceId/lastSelectedUserBookId 는 없는 상태이며 닉네임은 기본값.
      */
     public static User persistedUser(Long id, String sessionId) {
-        return persistedUser(id, sessionId, null, false);
+        return persistedUser(id, sessionId, DEFAULT_NICKNAME, null, false);
     }
 
     /**
-     * 저장되어 id 가 부여된 사용자. 마지막 선택 도서와 온보딩 완료 여부를 지정한다.
+     * 저장되어 id 가 부여된 사용자. 닉네임을 지정한다 (닉네임 없는 기존 사용자 재현 시 null 전달).
+     */
+    public static User persistedUser(Long id, String sessionId, String nickname) {
+        return persistedUser(id, sessionId, nickname, null, false);
+    }
+
+    /**
+     * 저장되어 id 가 부여된 사용자. 마지막 선택 도서와 온보딩 완료 여부를 지정한다 (닉네임은 기본값).
      */
     public static User persistedUser(
             Long id,
@@ -32,7 +41,20 @@ public final class UserFixture {
             Long lastSelectedUserBookId,
             boolean onboardingCompleted
     ) {
+        return persistedUser(id, sessionId, DEFAULT_NICKNAME, lastSelectedUserBookId, onboardingCompleted);
+    }
+
+    /**
+     * 저장되어 id 가 부여된 사용자. 닉네임 / 마지막 선택 도서 / 온보딩 완료 여부를 모두 지정한다.
+     */
+    public static User persistedUser(
+            Long id,
+            String sessionId,
+            String nickname,
+            Long lastSelectedUserBookId,
+            boolean onboardingCompleted
+    ) {
         LocalDateTime now = LocalDateTime.now();
-        return new User(id, null, sessionId, lastSelectedUserBookId, onboardingCompleted, now, now);
+        return new User(id, null, sessionId, nickname, lastSelectedUserBookId, onboardingCompleted, now, now);
     }
 }

--- a/src/test/java/com/readum/model/user/repository/UserBookConcurrencyTest.java
+++ b/src/test/java/com/readum/model/user/repository/UserBookConcurrencyTest.java
@@ -58,7 +58,7 @@ class UserBookConcurrencyTest {
         );
         // 임시 cookie 인증 패턴 — UserRepository 로 User row 를 만들고 그 session_id 를 명령 인자로 쓴다.
         // session_id unique 제약을 회피하기 위해 매 실행마다 UUID 로 다른 값을 쓴다.
-        User saved = userRepository.save(User.create(UUID.randomUUID()));
+        User saved = userRepository.save(User.create(UUID.randomUUID(), "책읽는여우"));
         userSessionId = saved.getSessionId();
         userId = saved.getId();
     }

--- a/src/test/java/com/readum/model/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/readum/model/user/repository/UserRepositoryTest.java
@@ -27,13 +27,14 @@ class UserRepositoryTest {
     @DisplayName("sessionId 로 저장한 사용자를 조회할 수 있다")
     void sessionId_로_조회() {
         UUID sessionId = UUID.randomUUID();
-        User saved = userRepository.save(User.create(sessionId));
+        User saved = userRepository.save(User.create(sessionId, "책읽는여우"));
 
         Optional<User> found = userRepository.findBySessionId(sessionId.toString());
 
         assertThat(found).isPresent();
         assertThat(found.get().getId()).isEqualTo(saved.getId());
         assertThat(found.get().getSessionId()).isEqualTo(sessionId.toString());
+        assertThat(found.get().getNickname()).isEqualTo("책읽는여우");
         assertThat(found.get().isOnboardingCompleted()).isFalse();
         assertThat(found.get().getLastSelectedUserBookId()).isNull();
     }

--- a/src/test/java/com/readum/presentation/controller/aiChat/AiChatStreamGuardrailTest.java
+++ b/src/test/java/com/readum/presentation/controller/aiChat/AiChatStreamGuardrailTest.java
@@ -90,7 +90,7 @@ class AiChatStreamGuardrailTest {
 
     @BeforeEach
     void setUp() {
-        User user = userRepository.save(User.create(UUID.randomUUID()));
+        User user = userRepository.save(User.create(UUID.randomUUID(), "책읽는여우"));
         cookie = new Cookie("user_session", user.getSessionId());
 
         Book book = bookRepository.save(BookFixture.persistedBook(

--- a/src/test/java/com/readum/presentation/controller/user/UserControllerTest.java
+++ b/src/test/java/com/readum/presentation/controller/user/UserControllerTest.java
@@ -1,0 +1,85 @@
+package com.readum.presentation.controller.user;
+
+import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.dto.UserProfileResult;
+import com.readum.domain.user.exception.UserErrorCode;
+import com.readum.domain.user.service.CompleteOnboardingService;
+import com.readum.domain.user.service.CreateUserSessionService;
+import com.readum.domain.user.service.UserSearchService;
+import com.readum.presentation.common.GlobalExceptionHandler;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class UserControllerTest {
+
+    private static final Cookie USER_SESSION_COOKIE = new Cookie("user_session", "test-session-id");
+
+    @Mock
+    private CreateUserSessionService createUserSessionService;
+
+    @Mock
+    private UserSearchService userSearchService;
+
+    @Mock
+    private CompleteOnboardingService completeOnboardingService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        UserController controller = new UserController(
+                createUserSessionService, userSearchService, completeOnboardingService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void 유효한_세션으로_프로필을_조회하면_닉네임을_반환한다() throws Exception {
+        given(userSearchService.findProfile("test-session-id"))
+                .willReturn(new UserProfileResult("문장수집가"));
+
+        mockMvc.perform(get("/api/v1/users/me/profile").cookie(USER_SESSION_COOKIE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.profile.nickname").value("문장수집가"));
+    }
+
+    @Test
+    void 닉네임이_없는_기존_사용자도_프로필_조회시_닉네임_키가_null_로_노출된다() throws Exception {
+        given(userSearchService.findProfile("test-session-id"))
+                .willReturn(new UserProfileResult(null));
+
+        mockMvc.perform(get("/api/v1/users/me/profile").cookie(USER_SESSION_COOKIE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.profile.nickname").value(nullValue()));
+    }
+
+    @Test
+    void 세션_쿠키가_없으면_401_을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/v1/users/me/profile"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 유효하지_않은_세션이면_401_을_반환한다() throws Exception {
+        given(userSearchService.findProfile("test-session-id"))
+                .willThrow(new UnauthorizedException(UserErrorCode.INVALID_SESSION));
+
+        mockMvc.perform(get("/api/v1/users/me/profile").cookie(USER_SESSION_COOKIE))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.message").value(UserErrorCode.INVALID_SESSION.getMessage()));
+    }
+}


### PR DESCRIPTION
- 익명 세션 생성 시 NicknameGenerator 가 고른 랜덤 한글 닉네임을 함께 저장 (독서 컨셉 정적 후보 10종, 중복 허용, ^[A-Za-z0-9가-힣]{1,10}$ 충족)
- GET /api/v1/users/me/profile 추가: user_session 쿠키로 프로필(닉네임) 조회
- User.nickname 은 nullable (기존 데이터 보존), 레거시 사용자는 null 노출
- 세션 생성 응답 형식은 변경 없음

배포 전 RDS 에 수동 DDL 필요 (Flyway 없음, ddl-auto=validate):
  ALTER TABLE user ADD COLUMN nickname VARCHAR(10) NULL AFTER session_id;

close #65 

