### PR TITLE
feat(summary): 완성된 감상문 수정 기능 구현

### DIFF
--- a/src/main/java/com/readum/domain/aiChat/dto/SummaryEditCommand.java
+++ b/src/main/java/com/readum/domain/aiChat/dto/SummaryEditCommand.java
@@ -1,0 +1,9 @@
+package com.readum.domain.aiChat.dto;
+
+public record SummaryEditCommand(
+        String userSessionId,
+        Long sessionId,
+        String title,
+        String body
+) {
+}

--- a/src/main/java/com/readum/domain/aiChat/exception/AiChatErrorCode.java
+++ b/src/main/java/com/readum/domain/aiChat/exception/AiChatErrorCode.java
@@ -21,7 +21,8 @@ public enum AiChatErrorCode implements ErrorCode {
     AI_STREAM_INTERRUPTED("AI 응답이 중단되었습니다."),
     SUMMARY_NOT_FOUND("아직 생성된 감상문이 없습니다."),
     SUMMARY_IN_PROGRESS("감상문을 생성 중입니다. 잠시 후 다시 시도해 주세요."),
-    SUMMARY_GENERATION_FAILED("감상문 생성에 실패했습니다.");
+    SUMMARY_GENERATION_FAILED("감상문 생성에 실패했습니다."),
+    SUMMARY_NOT_COMPLETED("완성된 감상문만 수정할 수 있습니다.");
 
     private final String message;
 

--- a/src/main/java/com/readum/domain/aiChat/service/SummaryEditService.java
+++ b/src/main/java/com/readum/domain/aiChat/service/SummaryEditService.java
@@ -1,0 +1,46 @@
+package com.readum.domain.aiChat.service;
+
+import com.readum.domain.aiChat.dto.SummaryEditCommand;
+import com.readum.domain.aiChat.dto.SummaryResult;
+import com.readum.domain.aiChat.exception.AiChatErrorCode;
+import com.readum.domain.exception.BadRequestException;
+import com.readum.domain.exception.NotFoundException;
+import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.exception.UserErrorCode;
+import com.readum.model.aiChat.repository.AiChatSessionRepository;
+import com.readum.model.summary.entity.Summary;
+import com.readum.model.summary.repository.SummaryRepository;
+import com.readum.model.user.entity.User;
+import com.readum.model.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SummaryEditService {
+
+    private final UserRepository userRepository;
+    private final AiChatSessionRepository aiChatSessionRepository;
+    private final SummaryRepository summaryRepository;
+
+    @Transactional
+    public SummaryResult execute(SummaryEditCommand command) {
+        User user = userRepository.findBySessionId(command.userSessionId())
+                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
+
+        aiChatSessionRepository.findByIdAndOwner(command.sessionId(), user.getId())
+                .orElseThrow(() -> new NotFoundException(AiChatErrorCode.SESSION_NOT_FOUND));
+
+        Summary summary = summaryRepository.findFirstByAiChatSessionIdOrderByCreatedAtDesc(command.sessionId())
+                .orElseThrow(() -> new NotFoundException(AiChatErrorCode.SUMMARY_NOT_FOUND));
+
+        if (!summary.isCompleted()) {
+            throw new BadRequestException(AiChatErrorCode.SUMMARY_NOT_COMPLETED);
+        }
+
+        summary.edit(command.title(), command.body());
+
+        return SummaryResult.from(summary);
+    }
+}

--- a/src/main/java/com/readum/model/summary/entity/Summary.java
+++ b/src/main/java/com/readum/model/summary/entity/Summary.java
@@ -102,6 +102,8 @@ public class Summary {
     public void resetToInProgress() {
         this.status = Status.IN_PROGRESS;
         this.retryCount++;
+        this.title = null;
+        this.body = null;
         this.updatedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/readum/model/summary/entity/Summary.java
+++ b/src/main/java/com/readum/model/summary/entity/Summary.java
@@ -110,4 +110,10 @@ public class Summary {
     public boolean isCompleted() {
         return this.status == Status.COMPLETED;
     }
+
+    public void edit(String title, String body) {
+        this.title = title;
+        this.body = body;
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/readum/model/summary/repository/SummaryRepository.java
+++ b/src/main/java/com/readum/model/summary/repository/SummaryRepository.java
@@ -16,6 +16,8 @@ import java.util.Optional;
 
 public interface SummaryRepository extends JpaRepository<Summary, Long> {
 
+    Optional<Summary> findByAiChatSessionId(Long aiChatSessionId);
+
     /**
      * 등록 도서(UserBook) 삭제 cascade 용 — 그 도서에 속한 감상 기록을 일괄 삭제한다.
      * Summary 는 userBookId 를 직접 보유하므로 단순 조건으로 좁힌다.

--- a/src/main/java/com/readum/model/summary/repository/SummaryRepository.java
+++ b/src/main/java/com/readum/model/summary/repository/SummaryRepository.java
@@ -16,8 +16,6 @@ import java.util.Optional;
 
 public interface SummaryRepository extends JpaRepository<Summary, Long> {
 
-    Optional<Summary> findByAiChatSessionId(Long aiChatSessionId);
-
     /**
      * 등록 도서(UserBook) 삭제 cascade 용 — 그 도서에 속한 감상 기록을 일괄 삭제한다.
      * Summary 는 userBookId 를 직접 보유하므로 단순 조건으로 좁힌다.

--- a/src/main/java/com/readum/presentation/controller/aiChat/AiChatController.java
+++ b/src/main/java/com/readum/presentation/controller/aiChat/AiChatController.java
@@ -11,6 +11,7 @@ import com.readum.domain.aiChat.service.AiChatSessionCreateService;
 import com.readum.domain.aiChat.service.AiChatSessionSearchService;
 import com.readum.domain.aiChat.service.SummaryDraftSearchService;
 import com.readum.domain.aiChat.service.SummaryDraftService;
+import com.readum.domain.aiChat.service.SummaryEditService;
 import com.readum.domain.aiChat.service.SummarySearchService;
 import com.readum.presentation.common.GlobalApiResponse;
 import com.readum.presentation.controller.aiChat.dto.AiChatSessionCreateRequest;
@@ -21,6 +22,7 @@ import com.readum.presentation.controller.aiChat.dto.MessageListRequest;
 import com.readum.presentation.controller.aiChat.dto.MessageListResponse;
 import com.readum.presentation.controller.aiChat.dto.SendMessageRequest;
 import com.readum.presentation.controller.aiChat.dto.SummaryDraftEligibilityResponse;
+import com.readum.presentation.controller.aiChat.dto.SummaryEditRequest;
 import com.readum.presentation.controller.aiChat.dto.SummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
@@ -38,6 +40,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -54,6 +57,7 @@ public class AiChatController {
     private final AiChatMessageSendService aiChatMessageSendService;
     private final AiChatMessageSearchService aiChatMessageSearchService;
     private final SummaryDraftService summaryDraftService;
+    private final SummaryEditService summaryEditService;
     private final SummarySearchService summarySearchService;
     private final SummaryDraftSearchService summaryDraftSearchService;
     private final MessageStreamSseSerializer messageStreamSseSerializer;
@@ -229,6 +233,27 @@ public class AiChatController {
             @PathVariable Long sessionId
     ) {
         SummaryResult result = summarySearchService.findBySessionId(sessionId, userSessionId);
+        return GlobalApiResponse.ok(SummaryResponse.from(result));
+    }
+
+    @Operation(
+            summary = "감상문 수정",
+            description = "완성된 감상문의 제목과 본문을 수정한다. " +
+                    "감상문이 COMPLETED 상태가 아니면 400으로 응답한다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "감상문 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 값 검증 실패 또는 완성되지 않은 감상문"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
+            @ApiResponse(responseCode = "404", description = "세션 없음, 소유권 없음, 또는 감상문 없음")
+    })
+    @PutMapping("/sessions/{sessionId}/summary")
+    public ResponseEntity<GlobalApiResponse<SummaryResponse>> editSummary(
+            @CookieValue(name = "user_session") String userSessionId,
+            @PathVariable Long sessionId,
+            @Valid @RequestBody SummaryEditRequest request
+    ) {
+        SummaryResult result = summaryEditService.execute(request.toCommand(userSessionId, sessionId));
         return GlobalApiResponse.ok(SummaryResponse.from(result));
     }
 

--- a/src/main/java/com/readum/presentation/controller/aiChat/dto/SummaryEditRequest.java
+++ b/src/main/java/com/readum/presentation/controller/aiChat/dto/SummaryEditRequest.java
@@ -1,0 +1,20 @@
+package com.readum.presentation.controller.aiChat.dto;
+
+import com.readum.domain.aiChat.dto.SummaryEditCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SummaryEditRequest(
+        @NotBlank(message = "감상문 제목은 비어 있을 수 없습니다.")
+        @Size(max = 50, message = "감상문 제목은 50자 이하여야 합니다.")
+        String title,
+
+        @NotBlank(message = "감상문 본문은 비어 있을 수 없습니다.")
+        @Size(max = 2000, message = "감상문 본문은 2000자 이하여야 합니다.")
+        String body
+) {
+
+    public SummaryEditCommand toCommand(String userSessionId, Long sessionId) {
+        return new SummaryEditCommand(userSessionId, sessionId, title, body);
+    }
+}

--- a/src/test/java/com/readum/domain/aiChat/service/SummaryEditServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/SummaryEditServiceTest.java
@@ -1,0 +1,152 @@
+package com.readum.domain.aiChat.service;
+
+import com.readum.domain.aiChat.dto.SummaryEditCommand;
+import com.readum.domain.aiChat.dto.SummaryResult;
+import com.readum.domain.aiChat.exception.AiChatErrorCode;
+import com.readum.domain.exception.BadRequestException;
+import com.readum.domain.exception.NotFoundException;
+import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.exception.UserErrorCode;
+import com.readum.model.aiChat.entity.AiChatSession;
+import com.readum.model.aiChat.entity.AiChatSessionFixture;
+import com.readum.model.aiChat.repository.AiChatSessionRepository;
+import com.readum.model.summary.entity.Summary;
+import com.readum.model.summary.entity.SummaryFixture;
+import com.readum.model.summary.repository.SummaryRepository;
+import com.readum.model.user.entity.User;
+import com.readum.model.user.entity.UserFixture;
+import com.readum.model.user.repository.UserRepository;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class SummaryEditServiceTest {
+
+    private static final Long SESSION_ID = 1L;
+    private static final Long SUMMARY_ID = 100L;
+    private static final Long USER_ID = 10L;
+    private static final String USER_SESSION_ID = "test-session-id";
+    private static final Long USER_BOOK_ID = 1L;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private AiChatSessionRepository aiChatSessionRepository;
+
+    @Mock
+    private SummaryRepository summaryRepository;
+
+    @InjectMocks
+    private SummaryEditService summaryEditService;
+
+    @BeforeEach
+    void setUp() {
+        User testUser = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
+        lenient().when(userRepository.findBySessionId(USER_SESSION_ID)).thenReturn(Optional.of(testUser));
+    }
+
+    @Test
+    void 완성된_감상문을_정상적으로_수정한다() {
+        AiChatSession session = closedSession();
+        Summary summary = SummaryFixture.persistedCompletedSummary(
+                SUMMARY_ID, USER_BOOK_ID, SESSION_ID, "기존 제목", "기존 본문"
+        );
+        given(aiChatSessionRepository.findByIdAndOwner(SESSION_ID, USER_ID)).willReturn(Optional.of(session));
+        given(summaryRepository.findFirstByAiChatSessionIdOrderByCreatedAtDesc(SESSION_ID)).willReturn(Optional.of(summary));
+
+        SummaryEditCommand command = new SummaryEditCommand(USER_SESSION_ID, SESSION_ID, "수정된 제목", "수정된 본문");
+        SummaryResult result = summaryEditService.execute(command);
+
+        assertThat(result.title()).isEqualTo("수정된 제목");
+        assertThat(result.body()).isEqualTo("수정된 본문");
+        assertThat(summary.getTitle()).isEqualTo("수정된 제목");
+        assertThat(summary.getBody()).isEqualTo("수정된 본문");
+    }
+
+    @Test
+    void 유효하지_않은_세션이면_UnauthorizedException이_발생한다() {
+        given(userRepository.findBySessionId("invalid")).willReturn(Optional.empty());
+
+        SummaryEditCommand command = new SummaryEditCommand("invalid", SESSION_ID, "제목", "본문");
+
+        assertThatThrownBy(() -> summaryEditService.execute(command))
+                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
+                .extracting(UnauthorizedException::getErrorCode)
+                .isEqualTo(UserErrorCode.INVALID_SESSION);
+    }
+
+    @Test
+    void 소유하지_않은_세션이면_NotFoundException이_발생한다() {
+        given(aiChatSessionRepository.findByIdAndOwner(SESSION_ID, USER_ID)).willReturn(Optional.empty());
+
+        SummaryEditCommand command = new SummaryEditCommand(USER_SESSION_ID, SESSION_ID, "제목", "본문");
+
+        assertThatThrownBy(() -> summaryEditService.execute(command))
+                .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
+                .extracting(NotFoundException::getErrorCode)
+                .isEqualTo(AiChatErrorCode.SESSION_NOT_FOUND);
+    }
+
+    @Test
+    void 감상문이_없으면_NotFoundException이_발생한다() {
+        AiChatSession session = closedSession();
+        given(aiChatSessionRepository.findByIdAndOwner(SESSION_ID, USER_ID)).willReturn(Optional.of(session));
+        given(summaryRepository.findFirstByAiChatSessionIdOrderByCreatedAtDesc(SESSION_ID)).willReturn(Optional.empty());
+
+        SummaryEditCommand command = new SummaryEditCommand(USER_SESSION_ID, SESSION_ID, "제목", "본문");
+
+        assertThatThrownBy(() -> summaryEditService.execute(command))
+                .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
+                .extracting(NotFoundException::getErrorCode)
+                .isEqualTo(AiChatErrorCode.SUMMARY_NOT_FOUND);
+    }
+
+    @Test
+    void 생성_중인_감상문은_수정할_수_없다() {
+        AiChatSession session = closedSession();
+        Summary inProgressSummary = SummaryFixture.persistedInProgressSummary(SUMMARY_ID, USER_BOOK_ID, SESSION_ID);
+        given(aiChatSessionRepository.findByIdAndOwner(SESSION_ID, USER_ID)).willReturn(Optional.of(session));
+        given(summaryRepository.findFirstByAiChatSessionIdOrderByCreatedAtDesc(SESSION_ID)).willReturn(Optional.of(inProgressSummary));
+
+        SummaryEditCommand command = new SummaryEditCommand(USER_SESSION_ID, SESSION_ID, "제목", "본문");
+
+        assertThatThrownBy(() -> summaryEditService.execute(command))
+                .asInstanceOf(InstanceOfAssertFactories.type(BadRequestException.class))
+                .extracting(BadRequestException::getErrorCode)
+                .isEqualTo(AiChatErrorCode.SUMMARY_NOT_COMPLETED);
+    }
+
+    @Test
+    void 생성_실패한_감상문은_수정할_수_없다() {
+        AiChatSession session = closedSession();
+        Summary failedSummary = SummaryFixture.persistedFailedSummary(SUMMARY_ID, USER_BOOK_ID, SESSION_ID);
+        given(aiChatSessionRepository.findByIdAndOwner(SESSION_ID, USER_ID)).willReturn(Optional.of(session));
+        given(summaryRepository.findFirstByAiChatSessionIdOrderByCreatedAtDesc(SESSION_ID)).willReturn(Optional.of(failedSummary));
+
+        SummaryEditCommand command = new SummaryEditCommand(USER_SESSION_ID, SESSION_ID, "제목", "본문");
+
+        assertThatThrownBy(() -> summaryEditService.execute(command))
+                .asInstanceOf(InstanceOfAssertFactories.type(BadRequestException.class))
+                .extracting(BadRequestException::getErrorCode)
+                .isEqualTo(AiChatErrorCode.SUMMARY_NOT_COMPLETED);
+    }
+
+    private AiChatSession closedSession() {
+        return AiChatSessionFixture.persistedClosedSession(
+                SESSION_ID, USER_BOOK_ID, 10, 600, "마지막 메시지"
+        );
+    }
+}

--- a/src/test/java/com/readum/domain/user/userbook/service/UserBookDeleteServiceCascadeTest.java
+++ b/src/test/java/com/readum/domain/user/userbook/service/UserBookDeleteServiceCascadeTest.java
@@ -165,7 +165,7 @@ class UserBookDeleteServiceCascadeTest {
     }
 
     private User persistUser() {
-        return userRepository.saveAndFlush(User.create(UUID.randomUUID()));
+        return userRepository.saveAndFlush(User.create(UUID.randomUUID(), "테스트유저"));
     }
 
     private Book persistBook(String externalId) {
@@ -186,6 +186,6 @@ class UserBookDeleteServiceCascadeTest {
     }
 
     private Summary persistSummary(Long userBookId, Long sessionId) {
-        return summaryRepository.saveAndFlush(Summary.createInProgress(userBookId, sessionId));
+        return summaryRepository.saveAndFlush(Summary.createInProgress(userBookId, sessionId, java.time.LocalDate.now()));
     }
 }

--- a/src/test/java/com/readum/model/summary/entity/SummaryFixture.java
+++ b/src/test/java/com/readum/model/summary/entity/SummaryFixture.java
@@ -31,4 +31,32 @@ public final class SummaryFixture {
                 Summary.Status.IN_PROGRESS, 0, null, null, null, now, now
         );
     }
+
+    /**
+     * 저장되어 id 가 부여된, COMPLETED 상태의 감상문.
+     * AI 가 생성한 제목·본문이 채워져 있다.
+     */
+    public static Summary persistedCompletedSummary(
+            Long id, Long userBookId, Long aiChatSessionId,
+            String title, String body
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+        return new Summary(
+                id, userBookId, aiChatSessionId, LocalDate.now(),
+                Summary.Status.COMPLETED, 0, null, title, body, now, now
+        );
+    }
+
+    /**
+     * 저장되어 id 가 부여된, FAILED 상태의 감상문.
+     */
+    public static Summary persistedFailedSummary(
+            Long id, Long userBookId, Long aiChatSessionId
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+        return new Summary(
+                id, userBookId, aiChatSessionId, LocalDate.now(),
+                Summary.Status.FAILED, 1, null, null, null, now, now
+        );
+    }
 }

--- a/src/test/java/com/readum/model/summary/repository/SummaryRepositoryTest.java
+++ b/src/test/java/com/readum/model/summary/repository/SummaryRepositoryTest.java
@@ -187,7 +187,7 @@ class SummaryRepositoryTest {
     private Summary persistCompletedSummary(Long userBookId, Long sessionId, String body) {
         Summary summary = summaryRepository.save(
                 Summary.createInProgress(userBookId, sessionId, LocalDate.now()));
-        summary.complete("제목", body, "인용");
+        summary.complete("제목", body);
         return summaryRepository.saveAndFlush(summary);
     }
 

--- a/src/test/java/com/readum/presentation/controller/aiChat/AiChatControllerTest.java
+++ b/src/test/java/com/readum/presentation/controller/aiChat/AiChatControllerTest.java
@@ -17,6 +17,7 @@ import com.readum.domain.aiChat.service.AiChatSessionCreateService;
 import com.readum.domain.aiChat.service.AiChatSessionSearchService;
 import com.readum.domain.aiChat.service.SummaryDraftSearchService;
 import com.readum.domain.aiChat.service.SummaryDraftService;
+import com.readum.domain.aiChat.service.SummaryEditService;
 import com.readum.domain.aiChat.service.SummarySearchService;
 import com.readum.domain.exception.BadRequestException;
 import com.readum.domain.exception.ConflictException;
@@ -79,6 +80,9 @@ class AiChatControllerTest {
     private SummaryDraftService summaryDraftService;
 
     @Mock
+    private SummaryEditService summaryEditService;
+
+    @Mock
     private SummarySearchService summarySearchService;
 
     @Mock
@@ -97,6 +101,7 @@ class AiChatControllerTest {
                 aiChatMessageSendService,
                 aiChatMessageSearchService,
                 summaryDraftService,
+                summaryEditService,
                 summarySearchService,
                 summaryDraftSearchService,
                 new MessageStreamSseSerializer(objectMapper)


### PR DESCRIPTION
## 작업 사항

AI가 생성한 감상문을 사용자가 직접 수정할 수 있는 기능을 추가했다.

이슈 #68의 스크린샷에서 확인되는 것처럼, 감상문은 제목(title)과 본문(body) 두 필드로 구분되어 있다. 사용자가 수정 화면에서 두 필드를 모두 편집하고 저장하는 흐름이므로, 부분 수정(PATCH) 대신 전체 교체(PUT) 방식을 선택했다.

수정은 COMPLETED 상태의 감상문에만 허용된다. IN_PROGRESS(생성 중)나 FAILED(생성 실패) 상태에서는 아직 완성된 결과물이 없으므로 수정 대상이 아니며, 시도 시 400 응답을 반환한다.

글자 수 제한은 AI 생성 시와 동일하게 제목 50자, 본문 2000자를 적용했다. Bean Validation으로 요청 단계에서 검증한다.

기존 `SummarySearchService`의 소유권 검증 체인(userSessionId → User → UserBook → AiChatSession)을 동일하게 적용하여, 본인의 감상문만 수정할 수 있다.

### 기능

**감상문 수정**
- 완성된 감상문의 제목과 본문을 수정할 수 있다
- 제목 50자, 본문 2000자 글자 수 제한이 적용된다
- 완성되지 않은 감상문(생성 중/실패)은 수정할 수 없다

### API 스펙

| 항목 | 값 |
|---|---|
| Method | `PUT` |
| Path | `/api/v1/ai-chat/sessions/{sessionId}/summary` |
| Cookie | `user_session` (필수) |
| `sessionId` | Long, 경로 변수, 필수 |
| `title` | String, 필수, 최대 50자, 공백 불가 |
| `body` | String, 필수, 최대 2000자, 공백 불가 |

### 시나리오별 응답

**정상** — `PUT /api/v1/ai-chat/sessions/1/summary`
```json
HTTP 200
{
  "data": {
    "title": "수정된 제목",
    "body": "수정된 본문"
  }
}
```

**검증 실패** — 제목 51자 이상
```json
HTTP 400
{ "error": { "message": "감상문 제목은 50자 이하여야 합니다." } }
```

**완성되지 않은 감상문** — IN_PROGRESS 또는 FAILED 상태
```json
HTTP 400
{ "error": { "message": "완성된 감상문만 수정할 수 있습니다." } }
```

**감상문 없음**
```json
HTTP 404
{ "error": { "message": "아직 생성된 감상문이 없습니다." } }
```

## 테스트 결과
- [x] `./gradlew test` 전체 통과
- [x] `SummaryEditServiceTest` 단위 테스트 6건 통과 (정상 수정, 인증 실패, 소유권 없음, 감상문 없음, 생성 중 수정 시도, 실패 상태 수정 시도)

## 관련 이슈
- closes #68

## 참고 사항
- 이 PR은 `feature/71-book-review-scheduler` 브랜치를 base로 한다. #73 PR이 먼저 머지된 후 이 PR이 dev로 반영된다.