### PR TITLE
fix(aiChat): 책별 세션 목록 응답에 세션 제목(sessionTitle) 추가

### DIFF
--- a/src/main/java/com/readum/domain/aiChat/dto/BookChatSessionsResult.java
+++ b/src/main/java/com/readum/domain/aiChat/dto/BookChatSessionsResult.java
@@ -19,5 +19,6 @@ public record BookChatSessionsResult(
         }
     }
 
-    public record SessionItem(Long sessionId, String latestSummaryContent, LocalDate lastChattedDate) {}
+    public record SessionItem(Long sessionId, String summaryTitle, String latestSummaryContent,
+                              LocalDate lastChattedDate) {}
 }

--- a/src/main/java/com/readum/domain/aiChat/dto/BookChatSessionsResult.java
+++ b/src/main/java/com/readum/domain/aiChat/dto/BookChatSessionsResult.java
@@ -19,6 +19,6 @@ public record BookChatSessionsResult(
         }
     }
 
-    public record SessionItem(Long sessionId, String summaryTitle, String latestSummaryContent,
+    public record SessionItem(Long sessionId, String sessionTitle, String latestSummaryContent,
                               LocalDate lastChattedDate) {}
 }

--- a/src/main/java/com/readum/domain/aiChat/service/BookChatSessionSearchService.java
+++ b/src/main/java/com/readum/domain/aiChat/service/BookChatSessionSearchService.java
@@ -53,30 +53,27 @@ public class BookChatSessionSearchService {
         List<AiChatSession> sessions = aiChatSessionRepository.findByUserBookId(userBookId);
         List<Long> sessionIds = sessions.stream().map(AiChatSession::getId).toList();
 
-        Map<Long, Summary> latestSummaryBySession = latestSummaries(sessionIds);
+        Map<Long, String> latestSummaryBodyBySession = latestSummaryBodies(sessionIds);
         Map<Long, LocalDate> lastChattedBySession = lastChattedDates(sessionIds);
 
         List<BookChatSessionsResult.SessionItem> items = sessions.stream()
-                .map(session -> {
-                    Summary summary = latestSummaryBySession.get(session.getId());
-                    return new BookChatSessionsResult.SessionItem(
-                            session.getId(),
-                            summary != null ? summary.getTitle() : null,
-                            summary != null ? summary.getBody() : null,
-                            lastChattedBySession.getOrDefault(session.getId(), session.getCreatedAt().toLocalDate()));
-                })
+                .map(session -> new BookChatSessionsResult.SessionItem(
+                        session.getId(),
+                        session.getTitle(),
+                        latestSummaryBodyBySession.get(session.getId()),
+                        lastChattedBySession.getOrDefault(session.getId(), session.getCreatedAt().toLocalDate())))
                 .sorted(Comparator.comparing(BookChatSessionsResult.SessionItem::lastChattedDate).reversed())
                 .toList();
 
         return new BookChatSessionsResult(BookChatSessionsResult.BookInfo.from(book), items);
     }
 
