### PR TITLE
fix(summary): 적재 INSERT 락 획득 실패에 짧은 backoff 재시도 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.retry:spring-retry:2.0.12'
 	implementation 'org.springframework.ai:spring-ai-starter-model-openai'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
 	implementation 'com.github.ben-manes.caffeine:caffeine'

--- a/src/main/java/com/readum/ReadumApplication.java
+++ b/src/main/java/com/readum/ReadumApplication.java
@@ -3,10 +3,12 @@ package com.readum;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableAsync
+@EnableRetry
 @EnableScheduling
 @SpringBootApplication
 @ConfigurationPropertiesScan

--- a/src/main/java/com/readum/domain/summary/service/EnqueueSummaryJobService.java
+++ b/src/main/java/com/readum/domain/summary/service/EnqueueSummaryJobService.java
@@ -2,9 +2,13 @@ package com.readum.domain.summary.service;
 
 import com.readum.domain.summary.dto.EnqueueSummaryJobResult;
 import com.readum.model.summary.repository.SummaryJobRepository;
+import jakarta.persistence.LockTimeoutException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 /**
@@ -23,6 +27,22 @@ public class EnqueueSummaryJobService {
     private final SummaryJobRepository summaryJobRepository;
     private final SummaryJobInserter summaryJobInserter;
 
+    /**
+     * 워커 폴링과 적재 INSERT 가 순간 경합하면 INSERT 가 락 대기 끝에 실패(MySQL 1205 →
+     * {@link CannotAcquireLockException})할 수 있다(#92). 이 순간 경합만 짧은 backoff 재시도로 구제한다.
+     * 매 재시도는 멱등 precheck 를 다시 거치고 {@code insertPending} 의 새 REQUIRES_NEW 트랜잭션으로 들어간다.
+     * unique 위반({@link DataIntegrityViolationException})은 catch 에서 멱등 처리되어 전파되지 않으므로
+     * 재시도 대상에서 빠진다.
+     *
+     * <p>전제: 재시도가 의미 있으려면 INSERT 가 빨리 실패해야 한다 — RDS {@code innodb_lock_wait_timeout}
+     * 을 짧게(보수적으로 약 10초) 둔 환경과 함께 적용한다. 이 재시도는 짧은 순간 겹치는 경합만 구제한다.
+     * 어떤 트랜잭션이 몇 분씩 락을 쥐고 있으면 재시도해도 매번 실패하므로(빨리 실패할 뿐이다),
+     * 락을 오래 점유하는 상황까지 해결해 주지는 않는다.
+     */
+    @Retryable(
+            retryFor = { CannotAcquireLockException.class, LockTimeoutException.class },
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 200, multiplier = 2.0, maxDelay = 1000))
     public EnqueueSummaryJobResult execute(Long sessionId) {
         if (summaryJobRepository.existsByActiveSessionId(sessionId)) {
             return new EnqueueSummaryJobResult(false);

--- a/src/test/java/com/readum/domain/summary/service/EnqueueSummaryJobServiceRetryTest.java
+++ b/src/test/java/com/readum/domain/summary/service/EnqueueSummaryJobServiceRetryTest.java
@@ -1,0 +1,73 @@
+package com.readum.domain.summary.service;
+
+import com.readum.domain.summary.dto.EnqueueSummaryJobResult;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * summary_job 적재 INSERT 의 락 획득 실패 재시도 계약 테스트 (이슈 #92).
+ *
+ * <p>워커 폴링과 적재 INSERT 가 순간 경합하면 INSERT 가 락 대기 끝에 실패(MySQL 1205 → Spring
+ * {@link CannotAcquireLockException})할 수 있다. 이 순간 경합을 짧은 backoff 재시도로 구제한다.
+ * unique 위반({@link DataIntegrityViolationException})은 같은 세션 동시 적재의 멱등 경로이므로
+ * 재시도하지 않는다.
+ *
+ * <p>{@code @Retryable} 은 AOP 프록시로만 동작하므로 컨텍스트를 띄워 검증한다.
+ * INSERT 본체({@link SummaryJobInserter})만 mock 으로 대체해 실패/성공을 주입한다.
+ */
+@SpringBootTest
+class EnqueueSummaryJobServiceRetryTest {
+
+    @Autowired
+    private EnqueueSummaryJobService enqueueSummaryJobService;
+
+    @MockitoBean
+    private SummaryJobInserter summaryJobInserter;
+
+    @Test
+    void 락_획득_실패는_짧은_backoff_로_재시도해_성공한다() {
+        long sessionId = System.nanoTime();
+        doThrow(new CannotAcquireLockException("lock wait timeout"))
+                .doThrow(new CannotAcquireLockException("lock wait timeout"))
+                .doNothing()
+                .when(summaryJobInserter).insertPending(sessionId);
+
+        EnqueueSummaryJobResult result = enqueueSummaryJobService.execute(sessionId);
+
+        assertThat(result.enqueued()).isTrue();
+        verify(summaryJobInserter, times(3)).insertPending(sessionId);
+    }
+
+    @Test
+    void 락_획득_실패가_최대_시도를_넘으면_예외를_전파한다() {
+        long sessionId = System.nanoTime();
+        doThrow(new CannotAcquireLockException("lock wait timeout"))
+                .when(summaryJobInserter).insertPending(sessionId);
+
+        assertThatThrownBy(() -> enqueueSummaryJobService.execute(sessionId))
+                .isInstanceOf(CannotAcquireLockException.class);
+        verify(summaryJobInserter, times(3)).insertPending(sessionId);
+    }
+
+    @Test
+    void unique_위반은_재시도하지_않는다() {
+        long sessionId = System.nanoTime();
+        doThrow(new DataIntegrityViolationException("duplicate active_session_id"))
+                .when(summaryJobInserter).insertPending(sessionId);
+
+        assertThatThrownBy(() -> enqueueSummaryJobService.execute(sessionId))
+                .isInstanceOf(DataIntegrityViolationException.class);
+        verify(summaryJobInserter, times(1)).insertPending(sessionId);
+    }
+}


### PR DESCRIPTION
## 작업 사항

워커 폴링과 summary_job 적재 INSERT 가 순간 경합하면 INSERT 가 락 대기 끝에 실패(MySQL 1205 → `CannotAcquireLockException`)할 수 있다(#92). 이 순간 경합을 짧은 backoff 재시도로 구제한다.

재시도는 `EnqueueSummaryJobService.execute` 에 `@Retryable` 로 둔다. execute 는 트랜잭션을 직접 갖지 않는 오케스트레이터라(실제 INSERT 는 `SummaryJobInserter.insertPending` 의 REQUIRES_NEW 트랜잭션), 매 재시도가 멱등 precheck(`existsByActiveSessionId`)를 다시 거치고 새 트랜잭션으로 다시 들어간다. 재시도 대상은 락 획득 실패(`CannotAcquireLockException`/`LockTimeoutException`)에 한정하고, unique 위반(`DataIntegrityViolationException`)은 같은 세션 동시 적재의 멱등 성공 경로이므로 재시도하지 않는다.

이 재시도는 짧은 순간 겹치는 경합만 구제한다. 어떤 트랜잭션이 몇 분씩 락을 쥐고 있으면 재시도해도 매번 실패하므로, 락을 오래 점유하는 상황까지 해결해 주지는 않는다. RC 전환(별도 PR) 이후로는 보조 역할이며, 남는 충돌(같은 세션 동시 적재)은 `active_session_id` unique 멱등이 이미 처리한다.

spring-retry 를 도입했다(`@EnableRetry`). `@Retryable` 은 기존 Spring AOP 프록시로 동작하므로 `spring-boot-starter-aop` 없이 `spring-retry` 의존성만 추가했다.

### 기능

**감상문 작업 적재 동시성**
- 적재 INSERT 가 워커와 순간 경합으로 락 대기 실패하면, 짧은 backoff 로 최대 3회 재시도해 사용자 요청이 곧바로 실패하지 않는다.
- unique 위반은 재시도 없이 기존대로 멱등 처리한다.

## 테스트 결과
- [x] `./gradlew test` 통과
- [x] 재시도 동작 테스트 추가 — 락 획득 실패는 재시도 후 성공 / 최대 시도 소진 시 예외 전파 / unique 위반은 재시도하지 않음

## 관련 이슈
- #92 (락 획득 실패 재시도 부분만 처리 — 이슈 완전 종료 아님, 서브태스크 잔존)

## 참고 사항

- **배포 선행조건**: 이 재시도가 의미 있으려면 INSERT 가 빨리 실패해야 한다. RDS 파라미터 그룹 `readum-dev-pg` 의 `innodb_lock_wait_timeout` 을 짧게(전역이라 영향 범위를 고려해 보수적으로 약 10초) 줄인 환경과 함께 적용한다. 동적 파라미터라 재부팅은 필요 없다. 타임아웃이 길면(현재 50초) 재시도가 매번 그만큼 기다려 오히려 사용자 응답이 더 느려지므로, 이 PR 과 파라미터 변경은 함께 적용해야 한다.
- backoff/시도 횟수(3회, 200ms~)는 우선 상수로 두었다. 운영 튜닝이 필요해지면 설정값으로 외부화한다.