### PR TITLE
fix(summary): claim·reaper 트랜잭션을 READ COMMITTED 로 전환해 gap lock 제거

### DIFF
--- a/src/main/java/com/readum/domain/summary/service/SummaryJobLifecycleService.java
+++ b/src/main/java/com/readum/domain/summary/service/SummaryJobLifecycleService.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -39,8 +40,12 @@ public class SummaryJobLifecycleService {
     /**
      * 처리 대상 작업을 하나 선점한다. SKIP LOCKED 로 다른 워커와 겹치지 않는다.
      * owner 는 이 선점만의 토큰. 반환된 작업 id 를 워커가 이후 단계에 넘긴다. 없으면 null.
+     *
+     * <p>READ COMMITTED 인 이유: findClaimable 의 PENDING 구간 범위 스캔이 RR 에서 gap lock 을 걸어
+     * 같은 구간으로 들어오는 신규 PENDING INSERT 와 충돌해 락 대기 타임아웃을 냈다(#92).
+     * RC 로 gap lock 을 없애도 SKIP LOCKED 행 락 분배는 그대로라 워커 간 중복 선점은 막힌다.
      */
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public Long claimOne(String owner) {
         List<SummaryJob> candidates = summaryJobRepository.findClaimable(
                 SummaryJob.Status.PENDING, LocalDateTime.now(), PageRequest.of(0, 1));
@@ -94,9 +99,12 @@ public class SummaryJobLifecycleService {
     /**
      * lease 만료된 고아 작업을 PENDING 으로 되돌린다(즉시 재선점 가능). 세션은 건드리지 않는다 —
      * 차단은 PROCESSING 의 유효 lease 가 사라지면 자동 해제되기 때문.
+     *
+     * <p>READ COMMITTED 인 이유: findOrphaned 의 PROCESSING 구간 범위 스캔도 claimOne 과 같은 gap lock
+     * 문제를 일으키므로 RC 로 gap lock 을 없앤다(#92). SKIP LOCKED 행 락 분배는 그대로 유지된다.
      * @return 회수한 작업 수
      */
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public int reclaimOrphans(int batchSize) {
         LocalDateTime now = LocalDateTime.now();
         List<SummaryJob> orphans = summaryJobRepository.findOrphaned(

--- a/src/test/java/com/readum/domain/summary/service/SummaryJobLifecycleServiceIsolationTest.java
+++ b/src/test/java/com/readum/domain/summary/service/SummaryJobLifecycleServiceIsolationTest.java
@@ -1,0 +1,60 @@
+package com.readum.domain.summary.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * claim/reaper 트랜잭션의 격리수준 계약 테스트 (이슈 #92).
+ *
+ * <p>워커 폴링 쿼리(findClaimable/findOrphaned)는 PENDING/PROCESSING 구간을 범위 스캔하므로
+ * MySQL 기본 격리수준 REPEATABLE READ 에서 gap lock 을 건다. 이 gap lock 이 같은 구간으로 들어오는
+ * 신규 PENDING INSERT 와 충돌해 락 대기 타임아웃을 냈다(#92). 처방은 이 두 트랜잭션만 READ COMMITTED 로
+ * 내려 gap lock 을 없애는 것 — 어노테이션이 유실되면 사고가 재발하므로 그 부착을 못 박는다.
+ *
+ * <p>실제 격리수준 적용은 Spring + Hibernate 가 보장하는 동작이고, 테스트 하네스(H2)의 기본 격리수준이
+ * 이미 READ COMMITTED 라 라이브로 RR↔RC 차이를 재현할 수 없다(H2 에선 어노테이션 유무가 구분되지 않음).
+ * 따라서 회귀 가드는 "두 메서드에 isolation = READ_COMMITTED 가 붙어 있고 나머지엔 없음" 을 단언한다.
+ * 실효(gap lock 제거)는 dev RDS MySQL 2세션 재현으로 별도 확인한다.
+ */
+class SummaryJobLifecycleServiceIsolationTest {
+
+    @Test
+    void claimOne_은_READ_COMMITTED_격리수준으로_선언된다() {
+        assertThat(isolationOf("claimOne", String.class)).isEqualTo(Isolation.READ_COMMITTED);
+    }
+
+    @Test
+    void reclaimOrphans_는_READ_COMMITTED_격리수준으로_선언된다() {
+        assertThat(isolationOf("reclaimOrphans", int.class)).isEqualTo(Isolation.READ_COMMITTED);
+    }
+
+    @Test
+    void 격리수준을_지정하지_않은_트랜잭션은_DB_기본값을_유지한다() {
+        assertThat(isolationOf("prepareGeneration", Long.class, String.class))
+                .isEqualTo(Isolation.DEFAULT);
+    }
+
+    private Isolation isolationOf(String methodName, Class<?>... parameterTypes) {
+        Method method = findMethod(methodName, parameterTypes);
+        Transactional transactional =
+                AnnotatedElementUtils.findMergedAnnotation(method, Transactional.class);
+        assertThat(transactional)
+                .as("%s 에 @Transactional 이 선언되어 있어야 한다", methodName)
+                .isNotNull();
+        return transactional.isolation();
+    }
+
+    private Method findMethod(String methodName, Class<?>... parameterTypes) {
+        try {
+            return SummaryJobLifecycleService.class.getMethod(methodName, parameterTypes);
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError("메서드를 찾을 수 없다: " + methodName, e);
+        }
+    }
+}


### PR DESCRIPTION
## 작업 사항

새벽 6시 감상문 작업 적재(`insert into summary_job`)가 `Lock wait timeout exceeded`(1205)로 연속 실패한 사고(#92)를 처리한다.

원인은 격리수준과 잠금 방식의 충돌이다. MySQL 기본 격리수준 REPEATABLE READ 에서, 워커 폴링 쿼리 `SummaryJobRepository.findClaimable`(`... FOR UPDATE SKIP LOCKED`)의 PENDING 구간 범위 스캔이 gap lock 을 건다. SKIP LOCKED 는 이미 잠긴 레코드만 건너뛸 뿐 gap lock 은 없애지 못하므로, 같은 구간으로 들어오는 신규 PENDING INSERT 의 insert intention lock 이 이 gap lock 과 충돌해 `innodb_lock_wait_timeout`(50초)까지 대기하다 실패한다.

처방은 gap lock 을 거는 두 워커 트랜잭션만 READ COMMITTED 로 내리는 것이다. RC 에서는 gap lock 이 사라지므로 INSERT 가 더 이상 막히지 않는다. SKIP LOCKED 의 행 단위 잠금·분배는 RC 에서도 동일하게 동작하므로 워커 간 중복 선점 방지는 그대로 유지된다. 대상은 `claimOne`(findClaimable)·`reclaimOrphans`(findOrphaned) 둘뿐이고, 단건 행 락(`findByIdForUpdate`)·INSERT 경로·다른 트랜잭션의 읽기 일관성은 건드리지 않는다.

전역 격리수준을 바꾸지 않고 두 메서드에만 `@Transactional(isolation = READ_COMMITTED)` 를 적용해 영향 범위를 최소화했다. Spring 이 트랜잭션 종료 시 커넥션 격리수준을 원복하므로 커넥션 풀에 설정이 남지 않는다.

### 기능

**감상문 작업 큐 동시성**
- 워커가 작업을 선점(claim)·회수(reaper)하는 중에도 신규 작업 적재 INSERT 가 gap lock 에 막히지 않는다.
- SKIP LOCKED 기반 워커 간 중복 선점 방지는 그대로 유지된다.

## 테스트 결과
- [x] `./gradlew test` 통과
- [x] 회귀 가드 단위 테스트 추가 — `claimOne`/`reclaimOrphans` 에 `isolation=READ_COMMITTED` 부착, 나머지는 DEFAULT 유지를 단언(어노테이션 유실 시 실패)
- [x] dev RDS MySQL 2세션 재현으로 사전 확인 — RR 에선 INSERT 가 50초 후 실패, RC 에선 즉시 성공

## 관련 이슈
- #92 (RR→RC 전환 부분만 처리 — 이슈 완전 종료 아님, 서브태스크 잔존)

## 참고 사항

- 테스트 하네스는 H2 인메모리(MODE=MySQL)라 MySQL 전용 격리수준·gap lock 동작을 라이브로 재현할 수 없다. 그래서 자동 테스트는 어노테이션 부착을 단언하는 회귀 가드로 두고, 실효 검증은 위의 dev RDS 2세션 재현으로 갈음했다.
- 사고 당시 5분간 락을 처음 오래 점유한 주체는 관측 데이터 부재로 확정하지 못했다(perf_schema·slow_query_log 가 꺼져 있던 시점). 재발 시 추적을 위해 dev RDS 관측 설정은 이후 켜 두었다. 이 부분은 코드 변경이 아니라 후속 관찰 대상이다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 트랜잭션 격리 수준을 조정하여 동시성으로 인한 타임아웃 문제를 해결했습니다.

* **Tests**
  * 트랜잭션 격리 수준 설정을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->