### PR TITLE
chore(summary): 워커 풀 동시 실행 수를 summary-job.pool-size 와 일치

### DIFF
--- a/src/main/java/com/readum/infrastructure/aiChat/scheduler/SummarySchedulerConfig.java
+++ b/src/main/java/com/readum/infrastructure/aiChat/scheduler/SummarySchedulerConfig.java
@@ -1,5 +1,6 @@
 package com.readum.infrastructure.aiChat.scheduler;
 
+import com.readum.domain.summary.config.SummaryJobProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -9,12 +10,19 @@ import java.util.concurrent.Executor;
 @Configuration
 public class SummarySchedulerConfig {
 
+    /**
+     * 감상문 워커 실행 풀. 동시 실행 수를 {@code summary-job.pool-size} 하나로 맞춘다.
+     * core=max=poolSize 라 제출된 작업이 곧바로 실행되고, 큐(버퍼)를 두지 않아 동시 실행이 정확히
+     * poolSize 다. 디스패처가 이미 runningWorkers 로 제출량을 poolSize 로 막으므로 정상 흐름에선
+     * 큐가 필요 없고, 혹시 모를 초과 제출은 RejectedExecutionException 으로 디스패처가 다음 틱에 재시도한다.
+     */
     @Bean
-    public Executor summaryExecutor() {
+    public Executor summaryExecutor(SummaryJobProperties properties) {
+        int poolSize = properties.poolSize();
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(3);
-        executor.setMaxPoolSize(5);
-        executor.setQueueCapacity(50);
+        executor.setCorePoolSize(poolSize);
+        executor.setMaxPoolSize(poolSize);
+        executor.setQueueCapacity(0);
         executor.setThreadNamePrefix("summary-");
         executor.initialize();
         return executor;

--- a/src/test/java/com/readum/infrastructure/aiChat/scheduler/SummarySchedulerConfigTest.java
+++ b/src/test/java/com/readum/infrastructure/aiChat/scheduler/SummarySchedulerConfigTest.java
@@ -1,0 +1,30 @@
+package com.readum.infrastructure.aiChat.scheduler;
+
+import com.readum.domain.summary.config.SummaryJobProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * summaryExecutor 의 동시 실행 수가 {@code summary-job.pool-size} 와 일치하는지 검증한다 (이슈 #92).
+ *
+ * <p>디스패처는 동시 처리 수를 poolSize 로 제한하려 하지만(OpenAI 동시성 한도), 풀의 core/max 가
+ * poolSize 와 따로 놀면 실제 동시 실행은 core 에 묶여 의도가 깨진다. core=max=poolSize 로 파생해
+ * poolSize 를 단일 기준으로 만든다.
+ */
+class SummarySchedulerConfigTest {
+
+    @Test
+    void summaryExecutor_의_core_와_max_는_poolSize_와_일치한다() {
+        int poolSize = 7;
+        SummaryJobProperties properties = new SummaryJobProperties(
+                poolSize, 2000L, 60000L, 300L, 5, 60L, 1024);
+
+        ThreadPoolTaskExecutor executor =
+                (ThreadPoolTaskExecutor) new SummarySchedulerConfig().summaryExecutor(properties);
+
+        assertThat(executor.getCorePoolSize()).isEqualTo(poolSize);
+        assertThat(executor.getMaxPoolSize()).isEqualTo(poolSize);
+    }
+}


### PR DESCRIPTION
## 작업 사항

`summaryExecutor` 가 `core=3 / max=5 / queue=50` 으로 하드코딩돼 있어, `summary-job.pool-size`(12)와 따로 놀고 있었다. `ThreadPoolExecutor` 는 core 까지 스레드를 만든 뒤 그 다음 작업은 큐에 넣고, 큐가 꽉 차야 max 까지 스레드를 늘린다. 큐 용량이 50 이라 디스패처가 poolSize(12)만큼 작업을 제출해도 실제로는 core 3개만 실행되고 나머지는 큐에서 대기했으며, 큐가 50 까지 찰 일이 없어 `max=5` 도 동작하지 않았다.

결과적으로 디스패처가 "동시 처리 수를 poolSize 로 제한해 OpenAI 동시성을 한도 아래로 묶는다"고 한 의도와 달리, 실제 동시 실행은 3 에 묶이고 `pool-size`·`max` 는 죽은 설정이었다.

`summaryExecutor` 를 `summary-job.pool-size` 하나에서 파생한다(`core=max=poolSize`, `queue=0`). 디스패처가 이미 `runningWorkers` 로 제출량을 poolSize 로 막으므로 버퍼(큐)가 필요 없고, 동시 실행이 정확히 poolSize 가 된다. 혹시 모를 초과 제출은 `RejectedExecutionException` 으로 디스패처가 다음 틱에 재시도한다(기존 처리 그대로). 실제 동시 LLM 호출이 늘지만, 워커는 호출 전 토큰 버킷(`summary.rate-limit`)에서 허가를 받으므로 OpenAI 처리량 자체는 그대로 묶인다.

이번 락 대기 타임아웃 사고(#92)와는 직접 관련 없는 설정 정합 정리다.

### 기능

**감상문 워커 풀**
- 동시 실행 워커 수가 `summary-job.pool-size` 설정값과 정확히 일치한다(이전엔 설정과 무관하게 3개로 묶여 있었다).
- core/max/queue 하드코딩과 동작하지 않던 `max` 설정을 제거하고, poolSize 를 단일 기준으로 삼는다.

## 테스트 결과
- [x] `./gradlew test` 통과
- [x] 단위 테스트 추가 — 주어진 poolSize 에 대해 executor 의 `corePoolSize == maxPoolSize == poolSize` 단언(설정 드리프트 회귀 가드)

## 관련 이슈
- #92 (워커 풀 설정 정합 부분 — 락 사고와는 무관한 별도 정리, 이슈 완전 종료 아님)