### PR TITLE
fix(summary): 마이페이지 감상기록 응답에 감상문 id·세션 제목 추가, content 제거

### DIFF
--- a/src/main/java/com/readum/domain/summary/dto/SummaryHistoryItemResult.java
+++ b/src/main/java/com/readum/domain/summary/dto/SummaryHistoryItemResult.java
@@ -5,31 +5,23 @@ import com.readum.model.summary.repository.projection.SummaryHistoryProjection;
 import java.time.LocalDateTime;
 
 /**
- * 감상 기록 1건. "감상문 내용"의 정의 자체가 미리보기이므로,
- * 본문을 100자까지만 노출하고 초과분은 "..." 로 줄이는 책임을 이 Result 가 갖는다.
+ * 감상 기록 1건. 목록 카드 표시·상세 이동에 필요한 감상문 id, 책 제목, 세션 제목, 생성일을 담는다.
+ * summaryId 는 감상문 행의 PK 라 항상 존재한다. sessionTitle 은 첫 대화 교환 뒤 비동기로 생성되며,
+ * 그 제목 생성이 실패한 드문 경우에만 null 일 수 있다.
  */
 public record SummaryHistoryItemResult(
+        Long summaryId,
         String bookTitle,
-        String content,
+        String sessionTitle,
         LocalDateTime createdAt
 ) {
 
-    private static final int MAX_CONTENT_PREVIEW_LENGTH = 100;
-
     public static SummaryHistoryItemResult from(SummaryHistoryProjection projection) {
         return new SummaryHistoryItemResult(
+                projection.summaryId(),
                 projection.bookTitle(),
-                preview(projection.body()),
+                projection.sessionTitle(),
                 projection.createdAt()
         );
-    }
-
-    private static String preview(String body) {
-        if (body == null) {
-            return null;
-        }
-        return body.length() <= MAX_CONTENT_PREVIEW_LENGTH
-                ? body
-                : body.substring(0, MAX_CONTENT_PREVIEW_LENGTH) + "...";
     }
 }

