### PR TITLE
chore(config): DB 커넥션 풀 크기를 Hikari 기본 10에서 20으로 상향

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,6 +15,11 @@ spring:
     username: ${MYSQL_USER}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    # 요약 워커(summary-job.pool-size=12)의 짧은 DB 단계가 순간적으로 겹쳐도 웹 요청과
+    # 경합하지 않도록 풀을 20 으로 둔다. RDS db.t4g.micro 의 max_connections(약 85)의 24% 수준이라
+    # 외부 접속·인스턴스 증설 여지를 남긴다. (minimum-idle 미지정 시 Hikari 가 max 와 같게 잡아 고정 크기)
+    hikari:
+      maximum-pool-size: 20
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
## 작업 사항

DB 커넥션 풀 최대 크기를 Hikari 기본값 10에서 20으로 명시 상향한다.
지금까지 `application-dev.yml` 의 datasource 에 hikari 설정이 없어 기본값 10 이
그대로 적용되고 있었다.

상향이 필요한 이유는 요약 워커 풀과의 커넥션 경합 때문이다. 요약 워커
(`summary-job.pool-size = 12`)는 작업을 claim·prepare·record 하는 짧은 트랜잭션
단계마다 커넥션을 잡는다. 느린 OpenAI 호출 구간은 트랜잭션 밖이라 커넥션을
점유하지 않지만(`SummaryGenerationWorker` 가 트랜잭션 없이 각 단계만 트랜잭션으로
호출하는 구조), 여러 워커의 DB 단계가 순간적으로 겹치면 최대 12개를 동시에
요구할 수 있다. 이때 풀이 10이면 웹 요청과 경합해 빠듯해진다.

풀 크기는 RDS 인스턴스 용량에 묶인 환경 의존값이라 환경 무관 상수만 두는
`application.yml` 이 아니라 `application-dev.yml` 에 둔다. 값 20 은 RDS
`db.t4g.micro` 의 `max_connections`(메모리 기반 공식상 약 85) 의 약 24% 수준으로,
DataGrip 같은 외부 접속과 향후 인스턴스 증설 여지를 남긴 선택이다.

커넥션 보유 시간(트랜잭션 경계)은 이미 OpenAI 호출 밖으로 분리돼 있어, 이번
작업은 설정값 한 줄 변경으로 한정하고 별도 구조 변경은 범위에 두지 않았다.

### 기능

**설정**
- `application-dev.yml` 에 `spring.datasource.hikari.maximum-pool-size: 20` 추가
- `minimum-idle` 은 지정하지 않아 Hikari 가 `maximum-pool-size` 와 같게 잡는다 (상시 20개 유지, 고정 크기 풀)

## 테스트 결과
- [x] `./gradlew build` 통과
- [ ] 배포 후 Actuator/Hikari 지표로 풀 크기 20 적용 확인

## 관련 이슈
- closes #98

## 참고 사항
- 정확한 `max_connections` 천장은 RDS 파라미터 그룹 또는 `SHOW VARIABLES LIKE 'max_connections';` 로 확인 가능. 85 는 t4g.micro 의 공식 기반 추정치다.
- 멀티 인스턴스 확장 시 인스턴스 수 × 20 이 천장을 넘지 않도록 재산정이 필요하다 (#88 맥락).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 개발 환경의 데이터베이스 연결 풀 설정을 최적화하여 시스템의 안정성과 동시 요청 처리 성능을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->