-    private Map<Long, Summary> latestSummaries(List<Long> sessionIds) {
+    private Map<Long, String> latestSummaryBodies(List<Long> sessionIds) {
         if (sessionIds.isEmpty()) {
             return Map.of();
         }
         return summaryRepository.findLatestByAiChatSessionIdIn(sessionIds).stream()
-                .collect(Collectors.toMap(Summary::getAiChatSessionId, summary -> summary));
+                .collect(Collectors.toMap(Summary::getAiChatSessionId, Summary::getBody));
     }
 
     private Map<Long, LocalDate> lastChattedDates(List<Long> sessionIds) {

--- a/src/main/java/com/readum/domain/aiChat/service/BookChatSessionSearchService.java
+++ b/src/main/java/com/readum/domain/aiChat/service/BookChatSessionSearchService.java
@@ -53,26 +53,30 @@ public class BookChatSessionSearchService {
         List<AiChatSession> sessions = aiChatSessionRepository.findByUserBookId(userBookId);
         List<Long> sessionIds = sessions.stream().map(AiChatSession::getId).toList();
 
-        Map<Long, String> latestSummaryBySession = latestSummaryBodies(sessionIds);
+        Map<Long, Summary> latestSummaryBySession = latestSummaries(sessionIds);
         Map<Long, LocalDate> lastChattedBySession = lastChattedDates(sessionIds);
 
         List<BookChatSessionsResult.SessionItem> items = sessions.stream()
-                .map(session -> new BookChatSessionsResult.SessionItem(
-                        session.getId(),
-                        latestSummaryBySession.get(session.getId()),
-                        lastChattedBySession.getOrDefault(session.getId(), session.getCreatedAt().toLocalDate())))
+                .map(session -> {
+                    Summary summary = latestSummaryBySession.get(session.getId());
+                    return new BookChatSessionsResult.SessionItem(
+                            session.getId(),
+                            summary != null ? summary.getTitle() : null,
+                            summary != null ? summary.getBody() : null,
+                            lastChattedBySession.getOrDefault(session.getId(), session.getCreatedAt().toLocalDate()));
+                })
                 .sorted(Comparator.comparing(BookChatSessionsResult.SessionItem::lastChattedDate).reversed())
                 .toList();
 
         return new BookChatSessionsResult(BookChatSessionsResult.BookInfo.from(book), items);
     }
 
-    private Map<Long, String> latestSummaryBodies(List<Long> sessionIds) {
+    private Map<Long, Summary> latestSummaries(List<Long> sessionIds) {
         if (sessionIds.isEmpty()) {
             return Map.of();
         }
         return summaryRepository.findLatestByAiChatSessionIdIn(sessionIds).stream()
-                .collect(Collectors.toMap(Summary::getAiChatSessionId, Summary::getBody));
+                .collect(Collectors.toMap(Summary::getAiChatSessionId, summary -> summary));
     }
 
     private Map<Long, LocalDate> lastChattedDates(List<Long> sessionIds) {

--- a/src/main/java/com/readum/presentation/controller/aiChat/dto/BookChatSessionsResponse.java
+++ b/src/main/java/com/readum/presentation/controller/aiChat/dto/BookChatSessionsResponse.java
@@ -11,7 +11,8 @@ public record BookChatSessionsResponse(
 ) {
     public record BookResponse(String title, Integer publishedYear, String publisher, String coverImageUrl) {}
 
-    public record SessionResponse(Long sessionId, String latestSummaryContent, LocalDate lastChattedDate) {}
+    public record SessionResponse(Long sessionId, String summaryTitle, String latestSummaryContent,
+                                  LocalDate lastChattedDate) {}
 
     public static BookChatSessionsResponse from(BookChatSessionsResult result) {
         BookChatSessionsResult.BookInfo book = result.book();
@@ -20,6 +21,7 @@ public record BookChatSessionsResponse(
                 result.sessions().stream()
                         .map(session -> new SessionResponse(
                                 session.sessionId(),
+                                session.summaryTitle(),
                                 session.latestSummaryContent(),
                                 session.lastChattedDate()))
                         .toList());

--- a/src/main/java/com/readum/presentation/controller/aiChat/dto/BookChatSessionsResponse.java
+++ b/src/main/java/com/readum/presentation/controller/aiChat/dto/BookChatSessionsResponse.java
@@ -11,7 +11,7 @@ public record BookChatSessionsResponse(
 ) {
     public record BookResponse(String title, Integer publishedYear, String publisher, String coverImageUrl) {}
 
-    public record SessionResponse(Long sessionId, String summaryTitle, String latestSummaryContent,
+    public record SessionResponse(Long sessionId, String sessionTitle, String latestSummaryContent,
                                   LocalDate lastChattedDate) {}
 
     public static BookChatSessionsResponse from(BookChatSessionsResult result) {
@@ -21,7 +21,7 @@ public record BookChatSessionsResponse(
                 result.sessions().stream()
                         .map(session -> new SessionResponse(
                                 session.sessionId(),
-                                session.summaryTitle(),
+                                session.sessionTitle(),
                                 session.latestSummaryContent(),
                                 session.lastChattedDate()))
                         .toList());

--- a/src/test/java/com/readum/domain/aiChat/service/BookChatSessionSearchServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/BookChatSessionSearchServiceTest.java
@@ -64,12 +64,16 @@ class BookChatSessionSearchServiceTest {
         LocalDateTime now = LocalDateTime.now();
 
         // 오래 전 대화한 세션 — 감상문 1건(1:1 모델)
-        AiChatSession older = aiChatSessionRepository.save(AiChatSession.create(userBook.getId()));
+        AiChatSession older = AiChatSession.create(userBook.getId());
+        older.updateTitle("오래된 세션 제목");
+        older = aiChatSessionRepository.save(older);
         aiChatMessageRepository.save(AiChatMessageFixture.userMessageAt(older.getId(), "옛 대화", now.minusDays(2)));
         summaryRepository.save(Summary.createCompleted(userBook.getId(), older.getId(), "새 제목", "최신 본문"));
 
-        // 최근 대화한 세션 — 감상문 없음(null)
-        AiChatSession newer = aiChatSessionRepository.save(AiChatSession.create(userBook.getId()));
+        // 최근 대화한 세션 — 감상문 없음
+        AiChatSession newer = AiChatSession.create(userBook.getId());
+        newer.updateTitle("최근 세션 제목");
+        newer = aiChatSessionRepository.save(newer);
         aiChatMessageRepository.save(AiChatMessageFixture.userMessageAt(newer.getId(), "최근 대화", now.minusHours(1)));
 
         BookChatSessionsResult result = bookChatSessionSearchService.findByUserBook(
@@ -83,10 +87,10 @@ class BookChatSessionSearchServiceTest {
         // 마지막 대화일 최신순 — newer 가 먼저
         assertThat(result.sessions()).extracting(BookChatSessionsResult.SessionItem::sessionId)
                 .containsExactly(newer.getId(), older.getId());
-        assertThat(result.sessions().get(0).summaryTitle()).isNull();
+        assertThat(result.sessions().get(0).sessionTitle()).isEqualTo("최근 세션 제목");
         assertThat(result.sessions().get(0).latestSummaryContent()).isNull();
         assertThat(result.sessions().get(0).lastChattedDate()).isEqualTo(now.minusHours(1).toLocalDate());
-        assertThat(result.sessions().get(1).summaryTitle()).isEqualTo("새 제목");
+        assertThat(result.sessions().get(1).sessionTitle()).isEqualTo("오래된 세션 제목");
         assertThat(result.sessions().get(1).latestSummaryContent()).isEqualTo("최신 본문");
         assertThat(result.sessions().get(1).lastChattedDate()).isEqualTo(now.minusDays(2).toLocalDate());
     }

--- a/src/test/java/com/readum/domain/aiChat/service/BookChatSessionSearchServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/BookChatSessionSearchServiceTest.java
@@ -83,8 +83,10 @@ class BookChatSessionSearchServiceTest {
         // 마지막 대화일 최신순 — newer 가 먼저
         assertThat(result.sessions()).extracting(BookChatSessionsResult.SessionItem::sessionId)
                 .containsExactly(newer.getId(), older.getId());
+        assertThat(result.sessions().get(0).summaryTitle()).isNull();
         assertThat(result.sessions().get(0).latestSummaryContent()).isNull();
         assertThat(result.sessions().get(0).lastChattedDate()).isEqualTo(now.minusHours(1).toLocalDate());
+        assertThat(result.sessions().get(1).summaryTitle()).isEqualTo("새 제목");
         assertThat(result.sessions().get(1).latestSummaryContent()).isEqualTo("최신 본문");
         assertThat(result.sessions().get(1).lastChattedDate()).isEqualTo(now.minusDays(2).toLocalDate());
     }

--- a/src/test/java/com/readum/presentation/controller/aiChat/AiChatControllerTest.java
+++ b/src/test/java/com/readum/presentation/controller/aiChat/AiChatControllerTest.java
@@ -235,8 +235,8 @@ class AiChatControllerTest {
                 .willReturn(new BookChatSessionsResult(
                         new BookChatSessionsResult.BookInfo("데미안", 2020, "민음사", "http://img/x.jpg"),
                         List.of(
-                                new BookChatSessionsResult.SessionItem(2L, "감상문 제목", "최신 본문", LocalDate.of(2026, 5, 7)),
-                                new BookChatSessionsResult.SessionItem(1L, null, null, LocalDate.of(2026, 5, 5))
+                                new BookChatSessionsResult.SessionItem(2L, "세션 제목 A", "최신 본문", LocalDate.of(2026, 5, 7)),
+                                new BookChatSessionsResult.SessionItem(1L, "세션 제목 B", null, LocalDate.of(2026, 5, 5))
                         )
                 ));
 
@@ -249,11 +249,11 @@ class AiChatControllerTest {
                 .andExpect(jsonPath("$.data.book.coverImageUrl").value("http://img/x.jpg"))
                 .andExpect(jsonPath("$.data.sessions.length()").value(2))
                 .andExpect(jsonPath("$.data.sessions[0].sessionId").value(2))
-                .andExpect(jsonPath("$.data.sessions[0].summaryTitle").value("감상문 제목"))
+                .andExpect(jsonPath("$.data.sessions[0].sessionTitle").value("세션 제목 A"))
                 .andExpect(jsonPath("$.data.sessions[0].latestSummaryContent").value("최신 본문"))
                 .andExpect(jsonPath("$.data.sessions[0].lastChattedDate").value("2026-05-07"))
                 .andExpect(jsonPath("$.data.sessions[1].sessionId").value(1))
-                .andExpect(jsonPath("$.data.sessions[1].summaryTitle").doesNotExist())
+                .andExpect(jsonPath("$.data.sessions[1].sessionTitle").value("세션 제목 B"))
                 .andExpect(jsonPath("$.data.sessions[1].lastChattedDate").value("2026-05-05"));
     }
 

--- a/src/test/java/com/readum/presentation/controller/aiChat/AiChatControllerTest.java
+++ b/src/test/java/com/readum/presentation/controller/aiChat/AiChatControllerTest.java
@@ -235,8 +235,8 @@ class AiChatControllerTest {
                 .willReturn(new BookChatSessionsResult(
                         new BookChatSessionsResult.BookInfo("데미안", 2020, "민음사", "http://img/x.jpg"),
                         List.of(
-                                new BookChatSessionsResult.SessionItem(2L, "최신 본문", LocalDate.of(2026, 5, 7)),
-                                new BookChatSessionsResult.SessionItem(1L, null, LocalDate.of(2026, 5, 5))
+                                new BookChatSessionsResult.SessionItem(2L, "감상문 제목", "최신 본문", LocalDate.of(2026, 5, 7)),
+                                new BookChatSessionsResult.SessionItem(1L, null, null, LocalDate.of(2026, 5, 5))
                         )
                 ));
 
@@ -249,9 +249,11 @@ class AiChatControllerTest {
                 .andExpect(jsonPath("$.data.book.coverImageUrl").value("http://img/x.jpg"))
                 .andExpect(jsonPath("$.data.sessions.length()").value(2))
                 .andExpect(jsonPath("$.data.sessions[0].sessionId").value(2))
+                .andExpect(jsonPath("$.data.sessions[0].summaryTitle").value("감상문 제목"))
                 .andExpect(jsonPath("$.data.sessions[0].latestSummaryContent").value("최신 본문"))
                 .andExpect(jsonPath("$.data.sessions[0].lastChattedDate").value("2026-05-07"))
                 .andExpect(jsonPath("$.data.sessions[1].sessionId").value(1))
+                .andExpect(jsonPath("$.data.sessions[1].summaryTitle").doesNotExist())
                 .andExpect(jsonPath("$.data.sessions[1].lastChattedDate").value("2026-05-05"));
     }
 


### PR DESCRIPTION
## 작업 사항

책별 대화 세션 목록 조회(`GET /api/v1/ai-chat/books/{userBookId}/sessions`) 응답에 세션 제목이 빠져 있었다. 클라이언트가 세션 카드에 제목을 표시하려면 이 필드가 필요한데, 기존 응답에는 `sessionId`, `latestSummaryContent`, `lastChattedDate`만 담겨 있었다.

`AiChatSession` 엔티티에는 이미 `title` 필드가 존재한다(첫 대화 교환 후 비동기로 생성). 서비스에서 세션을 조회하면서 `title`을 꺼내 DTO에 매핑하는 것만으로 해결되어, 추가 쿼리나 구조 변경 없이 반영했다.

### 기능

**책별 세션 목록**
- 각 세션 항목에서 세션 제목(`sessionTitle`)을 받아 카드에 표시할 수 있다.

### API 스펙

| 항목 | 값 |
|---|---|
| Method | `GET` |
| Path | `/api/v1/ai-chat/books/{userBookId}/sessions` |
| 인증 | `user_session` 쿠키 필수 |
| 응답 항목 필드 | `sessionId`, `sessionTitle`(추가), `latestSummaryContent`, `lastChattedDate` |

### 시나리오별 응답

**정상**
```json
HTTP 200
{
  "data": {
    "book": {
      "title": "데미안",
      "publishedYear": 2020,
      "publisher": "민음사",
      "coverImageUrl": "http://img/x.jpg"
    },
    "sessions": [
      {
        "sessionId": 2,
        "sessionTitle": "데미안을 읽고 든 생각",
        "latestSummaryContent": "최신 본문...",
        "lastChattedDate": "2026-05-07"
      },
      {
        "sessionId": 1,
        "sessionTitle": "첫 번째 대화",
        "latestSummaryContent": null,
        "lastChattedDate": "2026-05-05"
      }
    ]
  }
}
```

## 테스트 결과
- [x] `./gradlew test` 통과
- [x] 서비스 통합 테스트: 세션 제목이 응답에 포함됨 확인
- [x] 컨트롤러 테스트: 응답 JSON에 `sessionTitle` 포함 확인

## 관련 이슈
- (없음)

## 참고 사항
- `AiChatSession.title`은 첫 대화 교환 후 비동기로 생성되는 값이다. 세션 생성 직후 대화 전에는 `null`일 수 있다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 책 채팅 세션 목록 조회 응답에 세션 제목 정보가 추가되었습니다.

* **Tests**
  * 세션 제목 필드를 포함한 테스트 케이스 검증 범위가 확대되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->