--- a/src/main/java/com/readum/model/summary/repository/SummaryRepository.java
+++ b/src/main/java/com/readum/model/summary/repository/SummaryRepository.java
@@ -46,12 +46,14 @@ public interface SummaryRepository extends JpaRepository<Summary, Long> {
      * 사용자 본인의 감상 기록 목록 — 세션당 감상문은 1건(세션:감상문 = 1:1, uk_summary_session 제약),
      * 최신순(createdAt DESC, id DESC) Slice.
      * Summary / AiChatSession / UserBook / Book 사이에 JPA 연관관계가 없어 on 절로 직접 join 한다 (Hibernate 6+).
-     * book.title 을 투영해야 하므로 UserBook/Book join 이 불가피하고, userBook.userId 필터가 소유권 검증을 겸한다.
+     * 목록 카드에 책 제목·세션 제목을 함께 노출하고 상세 이동을 위해 감상문 id 가 필요하므로,
+     * book.title·aiChatSession.title 을 투영하는 join 이 불가피하다. userBook.userId 필터가 소유권 검증을 겸한다.
      */
     @Query("""
             select new com.readum.model.summary.repository.projection.SummaryHistoryProjection(
-                       book.title
-                     , summary.body
+                       summary.id
+                     , book.title
+                     , aiChatSession.title
                      , summary.createdAt
                    )
               from Summary summary

--- a/src/main/java/com/readum/model/summary/repository/projection/SummaryHistoryProjection.java
+++ b/src/main/java/com/readum/model/summary/repository/projection/SummaryHistoryProjection.java
@@ -5,10 +5,12 @@ import java.time.LocalDateTime;
 /**
  * 사용자 본인의 감상 기록(완성된 감상문) 목록 조회용 projection.
  * Summary / AiChatSession / UserBook / Book 사이에 JPA 연관관계가 없어 @Query 의 on 절로 직접 join 한 결과를 담는다.
+ * sessionTitle 은 비동기 제목 생성이 실패한 드문 경우에만 null 일 수 있다.
  */
 public record SummaryHistoryProjection(
+        Long summaryId,
         String bookTitle,
-        String body,
+        String sessionTitle,
         LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/readum/presentation/controller/summary/SummaryController.java
+++ b/src/main/java/com/readum/presentation/controller/summary/SummaryController.java
@@ -42,7 +42,8 @@ public class SummaryController {
             description = "로그인한 사용자 본인의 감상 기록을 생성일 내림차순(최신순)으로 페이지네이션 조회한다. " +
                     "채팅 세션이 종료(CLOSED)되었고 감상문이 완성(COMPLETED)된 기록만 포함한다 — " +
                     "아직 대화 중인 세션에 자동 생성된 감상문은 제외된다. " +
-                    "감상문 내용은 100자까지만 노출하고 초과분은 \"...\" 로 줄여 응답한다. " +
+                    "각 항목은 상세 이동용 감상문 id(summaryId), 책 제목(bookTitle), 세션 제목(sessionTitle), 생성일(createdAt)을 담는다. " +
+                    "summaryId 는 항상 존재하며, sessionTitle 은 비동기 제목 생성이 실패한 드문 경우에만 null 이다. " +
                     "한 번에 20개씩 조회하며, 기록이 없으면 빈 배열로 200 응답한다."
     )
     @ApiResponses({

--- a/src/main/java/com/readum/presentation/controller/summary/dto/SummaryHistoryItemResponse.java
+++ b/src/main/java/com/readum/presentation/controller/summary/dto/SummaryHistoryItemResponse.java
@@ -5,15 +5,17 @@ import com.readum.domain.summary.dto.SummaryHistoryItemResult;
 import java.time.LocalDateTime;
 
 public record SummaryHistoryItemResponse(
+        Long summaryId,
         String bookTitle,
-        String content,
+        String sessionTitle,
         LocalDateTime createdAt
 ) {
 
     public static SummaryHistoryItemResponse from(SummaryHistoryItemResult result) {
         return new SummaryHistoryItemResponse(
+                result.summaryId(),
                 result.bookTitle(),
-                result.content(),
+                result.sessionTitle(),
                 result.createdAt()
         );
     }

--- a/src/test/java/com/readum/domain/summary/dto/SummaryHistoryItemResultTest.java
+++ b/src/test/java/com/readum/domain/summary/dto/SummaryHistoryItemResultTest.java
@@ -10,53 +10,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SummaryHistoryItemResultTest {
 
     @Test
-    void 본문이_100자_이하면_원문_그대로_노출한다() {
-        String body = "가".repeat(50);
-
-        SummaryHistoryItemResult result = SummaryHistoryItemResult.from(
-                new SummaryHistoryProjection("책", body, LocalDateTime.now()));
-
-        assertThat(result.content()).isEqualTo(body);
-    }
-
-    @Test
-    void 본문이_정확히_100자면_말줄임표_없이_원문_그대로_노출한다() {
-        String body = "가".repeat(100);
-
-        SummaryHistoryItemResult result = SummaryHistoryItemResult.from(
-                new SummaryHistoryProjection("책", body, LocalDateTime.now()));
-
-        assertThat(result.content()).isEqualTo(body);
-        assertThat(result.content()).doesNotEndWith("...");
-    }
-
-    @Test
-    void 본문이_100자를_초과하면_앞_100자만_노출하고_말줄임표를_붙인다() {
-        String body = "가".repeat(101);
-
-        SummaryHistoryItemResult result = SummaryHistoryItemResult.from(
-                new SummaryHistoryProjection("책", body, LocalDateTime.now()));
-
-        assertThat(result.content()).isEqualTo("가".repeat(100) + "...");
-        assertThat(result.content()).hasSize(103);
-    }
-
-    @Test
-    void 본문이_null_이면_content_도_null_이다() {
-        SummaryHistoryItemResult result = SummaryHistoryItemResult.from(
-                new SummaryHistoryProjection("책", null, LocalDateTime.now()));
-
-        assertThat(result.content()).isNull();
-    }
-
-    @Test
-    void 책_제목과_생성일은_변형_없이_그대로_전달된다() {
+    void projection_의_모든_필드를_변형_없이_전달한다() {
         LocalDateTime createdAt = LocalDateTime.of(2026, 5, 7, 9, 0, 0);
 
         SummaryHistoryItemResult result = SummaryHistoryItemResult.from(
-                new SummaryHistoryProjection("데미안", "본문", createdAt));
+                new SummaryHistoryProjection(42L, "데미안", "데미안을 읽고 나서", createdAt));
 
+        assertThat(result.summaryId()).isEqualTo(42L);
         assertThat(result.bookTitle()).isEqualTo("데미안");
+        assertThat(result.sessionTitle()).isEqualTo("데미안을 읽고 나서");
         assertThat(result.createdAt()).isEqualTo(createdAt);
+    }
+
+    @Test
+    void 세션_제목_생성이_실패해_title_이_null_이어도_그대로_통과시킨다() {
+        SummaryHistoryItemResult result = SummaryHistoryItemResult.from(
+                new SummaryHistoryProjection(1L, "책", null, LocalDateTime.now()));
+
+        assertThat(result.sessionTitle()).isNull();
     }
 }

--- a/src/test/java/com/readum/domain/summary/service/SummaryHistorySearchServiceTest.java
+++ b/src/test/java/com/readum/domain/summary/service/SummaryHistorySearchServiceTest.java
@@ -83,7 +83,7 @@ class SummaryHistorySearchServiceTest {
         LocalDateTime createdAt = LocalDateTime.of(2026, 5, 7, 9, 0, 0);
         given(summaryRepository.findLatestHistoryByUserId(USER_ID, PageRequest.of(0, PAGE_SIZE)))
                 .willReturn(new SliceImpl<>(List.of(
-                        new SummaryHistoryProjection("데미안", "내 안에서 솟아 나오려는 것", createdAt)
+                        new SummaryHistoryProjection(101L, "데미안", "데미안을 읽고 나서", createdAt)
                 ), PageRequest.of(0, PAGE_SIZE), false));
 
         SummaryHistoryListResult result = summaryHistorySearchService.findMyHistory(
@@ -92,8 +92,9 @@ class SummaryHistorySearchServiceTest {
 
         assertThat(result.summaries()).hasSize(1);
         SummaryHistoryItemResult item = result.summaries().get(0);
+        assertThat(item.summaryId()).isEqualTo(101L);
         assertThat(item.bookTitle()).isEqualTo("데미안");
-        assertThat(item.content()).isEqualTo("내 안에서 솟아 나오려는 것");
+        assertThat(item.sessionTitle()).isEqualTo("데미안을 읽고 나서");
         assertThat(item.createdAt()).isEqualTo(createdAt);
     }
 
@@ -114,7 +115,7 @@ class SummaryHistorySearchServiceTest {
     void 다음_페이지가_있으면_hasNext_true_를_반환한다() {
         given(summaryRepository.findLatestHistoryByUserId(USER_ID, PageRequest.of(0, PAGE_SIZE)))
                 .willReturn(new SliceImpl<>(List.of(
-                        new SummaryHistoryProjection("책", "본문", LocalDateTime.now())
+                        new SummaryHistoryProjection(1L, "책", "세션 제목", LocalDateTime.now())
                 ), PageRequest.of(0, PAGE_SIZE), true));
 
         SummaryHistoryListResult result = summaryHistorySearchService.findMyHistory(

--- a/src/test/java/com/readum/model/summary/repository/SummaryRepositoryTest.java
+++ b/src/test/java/com/readum/model/summary/repository/SummaryRepositoryTest.java
@@ -97,21 +97,25 @@ class SummaryRepositoryTest {
     }
 
     @Test
-    @DisplayName("findLatestHistoryByUserId: 세션의 감상문 1건을 책 제목·본문·생성일과 함께 조회한다")
+    @DisplayName("findLatestHistoryByUserId: 세션의 감상문 1건을 감상문 id·책 제목·세션 제목·생성일과 함께 조회한다")
     void 세션당_최신_감상문을_조회한다() {
         Long userId = nextUserId();
         Long userBookId = persistUserBook(userId, "데미안");
         AiChatSession session = aiChatSessionRepository.save(AiChatSession.create(userBookId));
+        session.updateTitle("데미안을 읽고 나서");
+        aiChatSessionRepository.save(session);
         // 1:1 모델 — 세션당 감상문은 한 행이다
-        summaryRepository.save(Summary.createCompleted(userBookId, session.getId(), "새 제목", "내 안에서 솟아 나오려는 것"));
+        Summary saved = summaryRepository.save(
+                Summary.createCompleted(userBookId, session.getId(), "새 제목", "내 안에서 솟아 나오려는 것"));
 
         Slice<SummaryHistoryProjection> slice =
                 summaryRepository.findLatestHistoryByUserId(userId, PageRequest.of(0, 20));
 
         assertThat(slice.getContent()).hasSize(1);
         SummaryHistoryProjection row = slice.getContent().get(0);
+        assertThat(row.summaryId()).isEqualTo(saved.getId());
         assertThat(row.bookTitle()).isEqualTo("데미안");
-        assertThat(row.body()).isEqualTo("내 안에서 솟아 나오려는 것");
+        assertThat(row.sessionTitle()).isEqualTo("데미안을 읽고 나서");
         assertThat(row.createdAt()).isNotNull();
     }
 
@@ -144,7 +148,7 @@ class SummaryRepositoryTest {
                 summaryRepository.findLatestHistoryByUserId(userId, PageRequest.of(0, 20));
 
         assertThat(slice.getContent())
-                .extracting(SummaryHistoryProjection::body)
+                .extracting(SummaryHistoryProjection::sessionTitle)
                 .containsExactly("세번째", "두번째", "첫번째");
     }
 
@@ -211,8 +215,10 @@ class SummaryRepositoryTest {
         return userBook.getId();
     }
 
-    private void persistSessionWithSummary(Long userBookId, String body) {
+    private void persistSessionWithSummary(Long userBookId, String sessionTitle) {
         AiChatSession session = aiChatSessionRepository.save(AiChatSession.create(userBookId));
-        summaryRepository.save(Summary.createCompleted(userBookId, session.getId(), "제목", body));
+        session.updateTitle(sessionTitle);
+        aiChatSessionRepository.save(session);
+        summaryRepository.save(Summary.createCompleted(userBookId, session.getId(), "제목", "본문"));
     }
 }

--- a/src/test/java/com/readum/presentation/controller/summary/SummaryControllerTest.java
+++ b/src/test/java/com/readum/presentation/controller/summary/SummaryControllerTest.java
@@ -64,8 +64,8 @@ class SummaryControllerTest {
         given(summaryHistorySearchService.findMyHistory(any()))
                 .willReturn(new SummaryHistoryListResult(
                         List.of(
-                                new SummaryHistoryItemResult("데미안", "깊은 울림을 주는 책이었다.", createdAt),
-                                new SummaryHistoryItemResult("1984", "감시 사회의 공포.", createdAt.minusDays(1))
+                                new SummaryHistoryItemResult(101L, "데미안", "데미안을 읽고 나서", createdAt),
+                                new SummaryHistoryItemResult(102L, "1984", "감시 사회를 읽다", createdAt.minusDays(1))
                         ),
                         1,
                         20,
@@ -77,9 +77,12 @@ class SummaryControllerTest {
                         .param("page", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.summaries.length()").value(2))
+                .andExpect(jsonPath("$.data.summaries[0].summaryId").value(101))
                 .andExpect(jsonPath("$.data.summaries[0].bookTitle").value("데미안"))
-                .andExpect(jsonPath("$.data.summaries[0].content").value("깊은 울림을 주는 책이었다."))
+                .andExpect(jsonPath("$.data.summaries[0].sessionTitle").value("데미안을 읽고 나서"))
+                .andExpect(jsonPath("$.data.summaries[1].summaryId").value(102))
                 .andExpect(jsonPath("$.data.summaries[1].bookTitle").value("1984"))
+                .andExpect(jsonPath("$.data.summaries[1].sessionTitle").value("감시 사회를 읽다"))
                 .andExpect(jsonPath("$.data.page").value(1))
                 .andExpect(jsonPath("$.data.size").value(20))
                 .andExpect(jsonPath("$.data.hasNext").value(false));


### PR DESCRIPTION
## 작업 사항

마이페이지 감상기록 목록(`GET /api/v1/summaries`) 응답이 상세 화면 이동에 필요한 감상문 id 와 목록 카드에 표시할 세션 제목을 내려주지 않았다. 정작 클라이언트가 쓰지 않는 본문 미리보기(content)만 담고 있어, 프런트가 항목을 식별하거나 제목을 보여줄 수 없었다.

누락 지점은 응답 DTO 가 아니라 조회 쿼리 단계였다. 엔티티에는 값이 다 있는데(`Summary.id`, `Summary.aiChatSessionId`, `AiChatSession.title`) projection 이 `bookTitle`/`body`/`createdAt` 만 투영해 Result·Response 까지 그대로 비어 내려갔다.

이 조회 쿼리는 책 제목을 가져오려고 이미 `AiChatSession`·`UserBook`·`Book` 을 join 하고 있다. 그래서 같은 projection 에 `summary.id` 와 `aiChatSession.title` 을 추가로 투영하는 것만으로 해결된다 — 별도 repository 호출이나 구조 변경은 필요 없다. 더 이상 쓰지 않는 본문 미리보기(content) 투영과 100자 줄임 로직은 함께 제거했다.

`summaryId` 는 감상문 행의 PK 라 이 목록에서는 항상 존재한다. `sessionTitle` 은 첫 대화 교환 뒤 비동기로 생성되는 값이라, 그 제목 생성이 실패한 드문 경우에만 null 일 수 있다. 세션으로의 진입이 필요하면 감상문 상세(`GET /api/v1/summaries/{summaryId}`)가 `aiChatSessionId` 를 내려주므로, 목록에는 세션 id 를 포함하지 않았다.

### 기능

**마이페이지 감상기록 목록**
- 각 항목에서 감상문 id(`summaryId`)를 받아 상세 화면으로 이동할 수 있다.
- 각 항목에서 세션 제목(`sessionTitle`)을 받아 목록 카드에 표시할 수 있다.
- 쓰지 않던 본문 미리보기(`content`)는 응답에서 빠졌다.

### API 스펙

| 항목 | 값 |
|---|---|
| Method | `GET` |
| Path | `/api/v1/summaries` |
| 인증 | `user_session` 쿠키 필수 |
| page | int, 선택(기본 1), 1 이상 |
| 응답 항목 필드 | `summaryId`, `bookTitle`, `sessionTitle`, `createdAt` |

### 시나리오별 응답

**정상** — `GET /api/v1/summaries?page=1`
```json
HTTP 200
{
  "data": {
    "summaries": [
      {
        "summaryId": 101,
        "bookTitle": "데미안",
        "sessionTitle": "데미안을 읽고 나서",
        "createdAt": "2026-05-07T09:00:00"
      }
    ],
    "page": 1,
    "size": 20,
    "hasNext": false
  }
}
```

**기록 없음** — `GET /api/v1/summaries?page=1`
```json
HTTP 200
{
  "data": { "summaries": [], "page": 1, "size": 20, "hasNext": false }
}
```

**page 검증 실패** — `GET /api/v1/summaries?page=0`
```json
HTTP 400
{ "error": { "message": "page는 1 이상이어야 합니다." } }
```

## 테스트 결과
- [x] `./gradlew test` 전체 통과
- [x] repository 통합 테스트: projection 이 감상문 id·세션 제목을 함께 조회함 확인
- [x] controller 테스트: 응답 JSON 에 `summaryId`·`sessionTitle` 포함, `content` 제거 확인

## 관련 이슈
- closes #89

## 참고 사항
- 세션 제목(`AiChatSession.title`)은 채팅 첫 교환 후 별도 LLM 호출로 비동기 생성된다. 정상 흐름에선 감상문이 있으면 제목도 붙어 있고, `sessionTitle` 이 null 인 경우는 그 제목 생성이 실패한 가장자리 상황뿐이다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 감상문 히스토리 목록 조회 응답에 감상문 식별자와 세션 제목을 추가하여 더욱 명확한 정보 제공

* **Bug Fixes**
  * 감상문 내용 미리보기 로직을 제거하고 세션 제목 정보로 대체하여 응답 데이터 일관성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->