### PR TITLE
refactor(auth): 인증 신원 해석 일원화 및 호출 한도 키 사용자 단위 교정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+	testImplementation 'com.tngtech.archunit:archunit-junit5:1.4.1'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'io.projectreactor:reactor-test'

--- a/src/main/java/com/readum/domain/aiChat/dto/AiChatSessionCreateCommand.java
+++ b/src/main/java/com/readum/domain/aiChat/dto/AiChatSessionCreateCommand.java
@@ -1,7 +1,7 @@
 package com.readum.domain.aiChat.dto;
 
 public record AiChatSessionCreateCommand(
-        String userSessionId,
+        Long userId,
         Long userBookId
 ) {
 }

--- a/src/main/java/com/readum/domain/aiChat/dto/AiChatSessionListCommand.java
+++ b/src/main/java/com/readum/domain/aiChat/dto/AiChatSessionListCommand.java
@@ -1,7 +1,7 @@
 package com.readum.domain.aiChat.dto;
 
 public record AiChatSessionListCommand(
-        String userSessionId,
+        Long userId,
         Long userBookId,
         int page,
         int size

--- a/src/main/java/com/readum/domain/aiChat/dto/MessageListCommand.java
+++ b/src/main/java/com/readum/domain/aiChat/dto/MessageListCommand.java
@@ -1,7 +1,7 @@
 package com.readum.domain.aiChat.dto;
 
 public record MessageListCommand(
-        String userSessionId,
+        Long userId,
         Long sessionId,
         int page,
         int size

--- a/src/main/java/com/readum/domain/aiChat/dto/SendMessageCommand.java
+++ b/src/main/java/com/readum/domain/aiChat/dto/SendMessageCommand.java
@@ -1,7 +1,7 @@
 package com.readum.domain.aiChat.dto;
 
 public record SendMessageCommand(
-        String userSessionId,
+        Long userId,
         Long sessionId,
         String content
 ) {

--- a/src/main/java/com/readum/domain/aiChat/dto/SummaryDraftCommand.java
+++ b/src/main/java/com/readum/domain/aiChat/dto/SummaryDraftCommand.java
@@ -1,0 +1,7 @@
+package com.readum.domain.aiChat.dto;
+
+public record SummaryDraftCommand(
+        Long userId,
+        Long sessionId
+) {
+}

--- a/src/main/java/com/readum/domain/aiChat/dto/SummaryEditCommand.java
+++ b/src/main/java/com/readum/domain/aiChat/dto/SummaryEditCommand.java
@@ -1,7 +1,7 @@
 package com.readum.domain.aiChat.dto;
 
 public record SummaryEditCommand(
-        String userSessionId,
+        Long userId,
         Long sessionId,
         String title,
         String body

--- a/src/main/java/com/readum/domain/aiChat/service/AiChatMessageSearchService.java
+++ b/src/main/java/com/readum/domain/aiChat/service/AiChatMessageSearchService.java
@@ -5,13 +5,9 @@ import com.readum.domain.aiChat.dto.MessageListResult;
 import com.readum.domain.aiChat.dto.MessageResult;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.aiChat.entity.AiChatMessage;
 import com.readum.model.aiChat.repository.AiChatMessageRepository;
 import com.readum.model.aiChat.repository.AiChatSessionRepository;
-import com.readum.model.user.entity.User;
-import com.readum.model.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -21,15 +17,11 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AiChatMessageSearchService {
 
-    private final UserRepository userRepository;
     private final AiChatSessionRepository aiChatSessionRepository;
     private final AiChatMessageRepository aiChatMessageRepository;
 
     public MessageListResult findBySessionId(MessageListCommand command) {
-        User user = userRepository.findBySessionId(command.userSessionId())
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
-        aiChatSessionRepository.findByIdAndOwner(command.sessionId(), user.getId())
+        aiChatSessionRepository.findByIdAndOwner(command.sessionId(), command.userId())
                 .orElseThrow(() -> new NotFoundException(AiChatErrorCode.SESSION_NOT_FOUND));
 
         int pageIndex = Math.max(0, command.page() - 1);

--- a/src/main/java/com/readum/domain/aiChat/service/AiChatMessageSendService.java
+++ b/src/main/java/com/readum/domain/aiChat/service/AiChatMessageSendService.java
@@ -15,13 +15,9 @@ import com.readum.domain.exception.BusinessException;
 import com.readum.domain.exception.RateLimitInfo;
 import com.readum.domain.exception.ServiceUnavailableException;
 import com.readum.domain.exception.TooManyRequestsException;
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.aiChat.repository.AiChatMessageRepository;
 import com.readum.model.book.repository.BookRepository;
-import com.readum.model.user.entity.User;
 import com.readum.model.user.repository.UserBookRepository;
-import com.readum.model.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.retry.NonTransientAiException;
@@ -45,7 +41,6 @@ public class AiChatMessageSendService {
 
     private static final Pattern WHITESPACE_RUN = Pattern.compile("[\\p{Z}\\s]+");
 
-    private final UserRepository userRepository;
     private final AiChatMessagePersistService aiChatMessagePersistService;
     private final AiChatClient aiChatClient;
     private final AiChatProperties aiChatProperties;
@@ -55,19 +50,17 @@ public class AiChatMessageSendService {
     private final InputModerationClient inputModerationClient;
 
     public Flux<MessageStreamEvent> execute(SendMessageCommand command) {
-        User user = userRepository.findBySessionId(command.userSessionId())
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
         String normalizedContent = validateAndStripContent(command.content());
         Long sessionId = command.sessionId();
+        Long userId = command.userId();
 
         // 사전 단계: rate-limit 검사 / 이력 조회 / 입력 moderation / USER 메시지 영속화는 모두 SSE 시작 전에 끝난다.
         // 여기서 던진 예외는 SSE 이전에 GlobalExceptionHandler 가 처리해 4XX/5XX JSON 응답으로 나간다.
-        verifyUserMessageRateLimit(user.getId());
+        verifyUserMessageRateLimit(userId);
 
         // 이력만 조회(USER 미저장). 세션 검증은 여기서 끝난다.
         AiChatMessagePersistService.MessageLoadResult loaded =
-                aiChatMessagePersistService.loadHistory(sessionId, user.getId());
+                aiChatMessagePersistService.loadHistory(sessionId, userId);
 
         AiChatStreamCommand.BookContext bookContext = resolveBookContext(loaded.userBookId());
 
@@ -77,7 +70,7 @@ public class AiChatMessageSendService {
             case BLOCKED -> {
                 aiChatMessagePersistService.recordRejectedUserMessage(sessionId, normalizedContent);
                 log.warn("[Guardrail] 입력 차단 sessionId={} userId={} categories={}",
-                        sessionId, user.getId(), moderation.flaggedCategories());
+                        sessionId, userId, moderation.flaggedCategories());
                 throw new BadRequestException(AiChatErrorCode.GUARDRAIL_BLOCKED_INPUT);
             }
             case UNAVAILABLE -> {
@@ -90,7 +83,7 @@ public class AiChatMessageSendService {
         }
 
         // 통과한 경우에만 USER 메시지를 COMPLETED 로 저장(턴 카운트 포함).
-        aiChatMessagePersistService.recordUserMessage(sessionId, user.getId(), normalizedContent);
+        aiChatMessagePersistService.recordUserMessage(sessionId, userId, normalizedContent);
 
         List<HistoryMessage> withCurrent = new ArrayList<>(loaded.history().size() + 1);
         withCurrent.addAll(loaded.history());

--- a/src/main/java/com/readum/domain/aiChat/service/AiChatSessionCreateService.java
+++ b/src/main/java/com/readum/domain/aiChat/service/AiChatSessionCreateService.java
@@ -4,13 +4,9 @@ import com.readum.domain.aiChat.dto.AiChatSessionCreateCommand;
 import com.readum.domain.aiChat.dto.AiChatSessionCreateResult;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.aiChat.entity.AiChatSession;
 import com.readum.model.aiChat.repository.AiChatSessionRepository;
-import com.readum.model.user.entity.User;
 import com.readum.model.user.repository.UserBookRepository;
-import com.readum.model.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,16 +15,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AiChatSessionCreateService {
 
-    private final UserRepository userRepository;
     private final UserBookRepository userBookRepository;
     private final AiChatSessionRepository aiChatSessionRepository;
 
     @Transactional
     public AiChatSessionCreateResult execute(AiChatSessionCreateCommand command) {
-        User user = userRepository.findBySessionId(command.userSessionId())
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
-        userBookRepository.findByIdAndUserId(command.userBookId(), user.getId())
+        userBookRepository.findByIdAndUserId(command.userBookId(), command.userId())
                 .orElseThrow(() -> new NotFoundException(AiChatErrorCode.USER_BOOK_NOT_FOUND));
 
         AiChatSession saved = aiChatSessionRepository.save(AiChatSession.create(command.userBookId()));

--- a/src/main/java/com/readum/domain/aiChat/service/AiChatSessionSearchService.java
+++ b/src/main/java/com/readum/domain/aiChat/service/AiChatSessionSearchService.java
@@ -5,13 +5,9 @@ import com.readum.domain.aiChat.dto.AiChatSessionListResult;
 import com.readum.domain.aiChat.dto.AiChatSessionResult;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.aiChat.repository.AiChatSessionRepository;
 import com.readum.model.aiChat.repository.projection.AiChatSessionListProjection;
-import com.readum.model.user.entity.User;
 import com.readum.model.user.repository.UserBookRepository;
-import com.readum.model.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -21,21 +17,17 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AiChatSessionSearchService {
 
-    private final UserRepository userRepository;
     private final AiChatSessionRepository aiChatSessionRepository;
     private final UserBookRepository userBookRepository;
 
     public AiChatSessionListResult findByUserBookId(AiChatSessionListCommand command) {
-        User user = userRepository.findBySessionId(command.userSessionId())
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
-        userBookRepository.findByIdAndUserId(command.userBookId(), user.getId())
+        userBookRepository.findByIdAndUserId(command.userBookId(), command.userId())
                 .orElseThrow(() -> new NotFoundException(AiChatErrorCode.USER_BOOK_NOT_FOUND));
 
         int pageIndex = Math.max(0, command.page() - 1);
         Slice<AiChatSessionListProjection> slice = aiChatSessionRepository.findSessionsByUserBookIdAndOwner(
                 command.userBookId(),
-                user.getId(),
+                command.userId(),
                 PageRequest.of(pageIndex, command.size())
         );
 

--- a/src/main/java/com/readum/domain/aiChat/service/BookChatSessionSearchService.java
+++ b/src/main/java/com/readum/domain/aiChat/service/BookChatSessionSearchService.java
@@ -3,8 +3,6 @@ package com.readum.domain.aiChat.service;
 import com.readum.domain.aiChat.dto.BookChatSessionsResult;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.aiChat.entity.AiChatMessage;
 import com.readum.model.aiChat.entity.AiChatSession;
 import com.readum.model.aiChat.repository.AiChatMessageRepository;
@@ -14,10 +12,8 @@ import com.readum.model.book.entity.Book;
 import com.readum.model.book.repository.BookRepository;
 import com.readum.model.summary.entity.Summary;
 import com.readum.model.summary.repository.SummaryRepository;
-import com.readum.model.user.entity.User;
 import com.readum.model.user.entity.UserBook;
 import com.readum.model.user.repository.UserBookRepository;
-import com.readum.model.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -35,17 +31,14 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class BookChatSessionSearchService {
 
-    private final UserRepository userRepository;
     private final UserBookRepository userBookRepository;
     private final BookRepository bookRepository;
     private final AiChatSessionRepository aiChatSessionRepository;
     private final AiChatMessageRepository aiChatMessageRepository;
     private final SummaryRepository summaryRepository;
 
-    public BookChatSessionsResult findByUserBook(Long userBookId, String userSessionId) {
-        User user = userRepository.findBySessionId(userSessionId)
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-        UserBook userBook = userBookRepository.findByIdAndUserId(userBookId, user.getId())
+    public BookChatSessionsResult findByUserBook(Long userBookId, Long userId) {
+        UserBook userBook = userBookRepository.findByIdAndUserId(userBookId, userId)
                 .orElseThrow(() -> new NotFoundException(AiChatErrorCode.USER_BOOK_NOT_FOUND));
         Book book = bookRepository.findById(userBook.getBookId())
                 .orElseThrow(() -> new NotFoundException(AiChatErrorCode.USER_BOOK_NOT_FOUND));

--- a/src/main/java/com/readum/domain/aiChat/service/SummaryDraftSearchService.java
+++ b/src/main/java/com/readum/domain/aiChat/service/SummaryDraftSearchService.java
@@ -6,14 +6,10 @@ import com.readum.domain.aiChat.dto.SummaryDraftEligibilityResult;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.aiChat.service.policy.SummaryDraftPolicy;
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.aiChat.entity.AiChatSession;
 import com.readum.model.aiChat.repository.AiChatSessionRepository;
 import com.readum.model.summary.repository.SummaryJobRepository;
-import com.readum.model.user.entity.User;
 import com.readum.model.user.repository.UserBookRepository;
-import com.readum.model.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,20 +17,16 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SummaryDraftSearchService {
 
-    private final UserRepository userRepository;
     private final AiChatSessionRepository aiChatSessionRepository;
     private final UserBookRepository userBookRepository;
     private final SummaryDraftPolicy summaryDraftPolicy;
     private final SummaryJobRepository summaryJobRepository;
 
-    public SummaryDraftEligibilityResult findEligibility(Long sessionId, String userSessionId) {
-        User user = userRepository.findBySessionId(userSessionId)
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
+    public SummaryDraftEligibilityResult findEligibility(Long sessionId, Long userId) {
         AiChatSession session = aiChatSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new NotFoundException(AiChatErrorCode.SESSION_NOT_FOUND));
 
-        userBookRepository.findByIdAndUserId(session.getUserBookId(), user.getId())
+        userBookRepository.findByIdAndUserId(session.getUserBookId(), userId)
                 .orElseThrow(() -> new NotFoundException(AiChatErrorCode.SESSION_NOT_FOUND));
 
         int progressPercent = summaryDraftPolicy.calculateProgressPercent(session.getAccumulatedTokens());

--- a/src/main/java/com/readum/domain/aiChat/service/SummaryDraftService.java
+++ b/src/main/java/com/readum/domain/aiChat/service/SummaryDraftService.java
@@ -4,15 +4,11 @@ import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.aiChat.service.policy.SummaryDraftPolicy;
 import com.readum.domain.exception.ConflictException;
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
 import com.readum.domain.summary.service.EnqueueSummaryJobService;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.aiChat.entity.AiChatSession;
 import com.readum.model.aiChat.repository.AiChatSessionRepository;
 import com.readum.model.summary.repository.SummaryJobRepository;
-import com.readum.model.user.entity.User;
 import com.readum.model.user.repository.UserBookRepository;
-import com.readum.model.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,7 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SummaryDraftService {
 
-    private final UserRepository userRepository;
     private final AiChatSessionRepository aiChatSessionRepository;
     private final UserBookRepository userBookRepository;
     private final SummaryDraftPolicy summaryDraftPolicy;
@@ -37,14 +32,11 @@ public class SummaryDraftService {
     private final EnqueueSummaryJobService enqueueSummaryJobService;
 
     @Transactional
-    public void execute(Long sessionId, String userSessionId) {
-        User user = userRepository.findBySessionId(userSessionId)
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
+    public void execute(Long sessionId, Long userId) {
         AiChatSession session = aiChatSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new NotFoundException(AiChatErrorCode.SESSION_NOT_FOUND));
 
-        userBookRepository.findByIdAndUserId(session.getUserBookId(), user.getId())
+        userBookRepository.findByIdAndUserId(session.getUserBookId(), userId)
                 .orElseThrow(() -> new NotFoundException(AiChatErrorCode.SESSION_NOT_FOUND));
 
         // 이미 활성(완료·실패 전 상태 — PENDING/PROCESSING) 작업이 있으면 "생성 중" — 409 로 거부(중복 요청 방지).

--- a/src/main/java/com/readum/domain/aiChat/service/SummaryDraftService.java
+++ b/src/main/java/com/readum/domain/aiChat/service/SummaryDraftService.java
@@ -1,5 +1,6 @@
 package com.readum.domain.aiChat.service;
 
+import com.readum.domain.aiChat.dto.SummaryDraftCommand;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.aiChat.service.policy.SummaryDraftPolicy;
 import com.readum.domain.exception.ConflictException;
@@ -32,7 +33,10 @@ public class SummaryDraftService {
     private final EnqueueSummaryJobService enqueueSummaryJobService;
 
     @Transactional
-    public void execute(Long sessionId, Long userId) {
+    public void execute(SummaryDraftCommand command) {
+        Long sessionId = command.sessionId();
+        Long userId = command.userId();
+
         AiChatSession session = aiChatSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new NotFoundException(AiChatErrorCode.SESSION_NOT_FOUND));
 

--- a/src/main/java/com/readum/domain/aiChat/service/SummaryEditService.java
+++ b/src/main/java/com/readum/domain/aiChat/service/SummaryEditService.java
@@ -4,13 +4,9 @@ import com.readum.domain.aiChat.dto.SummaryEditCommand;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.summary.dto.SummaryResult;
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.aiChat.repository.AiChatSessionRepository;
 import com.readum.model.summary.entity.Summary;
 import com.readum.model.summary.repository.SummaryRepository;
-import com.readum.model.user.entity.User;
-import com.readum.model.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,16 +15,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SummaryEditService {
 
-    private final UserRepository userRepository;
     private final AiChatSessionRepository aiChatSessionRepository;
     private final SummaryRepository summaryRepository;
 
     @Transactional
     public SummaryResult execute(SummaryEditCommand command) {
-        User user = userRepository.findBySessionId(command.userSessionId())
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
-        aiChatSessionRepository.findByIdAndOwner(command.sessionId(), user.getId())
+        aiChatSessionRepository.findByIdAndOwner(command.sessionId(), command.userId())
                 .orElseThrow(() -> new NotFoundException(AiChatErrorCode.SESSION_NOT_FOUND));
 
         // 종료 모델에서 세션당 감상문은 한 행(1:1)이므로 그 행이 곧 편집 대상이다.

--- a/src/main/java/com/readum/domain/auth/service/SessionAuthenticationService.java
+++ b/src/main/java/com/readum/domain/auth/service/SessionAuthenticationService.java
@@ -1,0 +1,29 @@
+package com.readum.domain.auth.service;
+
+import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.exception.UserErrorCode;
+import com.readum.model.user.entity.User;
+import com.readum.model.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * user_session 쿠키 값을 사용자 신원(userId)으로 해석한다.
+ * 신원 해석은 이 서비스와 이를 호출하는 인증 필터(SessionCookieAuthenticationFilter) 한 경로로만
+ * 일어나도록 규칙을 둔다 — UserRepository.findBySessionId 의 허용 호출자는 이 서비스 하나다.
+ * (기존 서비스들의 직접 호출은 이 브랜치에서 제거되며, 규칙은 AuthenticationBoundaryArchTest 의
+ * ArchUnit 규칙으로 강제된다.)
+ * 소셜 로그인(JWT) 도입 시 TokenAuthenticationService 와 나란히 게스트 인증 담당으로 남는다.
+ */
+@Service
+@RequiredArgsConstructor
+public class SessionAuthenticationService {
+
+    private final UserRepository userRepository;
+
+    public Long authenticate(String userSessionId) {
+        User user = userRepository.findBySessionId(userSessionId)
+                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
+        return user.getId();
+    }
+}

--- a/src/main/java/com/readum/domain/summary/dto/SummaryHistoryListCommand.java
+++ b/src/main/java/com/readum/domain/summary/dto/SummaryHistoryListCommand.java
@@ -1,7 +1,7 @@
 package com.readum.domain.summary.dto;
 
 public record SummaryHistoryListCommand(
-        String userSessionId,
+        Long userId,
         int page
 ) {
 }

--- a/src/main/java/com/readum/domain/summary/service/SummaryHistorySearchService.java
+++ b/src/main/java/com/readum/domain/summary/service/SummaryHistorySearchService.java
@@ -1,14 +1,10 @@
 package com.readum.domain.summary.service;
 
-import com.readum.domain.exception.UnauthorizedException;
 import com.readum.domain.summary.dto.SummaryHistoryItemResult;
 import com.readum.domain.summary.dto.SummaryHistoryListCommand;
 import com.readum.domain.summary.dto.SummaryHistoryListResult;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.summary.repository.SummaryRepository;
 import com.readum.model.summary.repository.projection.SummaryHistoryProjection;
-import com.readum.model.user.entity.User;
-import com.readum.model.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -19,7 +15,7 @@ import org.springframework.stereotype.Service;
  * 페이지 크기는 20개로 고정한다.
  *
  * 형제 조회 서비스(AiChatSessionSearchService 등)와 동일하게 @Transactional(readOnly) 를 붙이지 않는다.
- * 인증 조회와 목록 조회가 한 트랜잭션의 일관성을 요구하지 않기 때문이다.
+ * 단일 Repository 호출이므로 서비스 레벨의 트랜잭션이 불필요하다.
  */
 @Service
 @RequiredArgsConstructor
@@ -27,16 +23,12 @@ public class SummaryHistorySearchService {
 
     private static final int PAGE_SIZE = 20;
 
-    private final UserRepository userRepository;
     private final SummaryRepository summaryRepository;
 
     public SummaryHistoryListResult findMyHistory(SummaryHistoryListCommand command) {
-        User user = userRepository.findBySessionId(command.userSessionId())
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
         int pageIndex = Math.max(0, command.page() - 1);
         Slice<SummaryHistoryProjection> slice = summaryRepository.findLatestHistoryByUserId(
-                user.getId(), PageRequest.of(pageIndex, PAGE_SIZE));
+                command.userId(), PageRequest.of(pageIndex, PAGE_SIZE));
 
         return new SummaryHistoryListResult(
                 slice.getContent().stream().map(SummaryHistoryItemResult::from).toList(),

--- a/src/main/java/com/readum/domain/summary/service/SummarySearchService.java
+++ b/src/main/java/com/readum/domain/summary/service/SummarySearchService.java
@@ -130,11 +130,8 @@ public class SummarySearchService {
     }
 
     @Transactional(readOnly = true)
-    public SummaryResult findBySessionId(Long sessionId, String userSessionId) {
-        User user = userRepository.findBySessionId(userSessionId)
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
-        AiChatSession session = aiChatSessionRepository.findByIdAndOwner(sessionId, user.getId())
+    public SummaryResult findBySessionId(Long sessionId, Long userId) {
+        AiChatSession session = aiChatSessionRepository.findByIdAndOwner(sessionId, userId)
                 .orElseThrow(() -> new NotFoundException(AiChatErrorCode.SESSION_NOT_FOUND));
 
         // "생성 중" 은 차단 판정 조건(PENDING 또는 유효 점유 PROCESSING)으로 판정(폴링 계약: 409 유지)

--- a/src/main/java/com/readum/domain/summary/service/SummarySearchService.java
+++ b/src/main/java/com/readum/domain/summary/service/SummarySearchService.java
@@ -3,11 +3,9 @@ package com.readum.domain.summary.service;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.exception.ConflictException;
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
 import com.readum.domain.summary.dto.MonthlyReadingRecordResult;
 import com.readum.domain.summary.dto.SummaryResult;
 import com.readum.domain.summary.exception.SummaryErrorCode;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.aiChat.entity.AiChatMessage;
 import com.readum.model.aiChat.entity.AiChatSession;
 import com.readum.model.aiChat.repository.AiChatMessageRepository;
@@ -18,10 +16,8 @@ import com.readum.model.book.entity.Book;
 import com.readum.model.book.repository.BookRepository;
 import com.readum.model.summary.entity.Summary;
 import com.readum.model.summary.repository.SummaryRepository;
-import com.readum.model.user.entity.User;
 import com.readum.model.user.entity.UserBook;
 import com.readum.model.user.repository.UserBookRepository;
-import com.readum.model.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,7 +38,6 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class SummarySearchService {
 
-    private final UserRepository userRepository;
     private final AiChatSessionRepository aiChatSessionRepository;
     private final AiChatMessageRepository aiChatMessageRepository;
     private final SummaryRepository summaryRepository;
@@ -51,11 +46,8 @@ public class SummarySearchService {
     private final BookRepository bookRepository;
 
     @Transactional(readOnly = true)
-    public List<MonthlyReadingRecordResult> findMonthly(YearMonth yearMonth, String userSessionId) {
-        User user = userRepository.findBySessionId(userSessionId)
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
-        List<UserBook> userBooks = userBookRepository.findByUserId(user.getId());
+    public List<MonthlyReadingRecordResult> findMonthly(YearMonth yearMonth, Long userId) {
+        List<UserBook> userBooks = userBookRepository.findByUserId(userId);
         if (userBooks.isEmpty()) {
             return List.of();
         }
@@ -116,14 +108,11 @@ public class SummarySearchService {
     }
 
     @Transactional(readOnly = true)
-    public SummaryResult findById(Long summaryId, String userSessionId) {
-        User user = userRepository.findBySessionId(userSessionId)
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
+    public SummaryResult findById(Long summaryId, Long userId) {
         Summary summary = summaryRepository.findById(summaryId)
                 .orElseThrow(() -> new NotFoundException(SummaryErrorCode.SUMMARY_NOT_FOUND));
 
-        userBookRepository.findByIdAndUserId(summary.getUserBookId(), user.getId())
+        userBookRepository.findByIdAndUserId(summary.getUserBookId(), userId)
                 .orElseThrow(() -> new NotFoundException(SummaryErrorCode.SUMMARY_NOT_FOUND));
 
         return SummaryResult.from(summary);

--- a/src/main/java/com/readum/domain/user/dto/UpdateNicknameCommand.java
+++ b/src/main/java/com/readum/domain/user/dto/UpdateNicknameCommand.java
@@ -1,4 +1,4 @@
 package com.readum.domain.user.dto;
 
-public record UpdateNicknameCommand(String sessionId, String nickname) {
+public record UpdateNicknameCommand(Long userId, String nickname) {
 }

--- a/src/main/java/com/readum/domain/user/service/CompleteOnboardingService.java
+++ b/src/main/java/com/readum/domain/user/service/CompleteOnboardingService.java
@@ -1,8 +1,6 @@
 package com.readum.domain.user.service;
 
-import com.readum.domain.exception.UnauthorizedException;
 import com.readum.domain.user.dto.CompleteOnboardingResult;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.user.entity.User;
 import com.readum.model.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,9 +14,10 @@ public class CompleteOnboardingService {
     private final UserRepository userRepository;
 
     @Transactional
-    public CompleteOnboardingResult execute(String sessionId) {
-        User user = userRepository.findBySessionId(sessionId)
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
+    public CompleteOnboardingResult execute(Long userId) {
+        // 인증 필터가 userId 의 실존을 이미 검증했다 — 빈 결과는 정상 흐름이 아니라 프로그램 버그.
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException("인증된 userId 의 사용자가 존재하지 않음: userId=" + userId));
 
         if (!user.isOnboardingCompleted()) {
             user.completeOnboarding();

--- a/src/main/java/com/readum/domain/user/service/UpdateNicknameService.java
+++ b/src/main/java/com/readum/domain/user/service/UpdateNicknameService.java
@@ -1,7 +1,6 @@
 package com.readum.domain.user.service;
 
 import com.readum.domain.exception.BadRequestException;
-import com.readum.domain.exception.UnauthorizedException;
 import com.readum.domain.user.dto.UpdateNicknameCommand;
 import com.readum.domain.user.dto.UpdateNicknameResult;
 import com.readum.domain.user.exception.UserErrorCode;
@@ -27,8 +26,10 @@ public class UpdateNicknameService {
             throw new BadRequestException(UserErrorCode.INVALID_NICKNAME);
         }
 
-        User user = userRepository.findBySessionId(command.sessionId())
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
+        // 인증 필터가 userId 의 실존을 이미 검증했다 — 빈 결과는 정상 흐름이 아니라 프로그램 버그.
+        User user = userRepository.findById(command.userId())
+                .orElseThrow(() -> new IllegalStateException(
+                        "인증된 userId 의 사용자가 존재하지 않음: userId=" + command.userId()));
 
         user.updateNickname(command.nickname());
 

--- a/src/main/java/com/readum/domain/user/service/UserSearchService.java
+++ b/src/main/java/com/readum/domain/user/service/UserSearchService.java
@@ -1,9 +1,7 @@
 package com.readum.domain.user.service;
 
-import com.readum.domain.exception.UnauthorizedException;
 import com.readum.domain.user.dto.UserProfileResult;
 import com.readum.domain.user.dto.UserSessionInfoResult;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.user.repository.UserBookRepository;
 import com.readum.model.user.entity.User;
 import com.readum.model.user.repository.UserRepository;
@@ -17,21 +15,22 @@ public class UserSearchService {
     private final UserRepository userRepository;
     private final UserBookRepository userBookRepository;
 
-    public UserSessionInfoResult findSessionInfo(String sessionId) {
-        User user = getUserBySessionIdOrThrow(sessionId);
+    public UserSessionInfoResult findSessionInfo(Long userId) {
+        User user = getUserByIdOrThrow(userId);
 
         boolean hasRegisteredBooks = userBookRepository.existsByUserId(user.getId());
 
         return UserSessionInfoResult.from(user, hasRegisteredBooks);
     }
 
-    public UserProfileResult findProfile(String sessionId) {
-        User user = getUserBySessionIdOrThrow(sessionId);
+    public UserProfileResult findProfile(Long userId) {
+        User user = getUserByIdOrThrow(userId);
         return UserProfileResult.from(user);
     }
 
-    private User getUserBySessionIdOrThrow(String sessionId) {
-        return userRepository.findBySessionId(sessionId)
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
+    // 인증 필터가 userId 의 실존을 이미 검증했다 — 빈 결과는 정상 흐름이 아니라 프로그램 버그.
+    private User getUserByIdOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException("인증된 userId 의 사용자가 존재하지 않음: userId=" + userId));
     }
 }

--- a/src/main/java/com/readum/domain/user/userbook/dto/UserBookCreateCommand.java
+++ b/src/main/java/com/readum/domain/user/userbook/dto/UserBookCreateCommand.java
@@ -1,7 +1,7 @@
 package com.readum.domain.user.userbook.dto;
 
 public record UserBookCreateCommand(
-        String userSessionId,
+        Long userId,
         String bookExternalId
 ) {
 }

--- a/src/main/java/com/readum/domain/user/userbook/dto/UserBookDeleteCommand.java
+++ b/src/main/java/com/readum/domain/user/userbook/dto/UserBookDeleteCommand.java
@@ -1,7 +1,7 @@
 package com.readum.domain.user.userbook.dto;
 
 public record UserBookDeleteCommand(
-        String userSessionId,
+        Long userId,
         Long userBookId
 ) {
 }

--- a/src/main/java/com/readum/domain/user/userbook/service/UserBookCreateService.java
+++ b/src/main/java/com/readum/domain/user/userbook/service/UserBookCreateService.java
@@ -3,17 +3,13 @@ package com.readum.domain.user.userbook.service;
 import com.readum.domain.book.dto.BookResult;
 import com.readum.domain.book.out.BookLookupClient;
 import com.readum.domain.exception.ConflictException;
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.domain.user.userbook.dto.UserBookCreateCommand;
 import com.readum.domain.user.userbook.dto.UserBookCreateResult;
 import com.readum.domain.user.userbook.exception.UserBookErrorCode;
 import com.readum.model.book.entity.Book;
 import com.readum.model.book.repository.BookRepository;
-import com.readum.model.user.entity.User;
 import com.readum.model.user.entity.UserBook;
 import com.readum.model.user.repository.UserBookRepository;
-import com.readum.model.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -24,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserBookCreateService {
 
-    private final UserRepository userRepository;
     private final BookLookupClient bookLookupClient;
     private final BookRepository bookRepository;
     private final UserBookRepository userBookRepository;
@@ -32,9 +27,6 @@ public class UserBookCreateService {
 
     @Transactional
     public UserBookCreateResult execute(UserBookCreateCommand command) {
-        User user = userRepository.findBySessionId(command.userSessionId())
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
         // 1. 알라딘에서 도서 정보 조회 (신뢰할 수 있는 원천 데이터 확보)
         BookResult bookInfo = bookLookupClient.execute(command.bookExternalId());
 
@@ -57,10 +49,10 @@ public class UserBookCreateService {
         // 중복(일반 재등록 또는 race condition) 발생 시 DataIntegrityViolationException을 잡아
         // 새 트랜잭션으로 재조회 후 409로 전환한다.
         try {
-            UserBook saved = userBookRepository.save(UserBook.create(user.getId(), book.getId()));
+            UserBook saved = userBookRepository.save(UserBook.create(command.userId(), book.getId()));
             return UserBookCreateResult.from(saved, book);
         } catch (DataIntegrityViolationException ex) {
-            UserBook raced = userBookConflictReader.find(user.getId(), book.getId())
+            UserBook raced = userBookConflictReader.find(command.userId(), book.getId())
                     .orElseThrow(() -> ex);
             throw new ConflictException(UserBookErrorCode.ALREADY_EXISTS, UserBookCreateResult.from(raced, book));
         }

--- a/src/main/java/com/readum/domain/user/userbook/service/UserBookDeleteService.java
+++ b/src/main/java/com/readum/domain/user/userbook/service/UserBookDeleteService.java
@@ -1,8 +1,6 @@
 package com.readum.domain.user.userbook.service;
 
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.domain.user.userbook.dto.UserBookDeleteCommand;
 import com.readum.domain.user.userbook.dto.UserBookDeleteResult;
 import com.readum.domain.user.userbook.exception.UserBookErrorCode;
@@ -10,7 +8,6 @@ import com.readum.model.aiChat.repository.AiChatMessageRepository;
 import com.readum.model.aiChat.repository.AiChatSessionRepository;
 import com.readum.model.summary.repository.SummaryJobRepository;
 import com.readum.model.summary.repository.SummaryRepository;
-import com.readum.model.user.entity.User;
 import com.readum.model.user.repository.UserBookRepository;
 import com.readum.model.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -42,13 +39,10 @@ public class UserBookDeleteService {
 
     @Transactional
     public UserBookDeleteResult execute(UserBookDeleteCommand command) {
-        User user = userRepository.findBySessionId(command.userSessionId())
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
         // 소유권 검증. 미소유/미존재를 구분하지 않고 404 로 응답해 타인 도서의 존재 여부를 누설하지 않는다.
         // 여기서 로드한 엔티티는 인가 판정·로깅에만 쓴다 — 첫 벌크 삭제(clearAutomatically) 시점에
         // 영속성 컨텍스트가 비워져 detached 가 되므로, 실제 부모 삭제는 deleteById(id) 로 수행한다.
-        userBookRepository.findByIdAndUserId(command.userBookId(), user.getId())
+        userBookRepository.findByIdAndUserId(command.userBookId(), command.userId())
                 .orElseThrow(() -> new NotFoundException(UserBookErrorCode.NOT_FOUND));
 
         Long userBookId = command.userBookId();
@@ -62,7 +56,7 @@ public class UserBookDeleteService {
         userBookRepository.deleteById(userBookId);
 
         log.info("등록 도서 삭제 완료 - userId={}, userBookId={}, deletedSessions={}, deletedMessages={}, deletedJobs={}, deletedSummaries={}",
-                user.getId(), userBookId, deletedSessions, deletedMessages, deletedJobs, deletedSummaries);
+                command.userId(), userBookId, deletedSessions, deletedMessages, deletedJobs, deletedSummaries);
 
         return new UserBookDeleteResult(userBookId, deletedSessions, deletedMessages, deletedSummaries);
     }

--- a/src/main/java/com/readum/domain/user/userbook/service/UserBookSearchService.java
+++ b/src/main/java/com/readum/domain/user/userbook/service/UserBookSearchService.java
@@ -1,12 +1,8 @@
 package com.readum.domain.user.userbook.service;
 
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.domain.user.userbook.dto.UserBookSearchItemResult;
 import com.readum.domain.user.userbook.dto.UserBookSearchResult;
-import com.readum.model.user.entity.User;
 import com.readum.model.user.repository.UserBookRepository;
-import com.readum.model.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,15 +12,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class UserBookSearchService {
 
-    private final UserRepository userRepository;
     private final UserBookRepository userBookRepository;
 
-    public UserBookSearchResult findMyBooks(String userSessionId) {
-        User user = userRepository.findBySessionId(userSessionId)
-                .orElseThrow(() -> new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
+    public UserBookSearchResult findMyBooks(Long userId) {
         List<UserBookSearchItemResult> books = userBookRepository
-                .findAllByUserIdOrderByCreatedAtDescIdDesc(user.getId())
+                .findAllByUserIdOrderByCreatedAtDescIdDesc(userId)
                 .stream()
                 .map(UserBookSearchItemResult::from)
                 .toList();

--- a/src/main/java/com/readum/infrastructure/ai/openai/ratelimit/AiChatRateLimitInterceptor.java
+++ b/src/main/java/com/readum/infrastructure/ai/openai/ratelimit/AiChatRateLimitInterceptor.java
@@ -6,23 +6,19 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+import java.security.Principal;
+
 /**
- * AI 채팅 rate limit interceptor.
- * /api/v1/ai-chat/** 엔드포인트에만 적용되며, 한도 초과 시 HTTP 429 응답을 반환한다.
+ * AI 채팅 호출 한도 interceptor.
+ * 비싼 LLM 호출(메시지 전송, 감상문 초안 생성 — POST)에만 적용되며, 초과 시 HTTP 429 를 반환한다.
  *
- * key 우선순위:
- *   1) Spring Security 의 인증 principal (Long userId 형태) — 인증 활성화 시
- *   2) ServletRequest.getRemoteAddr()
- *
- * 클라이언트가 임의로 설정 가능한 X-Forwarded-For 헤더는 신뢰하지 않는다.
- * (현 인프라는 단일 EC2 + nginx 직결이라 getRemoteAddr() 가 실제 클라이언트 IP 다.)
- * 향후 ALB / CDN 등 신뢰된 프록시 뒤로 들어가게 되면 Spring 의
- * `server.forward-headers-strategy: native` 설정으로 위임하여 인프라 레벨에서 처리한다.
+ * 키는 인증된 사용자(userId) 기준이다. 이 인터셉터가 붙는 경로는 전부 인증 필수(SecurityConfig)이므로
+ * principal 은 항상 존재한다 — 없다면 보안 설정이 무너진 것이므로 IP 등으로 조용히 대체하지 않고
+ * IllegalStateException 으로 즉시 드러낸다 (2026-06-20 429 사고의 교훈: IP 대체 동작이
+ * 프론트 프록시 IP 를 키로 만들어 서로 다른 사용자들이 한 버킷을 공유했다).
  */
 @Slf4j
 @Component
@@ -44,12 +40,16 @@ public class AiChatRateLimitInterceptor implements HandlerInterceptor {
         if (!rateLimiter.isEnabled()) {
             return true;
         }
+        // 읽기(GET 등)는 한도를 소비하지 않는다 — 비싼 LLM 호출(POST)만 대상.
+        if (!"POST".equals(request.getMethod())) {
+            return true;
+        }
         String key = resolveKey(request);
         if (rateLimiter.tryConsume(key)) {
             return true;
         }
 
-        log.info("[Guardrail] rate limit exceeded: keyHash={}", Integer.toHexString(key.hashCode()));
+        log.info("[Guardrail] 호출 한도 초과: key={}", key);
         response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
@@ -59,13 +59,11 @@ public class AiChatRateLimitInterceptor implements HandlerInterceptor {
     }
 
     private String resolveKey(HttpServletRequest request) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication != null && authentication.isAuthenticated()
-                && authentication.getPrincipal() != null
-                && !"anonymousUser".equals(authentication.getPrincipal())) {
-            return "user:" + authentication.getPrincipal();
+        Principal principal = request.getUserPrincipal();
+        if (principal == null) {
+            throw new IllegalStateException(
+                    "호출 한도 대상 요청에 인증 principal 이 없음 — 보안 설정 확인 필요: " + request.getRequestURI());
         }
-        String remote = request.getRemoteAddr();
-        return "ip:" + (remote == null ? "unknown" : remote);
+        return "user:" + principal.getName();
     }
 }

--- a/src/main/java/com/readum/infrastructure/ai/openai/ratelimit/AiChatRateLimitWebMvcConfig.java
+++ b/src/main/java/com/readum/infrastructure/ai/openai/ratelimit/AiChatRateLimitWebMvcConfig.java
@@ -13,7 +13,11 @@ public class AiChatRateLimitWebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
+        // 비싼 LLM 호출 2개만 대상 — 이력 조회 GET·eligibility GET·세션 생성 POST 는 한도를 소비하지 않는다.
         registry.addInterceptor(aiChatRateLimitInterceptor)
-                .addPathPatterns("/api/v1/ai-chat/**");
+                .addPathPatterns(
+                        "/api/v1/ai-chat/sessions/*/messages",
+                        "/api/v1/ai-chat/sessions/*/summary-draft"
+                );
     }
 }

--- a/src/main/java/com/readum/presentation/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/readum/presentation/common/GlobalExceptionHandler.java
@@ -149,7 +149,8 @@ public class GlobalExceptionHandler {
         return GlobalApiResponse.error(HttpStatus.BAD_REQUEST, ex.getMessage());
     }
 
-    // @CookieValue(required = true) 로 선언된 쿠키가 요청에 없을 때 (user_session 등 인증 쿠키 → 401)
+    // @CookieValue(required = true) 로 선언된 인증 쿠키가 요청에 없을 때 (refresh_token → 401).
+    // user_session 은 인증 필터가 처리하므로 여기 오지 않는다 — 이 핸들러는 auth 재발급 경로 전용.
     @ExceptionHandler(MissingRequestCookieException.class)
     public ResponseEntity<GlobalApiResponse<?>> handleMissingCookie(MissingRequestCookieException ex) {
         log.warn("Missing cookie: {}", ex.getCookieName());

--- a/src/main/java/com/readum/presentation/common/security/AuthenticatedUserId.java
+++ b/src/main/java/com/readum/presentation/common/security/AuthenticatedUserId.java
@@ -1,0 +1,15 @@
+package com.readum.presentation.common.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 인증 필터가 해석해 둔 현재 사용자 userId(Long) 를 주입받는다.
+ * 컨트롤러가 신원을 받는 유일한 통로 — 쿠키/헤더를 직접 읽지 않는다.
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticatedUserId {
+}

--- a/src/main/java/com/readum/presentation/common/security/AuthenticatedUserIdArgumentResolver.java
+++ b/src/main/java/com/readum/presentation/common/security/AuthenticatedUserIdArgumentResolver.java
@@ -1,0 +1,35 @@
+package com.readum.presentation.common.security;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class AuthenticatedUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthenticatedUserId.class)
+                && Long.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof Long userId)) {
+            // Security 계층이 인증을 강제하므로 여기 도달 = 보안 설정 버그.
+            // IP 등으로 조용히 대체하지 않고 즉시 드러낸다 (2026-06-20 429 사고의 교훈).
+            throw new IllegalStateException(
+                    "@AuthenticatedUserId 는 인증이 보장된 경로에서만 쓸 수 있다 — principal 이 비어 있음");
+        }
+        return userId;
+    }
+}

--- a/src/main/java/com/readum/presentation/common/security/AuthenticationWebMvcConfig.java
+++ b/src/main/java/com/readum/presentation/common/security/AuthenticationWebMvcConfig.java
@@ -1,0 +1,16 @@
+package com.readum.presentation.common.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class AuthenticationWebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new AuthenticatedUserIdArgumentResolver());
+    }
+}

--- a/src/main/java/com/readum/presentation/common/security/SecurityConfig.java
+++ b/src/main/java/com/readum/presentation/common/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.readum.presentation.common.security;
 
+import com.readum.domain.auth.service.SessionAuthenticationService;
 import com.readum.domain.auth.service.TokenAuthenticationService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,6 +19,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(
             HttpSecurity http,
             TokenAuthenticationService tokenAuthenticationService,
+            SessionAuthenticationService sessionAuthenticationService,
             JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint,
             JwtAccessDeniedHandler jwtAccessDeniedHandler
     ) throws Exception {
@@ -29,13 +31,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/refresh").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/logout").permitAll()
-                        // MVP: 쿠키 세션(user_session) 기반 인증 — Spring Security 레벨은 permitAll,
-                        // 실제 유저 검증은 각 서비스의 findBySessionId() 에서 수행
-                        .requestMatchers("/api/v1/ai-chat/**").permitAll()
-                        .requestMatchers("/api/v1/user-books/**").permitAll()
-                        .requestMatchers("/api/v1/users/**").permitAll()
+                        // 쿠키 발급(가입)은 익명 접근이 필요한 유일한 사용자 엔드포인트
+                        .requestMatchers(HttpMethod.POST, "/api/v1/users/sessions").permitAll()
+                        // 도서 검색은 쿠키를 읽지 않는 공개 API
                         .requestMatchers("/api/v1/books/**").permitAll()
-                        .requestMatchers("/api/v1/summaries/**").permitAll()
                         // 운영 모니터링: Prometheus 스크래핑·헬스체크용 actuator 엔드포인트만 허용.
                         // (/actuator/metrics 는 인증을 유지한다.) 외부 노출 차단은 네트워크 레벨에서 책임진다.
                         .requestMatchers(
@@ -50,6 +49,8 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/swagger-ui/**"
                         ).permitAll()
+                        // 신원 해석은 인증 필터(JWT/세션 쿠키)가, 인증 강제는 여기가 담당한다.
+                        // 미인증 요청은 JwtAuthenticationEntryPoint 가 401 로 응답한다.
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(exception -> exception
@@ -59,6 +60,11 @@ public class SecurityConfig {
                 .addFilterBefore(
                         new JwtAuthenticationFilter(tokenAuthenticationService),
                         UsernamePasswordAuthenticationFilter.class
+                )
+                // JWT 인증이 채우지 못한 요청에 한해 user_session 쿠키로 principal 을 채운다.
+                .addFilterAfter(
+                        new SessionCookieAuthenticationFilter(sessionAuthenticationService),
+                        JwtAuthenticationFilter.class
                 )
                 .build();
     }

--- a/src/main/java/com/readum/presentation/common/security/SessionCookieAuthenticationFilter.java
+++ b/src/main/java/com/readum/presentation/common/security/SessionCookieAuthenticationFilter.java
@@ -1,0 +1,84 @@
+package com.readum.presentation.common.security;
+
+import com.readum.domain.auth.service.SessionAuthenticationService;
+import com.readum.domain.exception.UnauthorizedException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * user_session 쿠키 인증 필터 — 쿠키를 해석해 principal 에 userId(Long) 를 채운다.
+ * principal 의 모양(userId + ROLE_*)은 JwtAuthenticationFilter 와 동일하게 맞춰,
+ * 아래 계층이 신원의 출처(쿠키/토큰)를 구분할 수 없게 한다.
+ * 401 판정은 이 필터가 아니라 SecurityConfig 의 인가 규칙이 담당한다 — 해석 실패 시 채우지 않고 통과만 한다.
+ * 소셜 로그인(JWT) 도입 시 이 필터는 게스트 인증 담당으로 남을 수 있다 — 그때 권한만 GUEST 로 바꾼다.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class SessionCookieAuthenticationFilter extends OncePerRequestFilter {
+
+    static final String USER_SESSION_COOKIE = "user_session";
+    // 소셜 로그인 도입 시 게스트 구분이 필요해지면 이 값만 "GUEST" 로 바꾼다.
+    private static final String SESSION_USER_ROLE = "USER";
+
+    private final SessionAuthenticationService sessionAuthenticationService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String userSessionId = extractSessionCookie(request);
+        if (userSessionId == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            Long userId = sessionAuthenticationService.authenticate(userSessionId);
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    userId,
+                    null,
+                    List.of(new SimpleGrantedAuthority("ROLE_" + SESSION_USER_ROLE))
+            );
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (UnauthorizedException ex) {
+            log.warn("세션 쿠키 검증 실패 uri={} errorCode={}",
+                    request.getRequestURI(), ex.getErrorCode().name());
+            SecurityContextHolder.clearContext();
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private String extractSessionCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        for (Cookie cookie : cookies) {
+            if (USER_SESSION_COOKIE.equals(cookie.getName())) {
+                String value = cookie.getValue();
+                return (value == null || value.isBlank()) ? null : value;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/readum/presentation/controller/aiChat/AiChatController.java
+++ b/src/main/java/com/readum/presentation/controller/aiChat/AiChatController.java
@@ -16,6 +16,7 @@ import com.readum.domain.aiChat.service.SummaryEditService;
 import com.readum.domain.summary.dto.SummaryResult;
 import com.readum.domain.summary.service.SummarySearchService;
 import com.readum.presentation.common.GlobalApiResponse;
+import com.readum.presentation.common.security.AuthenticatedUserId;
 import com.readum.presentation.controller.aiChat.dto.AiChatSessionCreateRequest;
 import com.readum.presentation.controller.aiChat.dto.AiChatSessionCreateResponse;
 import com.readum.presentation.controller.aiChat.dto.AiChatSessionListRequest;
@@ -38,7 +39,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.ServerSentEvent;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -78,10 +78,10 @@ public class AiChatController {
     })
     @PostMapping("/sessions")
     public ResponseEntity<GlobalApiResponse<AiChatSessionCreateResponse>> createSession(
-            @CookieValue(name = "user_session") String userSessionId,
+            @AuthenticatedUserId Long userId,
             @Valid @RequestBody AiChatSessionCreateRequest request
     ) {
-        AiChatSessionCreateResult result = aiChatSessionCreateService.execute(request.toCommand(userSessionId));
+        AiChatSessionCreateResult result = aiChatSessionCreateService.execute(request.toCommand(userId));
         return GlobalApiResponse.created(AiChatSessionCreateResponse.from(result));
     }
 
@@ -103,10 +103,10 @@ public class AiChatController {
     })
     @GetMapping("/sessions")
     public ResponseEntity<GlobalApiResponse<AiChatSessionListResponse>> getSessions(
-            @CookieValue(name = "user_session") String userSessionId,
+            @AuthenticatedUserId Long userId,
             @Valid @ModelAttribute AiChatSessionListRequest request
     ) {
-        AiChatSessionListResult result = aiChatSessionSearchService.findByUserBookId(request.toCommand(userSessionId));
+        AiChatSessionListResult result = aiChatSessionSearchService.findByUserBookId(request.toCommand(userId));
         return GlobalApiResponse.ok(AiChatSessionListResponse.from(result));
     }
 
@@ -123,10 +123,10 @@ public class AiChatController {
     })
     @GetMapping("/books/{userBookId}/sessions")
     public ResponseEntity<GlobalApiResponse<BookChatSessionsResponse>> getBookChatSessions(
-            @CookieValue(name = "user_session") String userSessionId,
+            @AuthenticatedUserId Long userId,
             @PathVariable Long userBookId
     ) {
-        BookChatSessionsResult result = bookChatSessionSearchService.findByUserBook(userBookId, userSessionId);
+        BookChatSessionsResult result = bookChatSessionSearchService.findByUserBook(userBookId, userId);
         return GlobalApiResponse.ok(BookChatSessionsResponse.from(result));
     }
 
@@ -203,12 +203,12 @@ public class AiChatController {
     })
     @PostMapping(value = "/sessions/{sessionId}/messages", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<Flux<ServerSentEvent<String>>> sendMessage(
-            @CookieValue(name = "user_session") String userSessionId,
+            @AuthenticatedUserId Long userId,
             @PathVariable Long sessionId,
             @Valid @RequestBody SendMessageRequest request
     ) {
         Flux<ServerSentEvent<String>> stream = aiChatMessageSendService
-                .execute(request.toCommand(userSessionId, sessionId))
+                .execute(request.toCommand(userId, sessionId))
                 .map(messageStreamSseSerializer::toServerSentEvent);
         return ResponseEntity.ok(stream);
     }
@@ -226,11 +226,11 @@ public class AiChatController {
     })
     @GetMapping("/sessions/{sessionId}/messages")
     public ResponseEntity<GlobalApiResponse<MessageListResponse>> getMessages(
-            @CookieValue(name = "user_session") String userSessionId,
+            @AuthenticatedUserId Long userId,
             @PathVariable Long sessionId,
             @Valid @ModelAttribute MessageListRequest request
     ) {
-        MessageListResult result = aiChatMessageSearchService.findBySessionId(request.toCommand(userSessionId, sessionId));
+        MessageListResult result = aiChatMessageSearchService.findBySessionId(request.toCommand(userId, sessionId));
         return GlobalApiResponse.ok(MessageListResponse.from(result));
     }
 
@@ -256,10 +256,10 @@ public class AiChatController {
     })
     @GetMapping("/sessions/{sessionId}/summary")
     public ResponseEntity<GlobalApiResponse<SummaryResponse>> getSummary(
-            @CookieValue(name = "user_session") String userSessionId,
+            @AuthenticatedUserId Long userId,
             @PathVariable Long sessionId
     ) {
-        SummaryResult result = summarySearchService.findBySessionId(sessionId, userSessionId);
+        SummaryResult result = summarySearchService.findBySessionId(sessionId, userId);
         return GlobalApiResponse.ok(SummaryResponse.from(result));
     }
 
@@ -275,11 +275,11 @@ public class AiChatController {
     })
     @PutMapping("/sessions/{sessionId}/summary")
     public ResponseEntity<GlobalApiResponse<SummaryResponse>> editSummary(
-            @CookieValue(name = "user_session") String userSessionId,
+            @AuthenticatedUserId Long userId,
             @PathVariable Long sessionId,
             @Valid @RequestBody SummaryEditRequest request
     ) {
-        SummaryResult result = summaryEditService.execute(request.toCommand(userSessionId, sessionId));
+        SummaryResult result = summaryEditService.execute(request.toCommand(userId, sessionId));
         return GlobalApiResponse.ok(SummaryResponse.from(result));
     }
 
@@ -296,10 +296,10 @@ public class AiChatController {
     })
     @GetMapping("/sessions/{sessionId}/summary-draft/eligibility")
     public ResponseEntity<GlobalApiResponse<SummaryDraftEligibilityResponse>> getSummaryDraftEligibility(
-            @CookieValue(name = "user_session") String userSessionId,
+            @AuthenticatedUserId Long userId,
             @PathVariable Long sessionId
     ) {
-        SummaryDraftEligibilityResult result = summaryDraftSearchService.findEligibility(sessionId, userSessionId);
+        SummaryDraftEligibilityResult result = summaryDraftSearchService.findEligibility(sessionId, userId);
         return GlobalApiResponse.ok(SummaryDraftEligibilityResponse.from(result));
     }
 
@@ -324,10 +324,10 @@ public class AiChatController {
     })
     @PostMapping("/sessions/{sessionId}/summary-draft")
     public ResponseEntity<Void> createSummaryDraft(
-            @CookieValue(name = "user_session") String userSessionId,
+            @AuthenticatedUserId Long userId,
             @PathVariable Long sessionId
     ) {
-        summaryDraftService.execute(sessionId, userSessionId);
+        summaryDraftService.execute(sessionId, userId);
         return ResponseEntity.accepted().build();
     }
 }

--- a/src/main/java/com/readum/presentation/controller/aiChat/AiChatController.java
+++ b/src/main/java/com/readum/presentation/controller/aiChat/AiChatController.java
@@ -4,6 +4,7 @@ import com.readum.domain.aiChat.dto.AiChatSessionCreateResult;
 import com.readum.domain.aiChat.dto.AiChatSessionListResult;
 import com.readum.domain.aiChat.dto.BookChatSessionsResult;
 import com.readum.domain.aiChat.dto.MessageListResult;
+import com.readum.domain.aiChat.dto.SummaryDraftCommand;
 import com.readum.domain.aiChat.dto.SummaryDraftEligibilityResult;
 import com.readum.domain.aiChat.service.AiChatMessageSearchService;
 import com.readum.domain.aiChat.service.AiChatMessageSendService;
@@ -327,7 +328,7 @@ public class AiChatController {
             @AuthenticatedUserId Long userId,
             @PathVariable Long sessionId
     ) {
-        summaryDraftService.execute(sessionId, userId);
+        summaryDraftService.execute(new SummaryDraftCommand(userId, sessionId));
         return ResponseEntity.accepted().build();
     }
 }

--- a/src/main/java/com/readum/presentation/controller/aiChat/dto/AiChatSessionCreateRequest.java
+++ b/src/main/java/com/readum/presentation/controller/aiChat/dto/AiChatSessionCreateRequest.java
@@ -10,7 +10,7 @@ public record AiChatSessionCreateRequest(
         Long userBookId
 ) {
 
-    public AiChatSessionCreateCommand toCommand(String userSessionId) {
-        return new AiChatSessionCreateCommand(userSessionId, userBookId);
+    public AiChatSessionCreateCommand toCommand(Long userId) {
+        return new AiChatSessionCreateCommand(userId, userBookId);
     }
 }

--- a/src/main/java/com/readum/presentation/controller/aiChat/dto/AiChatSessionListRequest.java
+++ b/src/main/java/com/readum/presentation/controller/aiChat/dto/AiChatSessionListRequest.java
@@ -19,7 +19,7 @@ public record AiChatSessionListRequest(
         int size
 ) {
 
-    public AiChatSessionListCommand toCommand(String userSessionId) {
-        return new AiChatSessionListCommand(userSessionId, userBookId, page, size);
+    public AiChatSessionListCommand toCommand(Long userId) {
+        return new AiChatSessionListCommand(userId, userBookId, page, size);
     }
 }

--- a/src/main/java/com/readum/presentation/controller/aiChat/dto/MessageListRequest.java
+++ b/src/main/java/com/readum/presentation/controller/aiChat/dto/MessageListRequest.java
@@ -13,7 +13,7 @@ public record MessageListRequest(
         int size
 ) {
 
-    public MessageListCommand toCommand(String userSessionId, Long sessionId) {
-        return new MessageListCommand(userSessionId, sessionId, page, size);
+    public MessageListCommand toCommand(Long userId, Long sessionId) {
+        return new MessageListCommand(userId, sessionId, page, size);
     }
 }

--- a/src/main/java/com/readum/presentation/controller/aiChat/dto/SendMessageRequest.java
+++ b/src/main/java/com/readum/presentation/controller/aiChat/dto/SendMessageRequest.java
@@ -13,7 +13,7 @@ public record SendMessageRequest(
         String content
 ) {
 
-    public SendMessageCommand toCommand(String userSessionId, Long sessionId) {
-        return new SendMessageCommand(userSessionId, sessionId, content);
+    public SendMessageCommand toCommand(Long userId, Long sessionId) {
+        return new SendMessageCommand(userId, sessionId, content);
     }
 }

--- a/src/main/java/com/readum/presentation/controller/aiChat/dto/SummaryEditRequest.java
+++ b/src/main/java/com/readum/presentation/controller/aiChat/dto/SummaryEditRequest.java
@@ -14,7 +14,7 @@ public record SummaryEditRequest(
         String body
 ) {
 
-    public SummaryEditCommand toCommand(String userSessionId, Long sessionId) {
-        return new SummaryEditCommand(userSessionId, sessionId, title, body);
+    public SummaryEditCommand toCommand(Long userId, Long sessionId) {
+        return new SummaryEditCommand(userId, sessionId, title, body);
     }
 }

--- a/src/main/java/com/readum/presentation/controller/summary/SummaryController.java
+++ b/src/main/java/com/readum/presentation/controller/summary/SummaryController.java
@@ -6,6 +6,7 @@ import com.readum.domain.summary.dto.SummaryResult;
 import com.readum.domain.summary.service.SummaryHistorySearchService;
 import com.readum.domain.summary.service.SummarySearchService;
 import com.readum.presentation.common.GlobalApiResponse;
+import com.readum.presentation.common.security.AuthenticatedUserId;
 import com.readum.presentation.controller.summary.dto.MonthlyReadingRecordsResponse;
 import com.readum.presentation.controller.summary.dto.SummaryDetailResponse;
 import com.readum.presentation.controller.summary.dto.SummaryHistoryListRequest;
@@ -17,7 +18,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -53,10 +53,10 @@ public class SummaryController {
     })
     @GetMapping
     public ResponseEntity<GlobalApiResponse<SummaryHistoryListResponse>> getMyHistory(
-            @CookieValue(name = "user_session") String userSessionId,
+            @AuthenticatedUserId Long userId,
             @Valid @ModelAttribute SummaryHistoryListRequest request
     ) {
-        SummaryHistoryListResult result = summaryHistorySearchService.findMyHistory(request.toCommand(userSessionId));
+        SummaryHistoryListResult result = summaryHistorySearchService.findMyHistory(request.toCommand(userId));
         return GlobalApiResponse.ok(SummaryHistoryListResponse.from(result));
     }
 
@@ -77,10 +77,10 @@ public class SummaryController {
     })
     @GetMapping("/calendar")
     public ResponseEntity<GlobalApiResponse<MonthlyReadingRecordsResponse>> getMonthlyReadingRecords(
-            @CookieValue(name = "user_session") String userSessionId,
+            @AuthenticatedUserId Long userId,
             @RequestParam YearMonth yearMonth
     ) {
-        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(yearMonth, userSessionId);
+        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(yearMonth, userId);
         return GlobalApiResponse.ok(MonthlyReadingRecordsResponse.from(results));
     }
 
@@ -99,10 +99,10 @@ public class SummaryController {
     })
     @GetMapping("/{summaryId}")
     public ResponseEntity<GlobalApiResponse<SummaryDetailResponse>> getSummaryDetail(
-            @CookieValue(name = "user_session") String userSessionId,
+            @AuthenticatedUserId Long userId,
             @PathVariable Long summaryId
     ) {
-        SummaryResult result = summarySearchService.findById(summaryId, userSessionId);
+        SummaryResult result = summarySearchService.findById(summaryId, userId);
         return GlobalApiResponse.ok(SummaryDetailResponse.from(result));
     }
 }

--- a/src/main/java/com/readum/presentation/controller/summary/dto/SummaryHistoryListRequest.java
+++ b/src/main/java/com/readum/presentation/controller/summary/dto/SummaryHistoryListRequest.java
@@ -8,7 +8,7 @@ public record SummaryHistoryListRequest(
         int page
 ) {
 
-    public SummaryHistoryListCommand toCommand(String userSessionId) {
-        return new SummaryHistoryListCommand(userSessionId, page);
+    public SummaryHistoryListCommand toCommand(Long userId) {
+        return new SummaryHistoryListCommand(userId, page);
     }
 }

--- a/src/main/java/com/readum/presentation/controller/user/UserBookController.java
+++ b/src/main/java/com/readum/presentation/controller/user/UserBookController.java
@@ -71,7 +71,7 @@ public class UserBookController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공 (등록 도서 0건이면 빈 배열)"),
-            @ApiResponse(responseCode = "401", description = "user_session 쿠키 누락 또는 유효하지 않은 세션")
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
     })
     @GetMapping
     public ResponseEntity<GlobalApiResponse<UserBookListResponse>> list(
@@ -89,7 +89,7 @@ public class UserBookController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "삭제 성공 (응답 본문 없음)"),
-            @ApiResponse(responseCode = "401", description = "user_session 쿠키 누락 또는 유효하지 않은 세션"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
             @ApiResponse(responseCode = "404", description = "본인 책장에 등록되지 않은 도서")
     })
     @DeleteMapping("/{userBookId}")

--- a/src/main/java/com/readum/presentation/controller/user/UserBookController.java
+++ b/src/main/java/com/readum/presentation/controller/user/UserBookController.java
@@ -7,6 +7,7 @@ import com.readum.domain.user.userbook.service.UserBookCreateService;
 import com.readum.domain.user.userbook.service.UserBookDeleteService;
 import com.readum.domain.user.userbook.service.UserBookSearchService;
 import com.readum.presentation.common.GlobalApiResponse;
+import com.readum.presentation.common.security.AuthenticatedUserId;
 import com.readum.presentation.controller.user.dto.UserBookCreateRequest;
 import com.readum.presentation.controller.user.dto.UserBookListResponse;
 import com.readum.presentation.controller.user.dto.UserBookResponse;
@@ -18,7 +19,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -51,9 +51,9 @@ public class UserBookController {
     })
     @PostMapping
     public ResponseEntity<GlobalApiResponse<UserBookResponse>> create(
-            @CookieValue(name = "user_session") String userSessionId,
+            @AuthenticatedUserId Long userId,
             @Valid @RequestBody UserBookCreateRequest request) {
-        UserBookCreateResult result = userBookCreateService.execute(request.toCommand(userSessionId));
+        UserBookCreateResult result = userBookCreateService.execute(request.toCommand(userId));
         UserBookResponse response = UserBookResponse.from(result);
 
         return ResponseEntity
@@ -75,8 +75,8 @@ public class UserBookController {
     })
     @GetMapping
     public ResponseEntity<GlobalApiResponse<UserBookListResponse>> list(
-            @CookieValue(name = "user_session") String userSessionId) {
-        UserBookSearchResult result = userBookSearchService.findMyBooks(userSessionId);
+            @AuthenticatedUserId Long userId) {
+        UserBookSearchResult result = userBookSearchService.findMyBooks(userId);
         return GlobalApiResponse.ok(UserBookListResponse.from(result));
     }
 
@@ -94,9 +94,9 @@ public class UserBookController {
     })
     @DeleteMapping("/{userBookId}")
     public ResponseEntity<Void> delete(
-            @CookieValue(name = "user_session") String userSessionId,
+            @AuthenticatedUserId Long userId,
             @PathVariable Long userBookId) {
-        userBookDeleteService.execute(new UserBookDeleteCommand(userSessionId, userBookId));
+        userBookDeleteService.execute(new UserBookDeleteCommand(userId, userBookId));
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/readum/presentation/controller/user/UserController.java
+++ b/src/main/java/com/readum/presentation/controller/user/UserController.java
@@ -10,6 +10,7 @@ import com.readum.domain.user.service.CreateUserSessionService;
 import com.readum.domain.user.service.UpdateNicknameService;
 import com.readum.domain.user.service.UserSearchService;
 import com.readum.presentation.common.GlobalApiResponse;
+import com.readum.presentation.common.security.AuthenticatedUserId;
 import com.readum.presentation.controller.user.dto.CompleteOnboardingResponse;
 import com.readum.presentation.controller.user.dto.CreateUserSessionResponse;
 import com.readum.presentation.controller.user.dto.UpdateNicknameRequest;
@@ -26,7 +27,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -81,8 +81,8 @@ public class UserController {
     })
     @GetMapping("/me")
     public ResponseEntity<GlobalApiResponse<UserSessionInfoResponse>> getSessionInfo(
-            @CookieValue(name = USER_SESSION_COOKIE, required = true) String sessionId) {
-        UserSessionInfoResult result = userSearchService.findSessionInfo(sessionId);
+            @AuthenticatedUserId Long userId) {
+        UserSessionInfoResult result = userSearchService.findSessionInfo(userId);
         return GlobalApiResponse.ok(UserSessionInfoResponse.from(result));
     }
 
@@ -96,8 +96,8 @@ public class UserController {
     })
     @GetMapping("/me/profile")
     public ResponseEntity<GlobalApiResponse<UserProfileResponse>> getProfile(
-            @CookieValue(name = USER_SESSION_COOKIE, required = true) String sessionId) {
-        UserProfileResult result = userSearchService.findProfile(sessionId);
+            @AuthenticatedUserId Long userId) {
+        UserProfileResult result = userSearchService.findProfile(userId);
         return GlobalApiResponse.ok(UserProfileResponse.from(result));
     }
 
@@ -111,8 +111,8 @@ public class UserController {
     })
     @PostMapping("/me/onboarding")
     public ResponseEntity<GlobalApiResponse<CompleteOnboardingResponse>> completeOnboarding(
-            @CookieValue(name = USER_SESSION_COOKIE, required = true) String sessionId) {
-        CompleteOnboardingResult result = completeOnboardingService.execute(sessionId);
+            @AuthenticatedUserId Long userId) {
+        CompleteOnboardingResult result = completeOnboardingService.execute(userId);
         return GlobalApiResponse.ok(CompleteOnboardingResponse.from(result));
     }
 
@@ -128,9 +128,9 @@ public class UserController {
     })
     @PutMapping("/me/nickname")
     public ResponseEntity<GlobalApiResponse<UpdateNicknameResponse>> updateNickname(
-            @CookieValue(name = USER_SESSION_COOKIE, required = true) String sessionId,
+            @AuthenticatedUserId Long userId,
             @RequestBody UpdateNicknameRequest request) {
-        UpdateNicknameResult result = updateNicknameService.execute(request.toCommand(sessionId));
+        UpdateNicknameResult result = updateNicknameService.execute(request.toCommand(userId));
         return GlobalApiResponse.ok(UpdateNicknameResponse.from(result));
     }
 

--- a/src/main/java/com/readum/presentation/controller/user/UserController.java
+++ b/src/main/java/com/readum/presentation/controller/user/UserController.java
@@ -77,7 +77,7 @@ public class UserController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "user_session 쿠키 누락 또는 유효하지 않은 세션")
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
     })
     @GetMapping("/me")
     public ResponseEntity<GlobalApiResponse<UserSessionInfoResponse>> getSessionInfo(
@@ -92,7 +92,7 @@ public class UserController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "user_session 쿠키 누락 또는 유효하지 않은 세션")
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
     })
     @GetMapping("/me/profile")
     public ResponseEntity<GlobalApiResponse<UserProfileResponse>> getProfile(
@@ -107,7 +107,7 @@ public class UserController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "온보딩 완료 처리 성공"),
-            @ApiResponse(responseCode = "401", description = "user_session 쿠키 누락 또는 유효하지 않은 세션")
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
     })
     @PostMapping("/me/onboarding")
     public ResponseEntity<GlobalApiResponse<CompleteOnboardingResponse>> completeOnboarding(
@@ -124,7 +124,7 @@ public class UserController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "닉네임 수정 성공"),
             @ApiResponse(responseCode = "400", description = "닉네임 형식이 올바르지 않음"),
-            @ApiResponse(responseCode = "401", description = "user_session 쿠키 누락 또는 유효하지 않은 세션")
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
     })
     @PutMapping("/me/nickname")
     public ResponseEntity<GlobalApiResponse<UpdateNicknameResponse>> updateNickname(

--- a/src/main/java/com/readum/presentation/controller/user/dto/UpdateNicknameRequest.java
+++ b/src/main/java/com/readum/presentation/controller/user/dto/UpdateNicknameRequest.java
@@ -4,7 +4,7 @@ import com.readum.domain.user.dto.UpdateNicknameCommand;
 
 public record UpdateNicknameRequest(String nickname) {
 
-    public UpdateNicknameCommand toCommand(String sessionId) {
-        return new UpdateNicknameCommand(sessionId, nickname);
+    public UpdateNicknameCommand toCommand(Long userId) {
+        return new UpdateNicknameCommand(userId, nickname);
     }
 }

--- a/src/main/java/com/readum/presentation/controller/user/dto/UserBookCreateRequest.java
+++ b/src/main/java/com/readum/presentation/controller/user/dto/UserBookCreateRequest.java
@@ -10,7 +10,7 @@ public record UserBookCreateRequest(
         @NotBlank String bookExternalId
 ) {
 
-    public UserBookCreateCommand toCommand(String userSessionId) {
-        return new UserBookCreateCommand(userSessionId, bookExternalId);
+    public UserBookCreateCommand toCommand(Long userId) {
+        return new UserBookCreateCommand(userId, bookExternalId);
     }
 }

--- a/src/test/java/com/readum/architecture/AuthenticationBoundaryArchTest.java
+++ b/src/test/java/com/readum/architecture/AuthenticationBoundaryArchTest.java
@@ -1,0 +1,58 @@
+package com.readum.architecture;
+
+import com.readum.domain.auth.service.SessionAuthenticationService;
+import com.readum.model.user.repository.UserRepository;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.springframework.web.bind.annotation.CookieValue;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * 인증 신원 해석 일원화 규칙 (2026-06-20 429 사고 재발 방지).
+ * 신원은 인증 필터가 해석해 principal 로만 전달한다 — 다른 컴포넌트가
+ * 쿠키/SecurityContext 를 직접 뒤지는 코드를 빌드 단계에서 차단한다.
+ */
+@AnalyzeClasses(packages = "com.readum", importOptions = ImportOption.DoNotIncludeTests.class)
+class AuthenticationBoundaryArchTest {
+
+    @ArchTest
+    static final ArchRule SecurityContextHolder_는_security_패키지_밖에서_직접_참조하지_않는다 =
+            noClasses()
+                    .that().resideOutsideOfPackage("com.readum.presentation.common.security")
+                    .should().dependOnClassesThat()
+                    .haveFullyQualifiedName("org.springframework.security.core.context.SecurityContextHolder")
+                    .because("신원은 @AuthenticatedUserId 로만 받는다 — SecurityContext 직접 접근은 인증 필터/리졸버의 책임");
+
+    @ArchTest
+    static final ArchRule user_session_쿠키는_컨트롤러가_직접_받지_않는다 =
+            methods().should(new ArchCondition<>("user_session 을 @CookieValue 로 직접 받지 않는다") {
+                @Override
+                public void check(JavaMethod method, ConditionEvents events) {
+                    method.getParameters().forEach(parameter ->
+                            parameter.tryGetAnnotationOfType(CookieValue.class).ifPresent(cookieValue -> {
+                                String cookieName = !cookieValue.name().isEmpty()
+                                        ? cookieValue.name()
+                                        : cookieValue.value();
+                                if ("user_session".equals(cookieName)) {
+                                    events.add(SimpleConditionEvent.violated(method,
+                                            method.getFullName() + " 가 user_session 쿠키를 직접 받는다 — @AuthenticatedUserId 를 사용할 것"));
+                                }
+                            }));
+                }
+            }).because("신원 수령 통로는 @AuthenticatedUserId 하나다");
+
+    @ArchTest
+    static final ArchRule findBySessionId_는_SessionAuthenticationService_만_호출한다 =
+            noClasses()
+                    .that().doNotHaveFullyQualifiedName(SessionAuthenticationService.class.getName())
+                    .should().callMethod(UserRepository.class, "findBySessionId", String.class)
+                    .because("세션 쿠키 → 사용자 해석은 SessionAuthenticationService 한 곳에서만 일어난다");
+}

--- a/src/test/java/com/readum/domain/aiChat/service/AiChatMessageSearchServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/AiChatMessageSearchServiceTest.java
@@ -4,19 +4,13 @@ import com.readum.domain.aiChat.dto.MessageListCommand;
 import com.readum.domain.aiChat.dto.MessageListResult;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.aiChat.entity.AiChatMessage;
 import com.readum.model.aiChat.entity.AiChatMessageFixture;
 import com.readum.model.aiChat.entity.AiChatSession;
 import com.readum.model.aiChat.entity.AiChatSessionFixture;
 import com.readum.model.aiChat.repository.AiChatMessageRepository;
 import com.readum.model.aiChat.repository.AiChatSessionRepository;
-import com.readum.model.user.entity.User;
-import com.readum.model.user.entity.UserFixture;
-import com.readum.model.user.repository.UserRepository;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -31,16 +25,11 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class AiChatMessageSearchServiceTest {
 
     private static final Long USER_ID = 1L;
-    private static final String USER_SESSION_ID = "test-session-id";
-
-    @Mock
-    private UserRepository userRepository;
 
     @Mock
     private AiChatSessionRepository aiChatSessionRepository;
@@ -51,31 +40,13 @@ class AiChatMessageSearchServiceTest {
     @InjectMocks
     private AiChatMessageSearchService aiChatMessageSearchService;
 
-    @BeforeEach
-    void setUp() {
-        User testUser = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
-        lenient().when(userRepository.findBySessionId(USER_SESSION_ID)).thenReturn(Optional.of(testUser));
-    }
-
-    @Test
-    void 유효하지_않은_session_쿠키면_UnauthorizedException() {
-        given(userRepository.findBySessionId("invalid")).willReturn(Optional.empty());
-
-        assertThatThrownBy(() -> aiChatMessageSearchService.findBySessionId(
-                new MessageListCommand("invalid", 7L, 1, 20)
-        ))
-                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
-                .extracting(UnauthorizedException::getErrorCode)
-                .isEqualTo(UserErrorCode.INVALID_SESSION);
-    }
-
     @Test
     void 소유권_없는_세션이면_NotFoundException() {
         Long sessionId = 7L;
         given(aiChatSessionRepository.findByIdAndOwner(sessionId, USER_ID)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> aiChatMessageSearchService.findBySessionId(
-                new MessageListCommand(USER_SESSION_ID, sessionId, 1, 20)
+                new MessageListCommand(USER_ID, sessionId, 1, 20)
         ))
                 .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
                 .extracting(NotFoundException::getErrorCode)
@@ -103,7 +74,7 @@ class AiChatMessageSearchServiceTest {
         )).willReturn(new SliceImpl<>(rows, PageRequest.of(0, 20), false));
 
         MessageListResult result = aiChatMessageSearchService.findBySessionId(
-                new MessageListCommand(USER_SESSION_ID, sessionId, 1, 20)
+                new MessageListCommand(USER_ID, sessionId, 1, 20)
         );
 
         assertThat(result.messages()).hasSize(2);

--- a/src/test/java/com/readum/domain/aiChat/service/AiChatMessageSendServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/AiChatMessageSendServiceTest.java
@@ -15,15 +15,11 @@ import com.readum.domain.exception.NotFoundException;
 import com.readum.domain.exception.RateLimitInfo;
 import com.readum.domain.exception.ServiceUnavailableException;
 import com.readum.domain.exception.TooManyRequestsException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.aiChat.entity.AiChatMessage;
 import com.readum.model.aiChat.entity.AiChatMessageFixture;
 import com.readum.model.aiChat.repository.AiChatMessageRepository;
 import com.readum.model.book.repository.BookRepository;
-import com.readum.model.user.entity.User;
-import com.readum.model.user.entity.UserFixture;
 import com.readum.model.user.repository.UserBookRepository;
-import com.readum.model.user.repository.UserRepository;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,10 +56,6 @@ import static org.mockito.Mockito.verify;
 class AiChatMessageSendServiceTest {
 
     private static final Long USER_ID = 1L;
-    private static final String USER_SESSION_ID = "test-session-id";
-
-    @Mock
-    private UserRepository userRepository;
 
     @Mock
     private AiChatMessagePersistService persistService;
@@ -94,14 +86,11 @@ class AiChatMessageSendServiceTest {
 
     @BeforeEach
     void setUp() {
-        User testUser = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
-        lenient().when(userRepository.findBySessionId(USER_SESSION_ID))
-                .thenReturn(java.util.Optional.of(testUser));
         // 입력 가드레일 기본값: 통과. 차단/장애 케이스는 각 테스트에서 override.
         lenient().when(inputModerationClient.check(anyString(), any()))
                 .thenReturn(InputModerationResult.passed());
         service = new AiChatMessageSendService(
-                userRepository, persistService, aiChatClient, aiChatProperties,
+                persistService, aiChatClient, aiChatProperties,
                 aiChatMessageRepository, userBookRepository, bookRepository, inputModerationClient
         );
     }
@@ -113,7 +102,7 @@ class AiChatMessageSendServiceTest {
 
     @Test
     void 빈_본문이면_BadRequest_MESSAGE_CONTENT_BLANK() {
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, 7L, "   ");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, 7L, "   ");
 
         assertThatThrownBy(() -> service.execute(command))
                 .asInstanceOf(InstanceOfAssertFactories.type(BadRequestException.class))
@@ -125,7 +114,7 @@ class AiChatMessageSendServiceTest {
 
     @Test
     void NBSP_등_유니코드_공백만_있으면_BadRequest_MESSAGE_CONTENT_BLANK() {
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, 7L, "   ");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, 7L, "   ");
 
         assertThatThrownBy(() -> service.execute(command))
                 .asInstanceOf(InstanceOfAssertFactories.type(BadRequestException.class))
@@ -137,7 +126,7 @@ class AiChatMessageSendServiceTest {
 
     @Test
     void 본문이_4001자면_BadRequest_MESSAGE_CONTENT_TOO_LONG() {
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, 7L, "가".repeat(4001));
+        SendMessageCommand command = new SendMessageCommand(USER_ID, 7L, "가".repeat(4001));
 
         assertThatThrownBy(() -> service.execute(command))
                 .asInstanceOf(InstanceOfAssertFactories.type(BadRequestException.class))
@@ -149,7 +138,7 @@ class AiChatMessageSendServiceTest {
 
     @Test
     void 최근_USER_메시지_카운트가_한도_미만이면_rate_limit_검사를_통과한다() {
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, 7L, "질문");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, 7L, "질문");
         given(aiChatMessageRepository.countRecentUserMessagesByOwner(eq(1L), any(LocalDateTime.class)))
                 .willReturn(4L);
         givenLoadHistory(7L, List.of(), 100L);
@@ -166,7 +155,7 @@ class AiChatMessageSendServiceTest {
 
     @Test
     void 최근_USER_메시지_카운트가_한도_도달이면_TooManyRequestsException_을_던진다() {
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, 7L, "질문");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, 7L, "질문");
         given(aiChatMessageRepository.countRecentUserMessagesByOwner(eq(1L), any(LocalDateTime.class)))
                 .willReturn(5L);
 
@@ -182,7 +171,7 @@ class AiChatMessageSendServiceTest {
     @Test
     void 거부_카운트가_거부_한도에_도달하면_정상_카운트가_0이어도_차단된다() {
         // 정상/거부 카운터 독립(AC-14): 정상 메시지가 0 건이어도 거부 한도(20) 도달이면 차단.
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, 7L, "질문");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, 7L, "질문");
         given(aiChatMessageRepository.countRecentUserMessagesByOwner(eq(1L), any(LocalDateTime.class)))
                 .willReturn(0L);
         given(aiChatMessageRepository.countRecentRejectedMessagesByOwner(eq(1L), any(LocalDateTime.class)))
@@ -200,7 +189,7 @@ class AiChatMessageSendServiceTest {
     @Test
     void 거부_카운트가_높아도_거부_한도_미만이면_정상_채팅은_차단되지_않는다() {
         // 정상/거부 카운터 독립(AC-14): false-positive 로 거부가 19건 쌓여도(한도 20 미만) 정상 채팅은 통과.
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, 7L, "질문");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, 7L, "질문");
         given(aiChatMessageRepository.countRecentUserMessagesByOwner(eq(1L), any(LocalDateTime.class)))
                 .willReturn(4L);
         given(aiChatMessageRepository.countRecentRejectedMessagesByOwner(eq(1L), any(LocalDateTime.class)))
@@ -217,7 +206,7 @@ class AiChatMessageSendServiceTest {
 
     @Test
     void 한도_초과_시_RateLimitInfo_에_retryAfter_와_limit_정보가_담긴다() {
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, 7L, "질문");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, 7L, "질문");
         given(aiChatMessageRepository.countRecentUserMessagesByOwner(eq(1L), any(LocalDateTime.class)))
                 .willReturn(7L);
 
@@ -234,7 +223,7 @@ class AiChatMessageSendServiceTest {
 
     @Test
     void rate_limit_카운트_쿼리는_count_period_초만큼_과거_시점부터_조회한다() {
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, 7L, "질문");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, 7L, "질문");
         given(aiChatMessageRepository.countRecentUserMessagesByOwner(eq(1L), any(LocalDateTime.class)))
                 .willReturn(0L);
         givenLoadHistory(7L, List.of(), 100L);
@@ -257,7 +246,7 @@ class AiChatMessageSendServiceTest {
 
     @Test
     void 사전_단계에서_NotFoundException_이_던져지면_그대로_전파된다() {
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, 7L, "질문");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, 7L, "질문");
         given(persistService.loadHistory(7L, 1L))
                 .willThrow(new NotFoundException(AiChatErrorCode.SESSION_NOT_FOUND));
 
@@ -269,7 +258,7 @@ class AiChatMessageSendServiceTest {
 
     @Test
     void 사전_단계에서_BadRequestException_SESSION_LOCKED_도_그대로_전파된다() {
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, 7L, "질문");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, 7L, "질문");
         given(persistService.loadHistory(7L, 1L))
                 .willThrow(new BadRequestException(AiChatErrorCode.SESSION_LOCKED));
 
@@ -281,7 +270,7 @@ class AiChatMessageSendServiceTest {
 
     @Test
     void 입력_가드레일에_차단되면_REJECTED_저장_후_BadRequest_를_던지고_스트림은_시작하지_않는다() {
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, 7L, "차단 대상");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, 7L, "차단 대상");
         givenLoadHistory(7L, List.of(), 100L);
         given(inputModerationClient.check(eq("차단 대상"), any()))
                 .willReturn(InputModerationResult.blocked(List.of("self-harm")));
@@ -298,7 +287,7 @@ class AiChatMessageSendServiceTest {
 
     @Test
     void 입력_가드레일_차단_응답_메시지는_거부_정본_텍스트다() {
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, 7L, "차단 대상");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, 7L, "차단 대상");
         givenLoadHistory(7L, List.of(), 100L);
         given(inputModerationClient.check(eq("차단 대상"), any()))
                 .willReturn(InputModerationResult.blocked(List.of("sexual-minors")));
@@ -310,7 +299,7 @@ class AiChatMessageSendServiceTest {
 
     @Test
     void Moderation_API_장애_UNAVAILABLE_이면_저장없이_ServiceUnavailable_을_던진다() {
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, 7L, "질문");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, 7L, "질문");
         givenLoadHistory(7L, List.of(), 100L);
         given(inputModerationClient.check(eq("질문"), any()))
                 .willReturn(InputModerationResult.serviceUnavailable("OpenAI Moderation 502"));
@@ -328,7 +317,7 @@ class AiChatMessageSendServiceTest {
     @Test
     void 정상_스트림이면_Token_여러개와_Done_이벤트가_방출되고_USER_와_ASSISTANT_가_저장된다() {
         Long sessionId = 7L;
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, sessionId, "주제 요약");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, sessionId, "주제 요약");
 
         givenLoadHistory(sessionId, List.of(), 100L);
         given(aiChatClient.stream(any(AiChatStreamCommand.class))).willReturn(Flux.just(
@@ -370,7 +359,7 @@ class AiChatMessageSendServiceTest {
     @Test
     void 스트림_도중_에러가_나면_FAILED_가_저장되고_Error_이벤트가_방출된다() throws InterruptedException {
         Long sessionId = 7L;
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, sessionId, "질문");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, sessionId, "질문");
 
         givenLoadHistory(sessionId, List.of(), 100L);
         given(aiChatClient.stream(any(AiChatStreamCommand.class))).willReturn(Flux.concat(
@@ -406,7 +395,7 @@ class AiChatMessageSendServiceTest {
     @Test
     void TooManyRequestsException_BURST_이면_AI_RATE_LIMIT_BURST_코드와_RateLimitInfo_가_Error_이벤트로_운반된다() {
         Long sessionId = 7L;
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, sessionId, "질문");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, sessionId, "질문");
 
         givenLoadHistory(sessionId, List.of(), 100L);
         RateLimitInfo info = new RateLimitInfo(
@@ -430,7 +419,7 @@ class AiChatMessageSendServiceTest {
     @Test
     void TooManyRequestsException_QUOTA_EXHAUSTED_이면_AI_QUOTA_EXHAUSTED_코드의_Error_이벤트가_방출된다() {
         Long sessionId = 7L;
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, sessionId, "질문");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, sessionId, "질문");
 
         givenLoadHistory(sessionId, List.of(), 100L);
         given(aiChatClient.stream(any(AiChatStreamCommand.class))).willReturn(Flux.error(
@@ -450,7 +439,7 @@ class AiChatMessageSendServiceTest {
     @Test
     void 토큰_도중_클라이언트가_disconnect_하면_부분_응답이_FAILED_로_저장된다() throws InterruptedException {
         Long sessionId = 7L;
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, sessionId, "질문");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, sessionId, "질문");
 
         givenLoadHistory(sessionId, List.of(), 100L);
         Sinks.Many<AiChatChunk> sink = Sinks.many().unicast().onBackpressureBuffer();
@@ -478,7 +467,7 @@ class AiChatMessageSendServiceTest {
     @Test
     void Completion_메타까지_받은_뒤_disconnect_하면_COMPLETED_로_저장된다() throws InterruptedException {
         Long sessionId = 7L;
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, sessionId, "질문");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, sessionId, "질문");
 
         givenLoadHistory(sessionId, List.of(), 100L);
         Sinks.Many<AiChatChunk> sink = Sinks.many().unicast().onBackpressureBuffer();
@@ -510,7 +499,7 @@ class AiChatMessageSendServiceTest {
     @Test
     void 첫_토큰도_받기_전에_disconnect_하면_ASSISTANT_메시지를_저장하지_않는다() {
         Long sessionId = 7L;
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, sessionId, "질문");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, sessionId, "질문");
 
         givenLoadHistory(sessionId, List.of(), 100L);
         given(aiChatClient.stream(any(AiChatStreamCommand.class))).willReturn(Flux.never());
@@ -527,7 +516,7 @@ class AiChatMessageSendServiceTest {
     @Test
     void 이전_이력이_있으면_LLM_호출_시_history_와_현재_user_메시지가_함께_전달된다() {
         Long sessionId = 7L;
-        SendMessageCommand command = new SendMessageCommand(USER_SESSION_ID, sessionId, "이번 질문");
+        SendMessageCommand command = new SendMessageCommand(USER_ID, sessionId, "이번 질문");
 
         givenLoadHistory(sessionId, List.of(
                 new HistoryMessage(HistoryMessage.Role.USER, "이전 질문"),

--- a/src/test/java/com/readum/domain/aiChat/service/AiChatSessionCreateServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/AiChatSessionCreateServiceTest.java
@@ -4,19 +4,13 @@ import com.readum.domain.aiChat.dto.AiChatSessionCreateCommand;
 import com.readum.domain.aiChat.dto.AiChatSessionCreateResult;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.aiChat.entity.AiChatSession;
 import com.readum.model.aiChat.entity.AiChatSessionFixture;
 import com.readum.model.aiChat.repository.AiChatSessionRepository;
-import com.readum.model.user.entity.User;
-import com.readum.model.user.entity.UserFixture;
 import com.readum.model.user.entity.UserBook;
 import com.readum.model.user.entity.UserBookFixture;
 import com.readum.model.user.repository.UserBookRepository;
-import com.readum.model.user.repository.UserRepository;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -29,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -37,10 +30,6 @@ import static org.mockito.Mockito.verify;
 class AiChatSessionCreateServiceTest {
 
     private static final Long USER_ID = 1L;
-    private static final String USER_SESSION_ID = "test-session-id";
-
-    @Mock
-    private UserRepository userRepository;
 
     @Mock
     private UserBookRepository userBookRepository;
@@ -51,16 +40,10 @@ class AiChatSessionCreateServiceTest {
     @InjectMocks
     private AiChatSessionCreateService aiChatSessionCreateService;
 
-    @BeforeEach
-    void setUp() {
-        User testUser = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
-        lenient().when(userRepository.findBySessionId(USER_SESSION_ID)).thenReturn(Optional.of(testUser));
-    }
-
     @Test
     void 본인_소유_userBook_으로_세션_생성_성공() {
         Long userBookId = 10L;
-        AiChatSessionCreateCommand command = new AiChatSessionCreateCommand(USER_SESSION_ID, userBookId);
+        AiChatSessionCreateCommand command = new AiChatSessionCreateCommand(USER_ID, userBookId);
 
         UserBook userBook = UserBookFixture.persistedUserBook(userBookId, USER_ID, 100L);
         given(userBookRepository.findByIdAndUserId(userBookId, USER_ID)).willReturn(Optional.of(userBook));
@@ -78,7 +61,7 @@ class AiChatSessionCreateServiceTest {
     @Test
     void 다른_사용자_소유_userBook_은_NotFoundException_을_던지고_save_는_호출되지_않는다() {
         Long userBookId = 10L;
-        AiChatSessionCreateCommand command = new AiChatSessionCreateCommand(USER_SESSION_ID, userBookId);
+        AiChatSessionCreateCommand command = new AiChatSessionCreateCommand(USER_ID, userBookId);
 
         given(userBookRepository.findByIdAndUserId(userBookId, USER_ID)).willReturn(Optional.empty());
 
@@ -93,7 +76,7 @@ class AiChatSessionCreateServiceTest {
     @Test
     void 존재하지_않는_userBook_도_동일한_USER_BOOK_NOT_FOUND_예외() {
         Long userBookId = 999_999L;
-        AiChatSessionCreateCommand command = new AiChatSessionCreateCommand(USER_SESSION_ID, userBookId);
+        AiChatSessionCreateCommand command = new AiChatSessionCreateCommand(USER_ID, userBookId);
 
         given(userBookRepository.findByIdAndUserId(userBookId, USER_ID)).willReturn(Optional.empty());
 
@@ -101,16 +84,5 @@ class AiChatSessionCreateServiceTest {
                 .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
                 .extracting(NotFoundException::getErrorCode)
                 .isEqualTo(AiChatErrorCode.USER_BOOK_NOT_FOUND);
-    }
-
-    @Test
-    void 유효하지_않은_session_쿠키면_UnauthorizedException() {
-        given(userRepository.findBySessionId("invalid")).willReturn(Optional.empty());
-        AiChatSessionCreateCommand command = new AiChatSessionCreateCommand("invalid", 10L);
-
-        assertThatThrownBy(() -> aiChatSessionCreateService.execute(command))
-                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
-                .extracting(UnauthorizedException::getErrorCode)
-                .isEqualTo(UserErrorCode.INVALID_SESSION);
     }
 }

--- a/src/test/java/com/readum/domain/aiChat/service/AiChatSessionSearchServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/AiChatSessionSearchServiceTest.java
@@ -6,17 +6,11 @@ import com.readum.domain.aiChat.dto.AiChatSessionListResult;
 import com.readum.domain.aiChat.dto.AiChatSessionResult;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.aiChat.repository.AiChatSessionRepository;
 import com.readum.model.aiChat.repository.projection.AiChatSessionListProjection;
-import com.readum.model.user.entity.User;
-import com.readum.model.user.entity.UserFixture;
 import com.readum.model.user.entity.UserBook;
 import com.readum.model.user.repository.UserBookRepository;
-import com.readum.model.user.repository.UserRepository;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -32,18 +26,13 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class AiChatSessionSearchServiceTest {
 
-    private static final String USER_SESSION_ID = "test-session-id";
     private static final Long USER_ID = 1L;
     private static final Long USER_BOOK_ID = 100L;
-
-    @Mock
-    private UserRepository userRepository;
 
     @Mock
     private AiChatSessionRepository aiChatSessionRepository;
@@ -54,30 +43,12 @@ class AiChatSessionSearchServiceTest {
     @InjectMocks
     private AiChatSessionSearchService aiChatSessionSearchService;
 
-    @BeforeEach
-    void setUp() {
-        User testUser = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
-        lenient().when(userRepository.findBySessionId(USER_SESSION_ID)).thenReturn(Optional.of(testUser));
-    }
-
-    @Test
-    void 유효하지_않은_user_session_쿠키면_UnauthorizedException() {
-        given(userRepository.findBySessionId("invalid")).willReturn(Optional.empty());
-
-        assertThatThrownBy(() -> aiChatSessionSearchService.findByUserBookId(
-                new AiChatSessionListCommand("invalid", USER_BOOK_ID, 1, 20)
-        ))
-                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
-                .extracting(UnauthorizedException::getErrorCode)
-                .isEqualTo(UserErrorCode.INVALID_SESSION);
-    }
-
     @Test
     void 소유권_없는_userBookId_면_NotFoundException() {
         given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> aiChatSessionSearchService.findByUserBookId(
-                new AiChatSessionListCommand(USER_SESSION_ID, USER_BOOK_ID, 1, 20)
+                new AiChatSessionListCommand(USER_ID, USER_BOOK_ID, 1, 20)
         ))
                 .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
                 .extracting(NotFoundException::getErrorCode)
@@ -92,7 +63,7 @@ class AiChatSessionSearchServiceTest {
         )).willReturn(new SliceImpl<>(List.of(), PageRequest.of(0, 20), false));
 
         AiChatSessionListResult result = aiChatSessionSearchService.findByUserBookId(
-                new AiChatSessionListCommand(USER_SESSION_ID, USER_BOOK_ID, 1, 20)
+                new AiChatSessionListCommand(USER_ID, USER_BOOK_ID, 1, 20)
         );
 
         assertThat(result.sessions()).isEmpty();
@@ -118,7 +89,7 @@ class AiChatSessionSearchServiceTest {
         )).willReturn(new SliceImpl<>(rows, PageRequest.of(0, 20), false));
 
         AiChatSessionListResult result = aiChatSessionSearchService.findByUserBookId(
-                new AiChatSessionListCommand(USER_SESSION_ID, USER_BOOK_ID, 1, 20)
+                new AiChatSessionListCommand(USER_ID, USER_BOOK_ID, 1, 20)
         );
 
         assertThat(result.sessions()).hasSize(3);
@@ -145,7 +116,7 @@ class AiChatSessionSearchServiceTest {
         )).willReturn(new SliceImpl<>(rows, PageRequest.of(0, 2), true));
 
         AiChatSessionListResult result = aiChatSessionSearchService.findByUserBookId(
-                new AiChatSessionListCommand(USER_SESSION_ID, USER_BOOK_ID, 1, 2)
+                new AiChatSessionListCommand(USER_ID, USER_BOOK_ID, 1, 2)
         );
 
         assertThat(result.hasNext()).isTrue();
@@ -159,7 +130,7 @@ class AiChatSessionSearchServiceTest {
         )).willReturn(new SliceImpl<>(List.of(), PageRequest.of(2, 10), false));
 
         AiChatSessionListResult result = aiChatSessionSearchService.findByUserBookId(
-                new AiChatSessionListCommand(USER_SESSION_ID, USER_BOOK_ID, 3, 10)
+                new AiChatSessionListCommand(USER_ID, USER_BOOK_ID, 3, 10)
         );
 
         assertThat(result.page()).isEqualTo(3);

--- a/src/test/java/com/readum/domain/aiChat/service/BookChatSessionSearchServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/BookChatSessionSearchServiceTest.java
@@ -77,7 +77,7 @@ class BookChatSessionSearchServiceTest {
         aiChatMessageRepository.save(AiChatMessageFixture.userMessageAt(newer.getId(), "최근 대화", now.minusHours(1)));
 
         BookChatSessionsResult result = bookChatSessionSearchService.findByUserBook(
-                userBook.getId(), user.getSessionId());
+                userBook.getId(), user.getId());
 
         assertThat(result.book().title()).isEqualTo("데미안");
         assertThat(result.book().publishedYear()).isEqualTo(2020);
@@ -104,7 +104,7 @@ class BookChatSessionSearchServiceTest {
         AiChatSession session = aiChatSessionRepository.save(AiChatSession.create(userBook.getId()));
 
         BookChatSessionsResult result = bookChatSessionSearchService.findByUserBook(
-                userBook.getId(), user.getSessionId());
+                userBook.getId(), user.getId());
 
         assertThat(result.sessions()).hasSize(1);
         assertThat(result.sessions().get(0).lastChattedDate())
@@ -120,7 +120,7 @@ class BookChatSessionSearchServiceTest {
         UserBook userBook = userBookRepository.save(UserBook.create(owner.getId(), book.getId()));
 
         assertThatThrownBy(() -> bookChatSessionSearchService.findByUserBook(
-                userBook.getId(), other.getSessionId()))
+                userBook.getId(), other.getId()))
                 .isInstanceOf(NotFoundException.class);
     }
 }

--- a/src/test/java/com/readum/domain/aiChat/service/SummaryDraftSearchServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/SummaryDraftSearchServiceTest.java
@@ -5,19 +5,13 @@ import com.readum.domain.aiChat.dto.SummaryDraftEligibilityResult;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.aiChat.service.policy.SummaryDraftPolicy;
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.aiChat.entity.AiChatSession;
 import com.readum.model.aiChat.entity.AiChatSessionFixture;
 import com.readum.model.aiChat.repository.AiChatSessionRepository;
 import com.readum.model.summary.repository.SummaryJobRepository;
-import com.readum.model.user.entity.User;
-import com.readum.model.user.entity.UserFixture;
 import com.readum.model.user.entity.UserBook;
 import com.readum.model.user.repository.UserBookRepository;
-import com.readum.model.user.repository.UserRepository;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -30,7 +24,6 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -41,13 +34,9 @@ class SummaryDraftSearchServiceTest {
 
     private static final Long SESSION_ID = 1L;
     private static final Long USER_ID = 10L;
-    private static final String USER_SESSION_ID = "test-session-id";
     private static final Long USER_BOOK_ID = 1L;
     private static final int SUFFICIENT_TOKENS = 600;
     private static final int INSUFFICIENT_TOKENS = 100;
-
-    @Mock
-    private UserRepository userRepository;
 
     @Mock
     private AiChatSessionRepository aiChatSessionRepository;
@@ -64,27 +53,11 @@ class SummaryDraftSearchServiceTest {
     @InjectMocks
     private SummaryDraftSearchService summaryDraftSearchService;
 
-    @BeforeEach
-    void setUp() {
-        User testUser = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
-        lenient().when(userRepository.findBySessionId(USER_SESSION_ID)).thenReturn(Optional.of(testUser));
-    }
-
-    @Test
-    void 유효하지_않은_세션이면_UnauthorizedException() {
-        given(userRepository.findBySessionId("invalid")).willReturn(Optional.empty());
-
-        assertThatThrownBy(() -> summaryDraftSearchService.findEligibility(SESSION_ID, "invalid"))
-                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
-                .extracting(UnauthorizedException::getErrorCode)
-                .isEqualTo(UserErrorCode.INVALID_SESSION);
-    }
-
     @Test
     void 세션이_없으면_NotFoundException이_발생한다() {
         given(aiChatSessionRepository.findById(SESSION_ID)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> summaryDraftSearchService.findEligibility(SESSION_ID, USER_SESSION_ID))
+        assertThatThrownBy(() -> summaryDraftSearchService.findEligibility(SESSION_ID, USER_ID))
                 .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
                 .extracting(NotFoundException::getErrorCode)
                 .isEqualTo(AiChatErrorCode.SESSION_NOT_FOUND);
@@ -98,7 +71,7 @@ class SummaryDraftSearchServiceTest {
         given(aiChatSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
         given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> summaryDraftSearchService.findEligibility(SESSION_ID, USER_SESSION_ID))
+        assertThatThrownBy(() -> summaryDraftSearchService.findEligibility(SESSION_ID, USER_ID))
                 .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
                 .extracting(NotFoundException::getErrorCode)
                 .isEqualTo(AiChatErrorCode.SESSION_NOT_FOUND);
@@ -110,7 +83,7 @@ class SummaryDraftSearchServiceTest {
         given(aiChatSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
         given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID)).willReturn(Optional.of(mock(UserBook.class)));
 
-        SummaryDraftEligibilityResult result = summaryDraftSearchService.findEligibility(SESSION_ID, USER_SESSION_ID);
+        SummaryDraftEligibilityResult result = summaryDraftSearchService.findEligibility(SESSION_ID, USER_ID);
 
         assertThat(result.eligible()).isTrue();
         assertThat(result.reason()).isNull();
@@ -124,7 +97,7 @@ class SummaryDraftSearchServiceTest {
         given(aiChatSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
         given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID)).willReturn(Optional.of(mock(UserBook.class)));
 
-        SummaryDraftEligibilityResult result = summaryDraftSearchService.findEligibility(SESSION_ID, USER_SESSION_ID);
+        SummaryDraftEligibilityResult result = summaryDraftSearchService.findEligibility(SESSION_ID, USER_ID);
 
         assertThat(result.eligible()).isFalse();
         assertThat(result.reason()).isEqualTo(IneligibleReason.ALREADY_SUMMARIZED.name());
@@ -138,7 +111,7 @@ class SummaryDraftSearchServiceTest {
         given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID)).willReturn(Optional.of(mock(UserBook.class)));
         given(summaryJobRepository.existsByActiveSessionId(SESSION_ID)).willReturn(true);
 
-        SummaryDraftEligibilityResult result = summaryDraftSearchService.findEligibility(SESSION_ID, USER_SESSION_ID);
+        SummaryDraftEligibilityResult result = summaryDraftSearchService.findEligibility(SESSION_ID, USER_ID);
 
         assertThat(result.eligible()).isFalse();
         assertThat(result.reason()).isEqualTo(IneligibleReason.SUMMARY_IN_PROGRESS.name());
@@ -151,7 +124,7 @@ class SummaryDraftSearchServiceTest {
         given(aiChatSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
         given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID)).willReturn(Optional.of(mock(UserBook.class)));
 
-        SummaryDraftEligibilityResult result = summaryDraftSearchService.findEligibility(SESSION_ID, USER_SESSION_ID);
+        SummaryDraftEligibilityResult result = summaryDraftSearchService.findEligibility(SESSION_ID, USER_ID);
 
         assertThat(result.eligible()).isFalse();
         assertThat(result.reason()).isEqualTo(IneligibleReason.CHAT_VOLUME_NOT_ENOUGH.name());
@@ -165,7 +138,7 @@ class SummaryDraftSearchServiceTest {
         given(aiChatSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
         given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID)).willReturn(Optional.of(mock(UserBook.class)));
 
-        summaryDraftSearchService.findEligibility(SESSION_ID, USER_SESSION_ID);
+        summaryDraftSearchService.findEligibility(SESSION_ID, USER_ID);
 
         verify(aiChatSessionRepository, never()).findByIdForUpdate(SESSION_ID);
         assertThat(session.getStatus()).isEqualTo(AiChatSession.Status.ACTIVE);

--- a/src/test/java/com/readum/domain/aiChat/service/SummaryDraftServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/SummaryDraftServiceTest.java
@@ -1,5 +1,6 @@
 package com.readum.domain.aiChat.service;
 
+import com.readum.domain.aiChat.dto.SummaryDraftCommand;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.aiChat.service.policy.SummaryDraftPolicy;
 import com.readum.domain.exception.ConflictException;
@@ -53,7 +54,7 @@ class SummaryDraftServiceTest {
         given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID)).willReturn(Optional.of(userBook));
         given(enqueueSummaryJobService.execute(SESSION_ID)).willReturn(new EnqueueSummaryJobResult(true));
 
-        summaryDraftService.execute(SESSION_ID, USER_ID);
+        summaryDraftService.execute(new SummaryDraftCommand(USER_ID, SESSION_ID));
 
         verify(enqueueSummaryJobService).execute(SESSION_ID);
     }
@@ -66,7 +67,7 @@ class SummaryDraftServiceTest {
         given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID)).willReturn(Optional.of(userBook));
         given(enqueueSummaryJobService.execute(SESSION_ID)).willReturn(new EnqueueSummaryJobResult(false));
 
-        assertThatThrownBy(() -> summaryDraftService.execute(SESSION_ID, USER_ID))
+        assertThatThrownBy(() -> summaryDraftService.execute(new SummaryDraftCommand(USER_ID, SESSION_ID)))
                 .asInstanceOf(InstanceOfAssertFactories.type(ConflictException.class))
                 .extracting(ConflictException::getErrorCode)
                 .isEqualTo(AiChatErrorCode.SUMMARY_IN_PROGRESS);
@@ -76,7 +77,7 @@ class SummaryDraftServiceTest {
     void 세션이_없으면_NotFoundException이_발생한다() {
         given(aiChatSessionRepository.findById(SESSION_ID)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> summaryDraftService.execute(SESSION_ID, USER_ID))
+        assertThatThrownBy(() -> summaryDraftService.execute(new SummaryDraftCommand(USER_ID, SESSION_ID)))
                 .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
                 .extracting(NotFoundException::getErrorCode)
                 .isEqualTo(AiChatErrorCode.SESSION_NOT_FOUND);
@@ -89,7 +90,7 @@ class SummaryDraftServiceTest {
         given(aiChatSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
         given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> summaryDraftService.execute(SESSION_ID, USER_ID))
+        assertThatThrownBy(() -> summaryDraftService.execute(new SummaryDraftCommand(USER_ID, SESSION_ID)))
                 .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
                 .extracting(NotFoundException::getErrorCode)
                 .isEqualTo(AiChatErrorCode.SESSION_NOT_FOUND);
@@ -105,7 +106,7 @@ class SummaryDraftServiceTest {
         willThrow(new ConflictException(AiChatErrorCode.SUMMARY_IN_PROGRESS))
                 .given(summaryDraftPolicy).assertEligible(session);
 
-        assertThatThrownBy(() -> summaryDraftService.execute(SESSION_ID, USER_ID))
+        assertThatThrownBy(() -> summaryDraftService.execute(new SummaryDraftCommand(USER_ID, SESSION_ID)))
                 .asInstanceOf(InstanceOfAssertFactories.type(ConflictException.class))
                 .extracting(ConflictException::getErrorCode)
                 .isEqualTo(AiChatErrorCode.SUMMARY_IN_PROGRESS);
@@ -120,7 +121,7 @@ class SummaryDraftServiceTest {
         given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID)).willReturn(Optional.of(userBook));
         given(summaryJobRepository.existsByActiveSessionId(SESSION_ID)).willReturn(true);
 
-        assertThatThrownBy(() -> summaryDraftService.execute(SESSION_ID, USER_ID))
+        assertThatThrownBy(() -> summaryDraftService.execute(new SummaryDraftCommand(USER_ID, SESSION_ID)))
                 .asInstanceOf(InstanceOfAssertFactories.type(ConflictException.class))
                 .extracting(ConflictException::getErrorCode)
                 .isEqualTo(AiChatErrorCode.SUMMARY_IN_PROGRESS);

--- a/src/test/java/com/readum/domain/aiChat/service/SummaryDraftServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/SummaryDraftServiceTest.java
@@ -4,20 +4,15 @@ import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.aiChat.service.policy.SummaryDraftPolicy;
 import com.readum.domain.exception.ConflictException;
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.domain.summary.dto.EnqueueSummaryJobResult;
 import com.readum.domain.summary.service.EnqueueSummaryJobService;
 import com.readum.model.aiChat.entity.AiChatSession;
 import com.readum.model.aiChat.entity.AiChatSessionFixture;
 import com.readum.model.aiChat.repository.AiChatSessionRepository;
 import com.readum.model.summary.repository.SummaryJobRepository;
-import com.readum.model.user.entity.User;
 import com.readum.model.user.entity.UserBook;
 import com.readum.model.user.entity.UserBookFixture;
-import com.readum.model.user.entity.UserFixture;
 import com.readum.model.user.repository.UserBookRepository;
-import com.readum.model.user.repository.UserRepository;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,13 +32,11 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 class SummaryDraftServiceTest {
 
-    private static final String USER_SESSION_ID = "user-session";
     private static final Long USER_ID = 10L;
     private static final Long SESSION_ID = 1L;
     private static final Long USER_BOOK_ID = 5L;
     private static final Long BOOK_ID = 99L;
 
-    @Mock private UserRepository userRepository;
     @Mock private AiChatSessionRepository aiChatSessionRepository;
     @Mock private UserBookRepository userBookRepository;
     @Mock private SummaryDraftPolicy summaryDraftPolicy;
@@ -54,53 +47,36 @@ class SummaryDraftServiceTest {
 
     @Test
     void 자격을_통과하면_작업을_적재한다() {
-        User user = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
         AiChatSession session = AiChatSessionFixture.persistedActiveSession(SESSION_ID, USER_BOOK_ID, 2, 600, "제목");
         UserBook userBook = UserBookFixture.persistedUserBook(USER_BOOK_ID, USER_ID, BOOK_ID);
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(user));
         given(aiChatSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
         given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID)).willReturn(Optional.of(userBook));
         given(enqueueSummaryJobService.execute(SESSION_ID)).willReturn(new EnqueueSummaryJobResult(true));
 
-        summaryDraftService.execute(SESSION_ID, USER_SESSION_ID);
+        summaryDraftService.execute(SESSION_ID, USER_ID);
 
         verify(enqueueSummaryJobService).execute(SESSION_ID);
     }
 
     @Test
     void 적재_경합으로_적재되지_않으면_409_SUMMARY_IN_PROGRESS() {
-        User user = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
         AiChatSession session = AiChatSessionFixture.persistedActiveSession(SESSION_ID, USER_BOOK_ID, 2, 600, "제목");
         UserBook userBook = UserBookFixture.persistedUserBook(USER_BOOK_ID, USER_ID, BOOK_ID);
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(user));
         given(aiChatSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
         given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID)).willReturn(Optional.of(userBook));
         given(enqueueSummaryJobService.execute(SESSION_ID)).willReturn(new EnqueueSummaryJobResult(false));
 
-        assertThatThrownBy(() -> summaryDraftService.execute(SESSION_ID, USER_SESSION_ID))
+        assertThatThrownBy(() -> summaryDraftService.execute(SESSION_ID, USER_ID))
                 .asInstanceOf(InstanceOfAssertFactories.type(ConflictException.class))
                 .extracting(ConflictException::getErrorCode)
                 .isEqualTo(AiChatErrorCode.SUMMARY_IN_PROGRESS);
     }
 
     @Test
-    void 사용자_세션이_유효하지_않으면_401() {
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.empty());
-
-        assertThatThrownBy(() -> summaryDraftService.execute(SESSION_ID, USER_SESSION_ID))
-                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
-                .extracting(UnauthorizedException::getErrorCode)
-                .isEqualTo(UserErrorCode.INVALID_SESSION);
-        verify(enqueueSummaryJobService, never()).execute(anyLong());
-    }
-
-    @Test
     void 세션이_없으면_NotFoundException이_발생한다() {
-        User user = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(user));
         given(aiChatSessionRepository.findById(SESSION_ID)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> summaryDraftService.execute(SESSION_ID, USER_SESSION_ID))
+        assertThatThrownBy(() -> summaryDraftService.execute(SESSION_ID, USER_ID))
                 .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
                 .extracting(NotFoundException::getErrorCode)
                 .isEqualTo(AiChatErrorCode.SESSION_NOT_FOUND);
@@ -109,13 +85,11 @@ class SummaryDraftServiceTest {
 
     @Test
     void 다른_사용자의_세션이면_NotFoundException이_발생한다() {
-        User user = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
         AiChatSession session = AiChatSessionFixture.persistedActiveSession(SESSION_ID, USER_BOOK_ID, 2, 600, "제목");
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(user));
         given(aiChatSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
         given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> summaryDraftService.execute(SESSION_ID, USER_SESSION_ID))
+        assertThatThrownBy(() -> summaryDraftService.execute(SESSION_ID, USER_ID))
                 .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
                 .extracting(NotFoundException::getErrorCode)
                 .isEqualTo(AiChatErrorCode.SESSION_NOT_FOUND);
@@ -124,16 +98,14 @@ class SummaryDraftServiceTest {
 
     @Test
     void 자격검증에_실패하면_적재하지_않고_예외를_전파한다() {
-        User user = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
         AiChatSession session = AiChatSessionFixture.persistedActiveSession(SESSION_ID, USER_BOOK_ID, 2, 600, "제목");
         UserBook userBook = UserBookFixture.persistedUserBook(USER_BOOK_ID, USER_ID, BOOK_ID);
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(user));
         given(aiChatSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
         given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID)).willReturn(Optional.of(userBook));
         willThrow(new ConflictException(AiChatErrorCode.SUMMARY_IN_PROGRESS))
                 .given(summaryDraftPolicy).assertEligible(session);
 
-        assertThatThrownBy(() -> summaryDraftService.execute(SESSION_ID, USER_SESSION_ID))
+        assertThatThrownBy(() -> summaryDraftService.execute(SESSION_ID, USER_ID))
                 .asInstanceOf(InstanceOfAssertFactories.type(ConflictException.class))
                 .extracting(ConflictException::getErrorCode)
                 .isEqualTo(AiChatErrorCode.SUMMARY_IN_PROGRESS);
@@ -142,15 +114,13 @@ class SummaryDraftServiceTest {
 
     @Test
     void 이미_활성_작업이_있으면_409_SUMMARY_IN_PROGRESS_이고_적재하지_않는다() {
-        User user = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
         AiChatSession session = AiChatSessionFixture.persistedActiveSession(SESSION_ID, USER_BOOK_ID, 2, 600, "제목");
         UserBook userBook = UserBookFixture.persistedUserBook(USER_BOOK_ID, USER_ID, BOOK_ID);
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(user));
         given(aiChatSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
         given(userBookRepository.findByIdAndUserId(USER_BOOK_ID, USER_ID)).willReturn(Optional.of(userBook));
         given(summaryJobRepository.existsByActiveSessionId(SESSION_ID)).willReturn(true);
 
-        assertThatThrownBy(() -> summaryDraftService.execute(SESSION_ID, USER_SESSION_ID))
+        assertThatThrownBy(() -> summaryDraftService.execute(SESSION_ID, USER_ID))
                 .asInstanceOf(InstanceOfAssertFactories.type(ConflictException.class))
                 .extracting(ConflictException::getErrorCode)
                 .isEqualTo(AiChatErrorCode.SUMMARY_IN_PROGRESS);

--- a/src/test/java/com/readum/domain/aiChat/service/SummaryEditServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/SummaryEditServiceTest.java
@@ -4,19 +4,13 @@ import com.readum.domain.aiChat.dto.SummaryEditCommand;
 import com.readum.domain.summary.dto.SummaryResult;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.aiChat.entity.AiChatSession;
 import com.readum.model.aiChat.entity.AiChatSessionFixture;
 import com.readum.model.aiChat.repository.AiChatSessionRepository;
 import com.readum.model.summary.entity.Summary;
 import com.readum.model.summary.entity.SummaryFixture;
 import com.readum.model.summary.repository.SummaryRepository;
-import com.readum.model.user.entity.User;
-import com.readum.model.user.entity.UserFixture;
-import com.readum.model.user.repository.UserRepository;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -28,7 +22,6 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class SummaryEditServiceTest {
@@ -36,11 +29,7 @@ class SummaryEditServiceTest {
     private static final Long SESSION_ID = 1L;
     private static final Long SUMMARY_ID = 100L;
     private static final Long USER_ID = 10L;
-    private static final String USER_SESSION_ID = "test-session-id";
     private static final Long USER_BOOK_ID = 1L;
-
-    @Mock
-    private UserRepository userRepository;
 
     @Mock
     private AiChatSessionRepository aiChatSessionRepository;
@@ -50,12 +39,6 @@ class SummaryEditServiceTest {
 
     @InjectMocks
     private SummaryEditService summaryEditService;
-
-    @BeforeEach
-    void setUp() {
-        User testUser = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
-        lenient().when(userRepository.findBySessionId(USER_SESSION_ID)).thenReturn(Optional.of(testUser));
-    }
 
     @Test
     void 최신_감상문을_정상적으로_수정한다() {
@@ -67,7 +50,7 @@ class SummaryEditServiceTest {
         given(summaryRepository.findByAiChatSessionId(SESSION_ID))
                 .willReturn(Optional.of(summary));
 
-        SummaryEditCommand command = new SummaryEditCommand(USER_SESSION_ID, SESSION_ID, "수정된 제목", "수정된 본문");
+        SummaryEditCommand command = new SummaryEditCommand(USER_ID, SESSION_ID, "수정된 제목", "수정된 본문");
         SummaryResult result = summaryEditService.execute(command);
 
         assertThat(result.title()).isEqualTo("수정된 제목");
@@ -77,22 +60,10 @@ class SummaryEditServiceTest {
     }
 
     @Test
-    void 유효하지_않은_세션이면_UnauthorizedException이_발생한다() {
-        given(userRepository.findBySessionId("invalid")).willReturn(Optional.empty());
-
-        SummaryEditCommand command = new SummaryEditCommand("invalid", SESSION_ID, "제목", "본문");
-
-        assertThatThrownBy(() -> summaryEditService.execute(command))
-                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
-                .extracting(UnauthorizedException::getErrorCode)
-                .isEqualTo(UserErrorCode.INVALID_SESSION);
-    }
-
-    @Test
     void 소유하지_않은_세션이면_NotFoundException이_발생한다() {
         given(aiChatSessionRepository.findByIdAndOwner(SESSION_ID, USER_ID)).willReturn(Optional.empty());
 
-        SummaryEditCommand command = new SummaryEditCommand(USER_SESSION_ID, SESSION_ID, "제목", "본문");
+        SummaryEditCommand command = new SummaryEditCommand(USER_ID, SESSION_ID, "제목", "본문");
 
         assertThatThrownBy(() -> summaryEditService.execute(command))
                 .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
@@ -107,7 +78,7 @@ class SummaryEditServiceTest {
         given(summaryRepository.findByAiChatSessionId(SESSION_ID))
                 .willReturn(Optional.empty());
 
-        SummaryEditCommand command = new SummaryEditCommand(USER_SESSION_ID, SESSION_ID, "제목", "본문");
+        SummaryEditCommand command = new SummaryEditCommand(USER_ID, SESSION_ID, "제목", "본문");
 
         assertThatThrownBy(() -> summaryEditService.execute(command))
                 .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))

--- a/src/test/java/com/readum/domain/auth/service/SessionAuthenticationServiceTest.java
+++ b/src/test/java/com/readum/domain/auth/service/SessionAuthenticationServiceTest.java
@@ -1,0 +1,49 @@
+package com.readum.domain.auth.service;
+
+import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.exception.UserErrorCode;
+import com.readum.model.user.entity.User;
+import com.readum.model.user.entity.UserFixture;
+import com.readum.model.user.repository.UserRepository;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class SessionAuthenticationServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private SessionAuthenticationService sessionAuthenticationService;
+
+    @Test
+    void 유효한_세션이면_해당_사용자의_userId_를_반환한다() {
+        User user = UserFixture.persistedUser(7L, "valid-session-id");
+        given(userRepository.findBySessionId("valid-session-id")).willReturn(Optional.of(user));
+
+        Long userId = sessionAuthenticationService.authenticate("valid-session-id");
+
+        assertThat(userId).isEqualTo(7L);
+    }
+
+    @Test
+    void 존재하지_않는_세션이면_INVALID_SESSION_예외가_발생한다() {
+        given(userRepository.findBySessionId("unknown-session-id")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sessionAuthenticationService.authenticate("unknown-session-id"))
+                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
+                .extracting(UnauthorizedException::getErrorCode)
+                .isEqualTo(UserErrorCode.INVALID_SESSION);
+    }
+}

--- a/src/test/java/com/readum/domain/summary/service/SummaryHistorySearchServiceTest.java
+++ b/src/test/java/com/readum/domain/summary/service/SummaryHistorySearchServiceTest.java
@@ -1,17 +1,10 @@
 package com.readum.domain.summary.service;
 
-import com.readum.domain.exception.UnauthorizedException;
 import com.readum.domain.summary.dto.SummaryHistoryItemResult;
 import com.readum.domain.summary.dto.SummaryHistoryListCommand;
 import com.readum.domain.summary.dto.SummaryHistoryListResult;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.summary.repository.SummaryRepository;
 import com.readum.model.summary.repository.projection.SummaryHistoryProjection;
-import com.readum.model.user.entity.User;
-import com.readum.model.user.entity.UserFixture;
-import com.readum.model.user.repository.UserRepository;
-import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -22,22 +15,15 @@ import org.springframework.data.domain.SliceImpl;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class SummaryHistorySearchServiceTest {
 
-    private static final String USER_SESSION_ID = "test-session-id";
     private static final Long USER_ID = 1L;
     private static final int PAGE_SIZE = 20;
-
-    @Mock
-    private UserRepository userRepository;
 
     @Mock
     private SummaryRepository summaryRepository;
@@ -45,31 +31,13 @@ class SummaryHistorySearchServiceTest {
     @InjectMocks
     private SummaryHistorySearchService summaryHistorySearchService;
 
-    @BeforeEach
-    void setUp() {
-        User testUser = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
-        lenient().when(userRepository.findBySessionId(USER_SESSION_ID)).thenReturn(Optional.of(testUser));
-    }
-
-    @Test
-    void 유효하지_않은_user_session_쿠키면_UnauthorizedException() {
-        given(userRepository.findBySessionId("invalid")).willReturn(Optional.empty());
-
-        assertThatThrownBy(() -> summaryHistorySearchService.findMyHistory(
-                new SummaryHistoryListCommand("invalid", 1)
-        ))
-                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
-                .extracting(UnauthorizedException::getErrorCode)
-                .isEqualTo(UserErrorCode.INVALID_SESSION);
-    }
-
     @Test
     void 감상_기록이_없으면_빈_배열과_hasNext_false_를_반환한다() {
         given(summaryRepository.findLatestHistoryByUserId(USER_ID, PageRequest.of(0, PAGE_SIZE)))
                 .willReturn(new SliceImpl<>(List.of(), PageRequest.of(0, PAGE_SIZE), false));
 
         SummaryHistoryListResult result = summaryHistorySearchService.findMyHistory(
-                new SummaryHistoryListCommand(USER_SESSION_ID, 1)
+                new SummaryHistoryListCommand(USER_ID, 1)
         );
 
         assertThat(result.summaries()).isEmpty();
@@ -87,7 +55,7 @@ class SummaryHistorySearchServiceTest {
                 ), PageRequest.of(0, PAGE_SIZE), false));
 
         SummaryHistoryListResult result = summaryHistorySearchService.findMyHistory(
-                new SummaryHistoryListCommand(USER_SESSION_ID, 1)
+                new SummaryHistoryListCommand(USER_ID, 1)
         );
 
         assertThat(result.summaries()).hasSize(1);
@@ -104,7 +72,7 @@ class SummaryHistorySearchServiceTest {
                 .willReturn(new SliceImpl<>(List.of(), PageRequest.of(2, PAGE_SIZE), false));
 
         SummaryHistoryListResult result = summaryHistorySearchService.findMyHistory(
-                new SummaryHistoryListCommand(USER_SESSION_ID, 3)
+                new SummaryHistoryListCommand(USER_ID, 3)
         );
 
         assertThat(result.page()).isEqualTo(3);
@@ -119,7 +87,7 @@ class SummaryHistorySearchServiceTest {
                 ), PageRequest.of(0, PAGE_SIZE), true));
 
         SummaryHistoryListResult result = summaryHistorySearchService.findMyHistory(
-                new SummaryHistoryListCommand(USER_SESSION_ID, 1)
+                new SummaryHistoryListCommand(USER_ID, 1)
         );
 
         assertThat(result.hasNext()).isTrue();

--- a/src/test/java/com/readum/domain/summary/service/SummarySearchServiceTest.java
+++ b/src/test/java/com/readum/domain/summary/service/SummarySearchServiceTest.java
@@ -3,11 +3,9 @@ package com.readum.domain.summary.service;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.exception.ConflictException;
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
 import com.readum.domain.summary.dto.MonthlyReadingRecordResult;
 import com.readum.domain.summary.dto.SummaryResult;
 import com.readum.domain.summary.exception.SummaryErrorCode;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.aiChat.entity.AiChatMessage;
 import com.readum.model.aiChat.entity.AiChatSession;
 import com.readum.model.aiChat.entity.AiChatSessionFixture;
@@ -21,12 +19,9 @@ import com.readum.model.summary.entity.SummaryFixture;
 import com.readum.model.summary.repository.SummaryJobRepository;
 import com.readum.model.summary.repository.SummaryRepository;
 import com.readum.model.book.repository.BookRepository;
-import com.readum.model.user.entity.User;
 import com.readum.model.user.entity.UserBook;
 import com.readum.model.user.entity.UserBookFixture;
-import com.readum.model.user.entity.UserFixture;
 import com.readum.model.user.repository.UserBookRepository;
-import com.readum.model.user.repository.UserRepository;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,9 +45,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 class SummarySearchServiceTest {
 
     @Mock
-    private UserRepository userRepository;
-
-    @Mock
     private AiChatSessionRepository aiChatSessionRepository;
 
     @Mock
@@ -74,12 +66,7 @@ class SummarySearchServiceTest {
     private SummarySearchService summarySearchService;
 
     private static final Long USER_ID = 1L;
-    private static final String USER_SESSION_ID = "test-session-id";
     private static final YearMonth JUNE = YearMonth.of(2026, 6);
-
-    private User stubUser() {
-        return UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
-    }
 
     private static final LocalDateTime JUNE_11 = LocalDateTime.of(2026, 6, 11, 14, 32, 5);
 
@@ -91,7 +78,6 @@ class SummarySearchServiceTest {
         AiChatSession session = AiChatSessionFixture.persistedActiveSession(1000L, 10L, 3, 100, "채팅 제목");
         Summary summary = SummaryFixture.persistedSummary(17L, 10L, 1000L, "감상문 제목", "감상문 본문");
 
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(userBookRepository.findByUserId(USER_ID)).willReturn(List.of(userBook));
         given(aiChatSessionRepository.findByUserBookIdIn(List.of(10L))).willReturn(List.of(session));
         given(aiChatMessageRepository.findLastChattedAtBySessionIds(List.of(1000L), AiChatMessage.Status.COMPLETED))
@@ -99,7 +85,7 @@ class SummarySearchServiceTest {
         given(summaryRepository.findLatestByAiChatSessionIdIn(List.of(1000L))).willReturn(List.of(summary));
         given(bookRepository.findAllById(List.of(100L))).willReturn(List.of(book));
 
-        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(JUNE, USER_SESSION_ID);
+        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(JUNE, USER_ID);
 
         assertThat(results).hasSize(1);
         MonthlyReadingRecordResult record = results.get(0);
@@ -117,7 +103,6 @@ class SummarySearchServiceTest {
                 100L, "ext-1", "테스트 책", "저자", "출판사", 2024, "http://example.com/c.jpg");
         AiChatSession session = AiChatSessionFixture.persistedActiveSession(1000L, 10L, 3, 100, "채팅 제목");
 
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(userBookRepository.findByUserId(USER_ID)).willReturn(List.of(userBook));
         given(aiChatSessionRepository.findByUserBookIdIn(List.of(10L))).willReturn(List.of(session));
         given(aiChatMessageRepository.findLastChattedAtBySessionIds(List.of(1000L), AiChatMessage.Status.COMPLETED))
@@ -125,7 +110,7 @@ class SummarySearchServiceTest {
         given(summaryRepository.findLatestByAiChatSessionIdIn(List.of(1000L))).willReturn(List.of());
         given(bookRepository.findAllById(List.of(100L))).willReturn(List.of(book));
 
-        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(JUNE, USER_SESSION_ID);
+        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(JUNE, USER_ID);
 
         assertThat(results).hasSize(1);
         assertThat(results.get(0).summaryId()).isNull();
@@ -140,7 +125,6 @@ class SummarySearchServiceTest {
         AiChatSession chatted = AiChatSessionFixture.persistedActiveSession(1000L, 10L, 3, 100, "대화함");
         AiChatSession empty = AiChatSessionFixture.persistedActiveSession(1001L, 10L, 0, 0, null);
 
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(userBookRepository.findByUserId(USER_ID)).willReturn(List.of(userBook));
         given(aiChatSessionRepository.findByUserBookIdIn(List.of(10L)))
                 .willReturn(List.of(chatted, empty));
@@ -150,7 +134,7 @@ class SummarySearchServiceTest {
         given(summaryRepository.findLatestByAiChatSessionIdIn(List.of(1000L))).willReturn(List.of());
         given(bookRepository.findAllById(List.of(100L))).willReturn(List.of(book));
 
-        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(JUNE, USER_SESSION_ID);
+        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(JUNE, USER_ID);
 
         assertThat(results).extracting(MonthlyReadingRecordResult::chatSessionId).containsExactly(1000L);
     }
@@ -163,7 +147,6 @@ class SummarySearchServiceTest {
         AiChatSession june = AiChatSessionFixture.persistedActiveSession(1000L, 10L, 3, 100, "6월 대화");
         AiChatSession may = AiChatSessionFixture.persistedActiveSession(1001L, 10L, 3, 100, "5월 대화");
 
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(userBookRepository.findByUserId(USER_ID)).willReturn(List.of(userBook));
         given(aiChatSessionRepository.findByUserBookIdIn(List.of(10L)))
                 .willReturn(List.of(june, may));
@@ -175,7 +158,7 @@ class SummarySearchServiceTest {
         given(summaryRepository.findLatestByAiChatSessionIdIn(List.of(1000L))).willReturn(List.of());
         given(bookRepository.findAllById(List.of(100L))).willReturn(List.of(book));
 
-        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(JUNE, USER_SESSION_ID);
+        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(JUNE, USER_ID);
 
         assertThat(results).extracting(MonthlyReadingRecordResult::chatSessionId).containsExactly(1000L);
     }
@@ -188,7 +171,6 @@ class SummarySearchServiceTest {
         AiChatSession older = AiChatSessionFixture.persistedActiveSession(1000L, 10L, 3, 100, "오래된 대화");
         AiChatSession newer = AiChatSessionFixture.persistedActiveSession(1001L, 10L, 3, 100, "최근 대화");
 
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(userBookRepository.findByUserId(USER_ID)).willReturn(List.of(userBook));
         given(aiChatSessionRepository.findByUserBookIdIn(List.of(10L)))
                 .willReturn(List.of(older, newer));
@@ -200,7 +182,7 @@ class SummarySearchServiceTest {
         given(summaryRepository.findLatestByAiChatSessionIdIn(List.of(1000L, 1001L))).willReturn(List.of());
         given(bookRepository.findAllById(List.of(100L))).willReturn(List.of(book));
 
-        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(JUNE, USER_SESSION_ID);
+        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(JUNE, USER_ID);
 
         assertThat(results).extracting(MonthlyReadingRecordResult::chatSessionId)
                 .containsExactly(1001L, 1000L);
@@ -215,7 +197,6 @@ class SummarySearchServiceTest {
         AiChatSession monthEnd = AiChatSessionFixture.persistedActiveSession(1001L, 10L, 3, 100, "월말");
         AiChatSession nextMonth = AiChatSessionFixture.persistedActiveSession(1002L, 10L, 3, 100, "다음달 0시");
 
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(userBookRepository.findByUserId(USER_ID)).willReturn(List.of(userBook));
         given(aiChatSessionRepository.findByUserBookIdIn(List.of(10L)))
                 .willReturn(List.of(monthStart, monthEnd, nextMonth));
@@ -228,7 +209,7 @@ class SummarySearchServiceTest {
         given(summaryRepository.findLatestByAiChatSessionIdIn(List.of(1000L, 1001L))).willReturn(List.of());
         given(bookRepository.findAllById(List.of(100L))).willReturn(List.of(book));
 
-        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(JUNE, USER_SESSION_ID);
+        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(JUNE, USER_ID);
 
         // 월말(1001)이 최신순으로 앞, 월초(1000)가 뒤. 다음달 0시(1002)는 제외.
         assertThat(results).extracting(MonthlyReadingRecordResult::chatSessionId)
@@ -243,7 +224,6 @@ class SummarySearchServiceTest {
         AiChatSession lower = AiChatSessionFixture.persistedActiveSession(1000L, 10L, 3, 100, "같은 시각 A");
         AiChatSession higher = AiChatSessionFixture.persistedActiveSession(1001L, 10L, 3, 100, "같은 시각 B");
 
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(userBookRepository.findByUserId(USER_ID)).willReturn(List.of(userBook));
         given(aiChatSessionRepository.findByUserBookIdIn(List.of(10L)))
                 .willReturn(List.of(lower, higher));
@@ -255,7 +235,7 @@ class SummarySearchServiceTest {
         given(summaryRepository.findLatestByAiChatSessionIdIn(List.of(1000L, 1001L))).willReturn(List.of());
         given(bookRepository.findAllById(List.of(100L))).willReturn(List.of(book));
 
-        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(JUNE, USER_SESSION_ID);
+        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(JUNE, USER_ID);
 
         assertThat(results).extracting(MonthlyReadingRecordResult::chatSessionId)
                 .containsExactly(1001L, 1000L);
@@ -263,34 +243,22 @@ class SummarySearchServiceTest {
 
     @Test
     void 등록한_책이_없으면_세션_조회_없이_빈_리스트를_반환한다() {
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(userBookRepository.findByUserId(USER_ID)).willReturn(List.of());
 
-        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(JUNE, USER_SESSION_ID);
+        List<MonthlyReadingRecordResult> results = summarySearchService.findMonthly(JUNE, USER_ID);
 
         assertThat(results).isEmpty();
         verifyNoInteractions(aiChatSessionRepository, aiChatMessageRepository, summaryRepository, bookRepository);
     }
 
     @Test
-    void 월별_조회_시_세션이_유효하지_않으면_UnauthorizedException_을_던진다() {
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.empty());
-
-        assertThatThrownBy(() -> summarySearchService.findMonthly(JUNE, USER_SESSION_ID))
-                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
-                .extracting(UnauthorizedException::getErrorCode)
-                .isEqualTo(UserErrorCode.INVALID_SESSION);
-    }
-
-    @Test
     void 상세_조회는_본인_소유의_감상문을_반환한다() {
         Summary summary = SummaryFixture.persistedSummary(17L, 10L, 1000L, "감상문 제목", "감상문 본문");
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(summaryRepository.findById(17L)).willReturn(Optional.of(summary));
         given(userBookRepository.findByIdAndUserId(10L, USER_ID))
                 .willReturn(Optional.of(UserBookFixture.persistedUserBook(10L, USER_ID, 100L)));
 
-        SummaryResult result = summarySearchService.findById(17L, USER_SESSION_ID);
+        SummaryResult result = summarySearchService.findById(17L, USER_ID);
 
         assertThat(result.aiChatSessionId()).isEqualTo(1000L);
         assertThat(result.title()).isEqualTo("감상문 제목");
@@ -298,21 +266,10 @@ class SummarySearchServiceTest {
     }
 
     @Test
-    void 상세_조회_시_세션이_유효하지_않으면_UnauthorizedException_을_던진다() {
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.empty());
-
-        assertThatThrownBy(() -> summarySearchService.findById(17L, USER_SESSION_ID))
-                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
-                .extracting(UnauthorizedException::getErrorCode)
-                .isEqualTo(UserErrorCode.INVALID_SESSION);
-    }
-
-    @Test
     void 존재하지_않는_감상문을_상세_조회하면_NotFoundException_을_던진다() {
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(summaryRepository.findById(99L)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> summarySearchService.findById(99L, USER_SESSION_ID))
+        assertThatThrownBy(() -> summarySearchService.findById(99L, USER_ID))
                 .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
                 .extracting(NotFoundException::getErrorCode)
                 .isEqualTo(SummaryErrorCode.SUMMARY_NOT_FOUND);
@@ -321,11 +278,10 @@ class SummarySearchServiceTest {
     @Test
     void 남의_감상문을_상세_조회하면_NotFoundException_을_던진다() {
         Summary summary = SummaryFixture.persistedSummary(17L, 10L, 1000L, "감상문 제목", "감상문 본문");
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(summaryRepository.findById(17L)).willReturn(Optional.of(summary));
         given(userBookRepository.findByIdAndUserId(10L, USER_ID)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> summarySearchService.findById(17L, USER_SESSION_ID))
+        assertThatThrownBy(() -> summarySearchService.findById(17L, USER_ID))
                 .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
                 .extracting(NotFoundException::getErrorCode)
                 .isEqualTo(SummaryErrorCode.SUMMARY_NOT_FOUND);

--- a/src/test/java/com/readum/domain/summary/service/SummarySearchServiceTest.java
+++ b/src/test/java/com/readum/domain/summary/service/SummarySearchServiceTest.java
@@ -337,13 +337,12 @@ class SummarySearchServiceTest {
     void 세션_ID로_조회는_감상문을_반환한다() {
         AiChatSession active = AiChatSessionFixture.persistedActiveSession(SESSION_ID, 10L, 3, 100, null);
         Summary summary = SummaryFixture.persistedSummary(17L, 10L, SESSION_ID, "감상문 제목", "감상문 본문");
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(aiChatSessionRepository.findByIdAndOwner(SESSION_ID, USER_ID)).willReturn(Optional.of(active));
         given(summaryJobRepository.existsBlockingSummaryJob(eq(SESSION_ID), any(LocalDateTime.class)))
                 .willReturn(false);
         given(summaryRepository.findByAiChatSessionId(SESSION_ID)).willReturn(Optional.of(summary));
 
-        SummaryResult result = summarySearchService.findBySessionId(SESSION_ID, USER_SESSION_ID);
+        SummaryResult result = summarySearchService.findBySessionId(SESSION_ID, USER_ID);
 
         assertThat(result.title()).isEqualTo("감상문 제목");
         assertThat(result.body()).isEqualTo("감상문 본문");
@@ -353,12 +352,11 @@ class SummarySearchServiceTest {
     @Test
     void 세션_ID로_조회_시_차단_작업이_있으면_ConflictException_을_던진다() {
         AiChatSession active = AiChatSessionFixture.persistedActiveSession(SESSION_ID, 10L, 3, 100, null);
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(aiChatSessionRepository.findByIdAndOwner(SESSION_ID, USER_ID)).willReturn(Optional.of(active));
         given(summaryJobRepository.existsBlockingSummaryJob(eq(SESSION_ID), any(LocalDateTime.class)))
                 .willReturn(true);
 
-        assertThatThrownBy(() -> summarySearchService.findBySessionId(SESSION_ID, USER_SESSION_ID))
+        assertThatThrownBy(() -> summarySearchService.findBySessionId(SESSION_ID, USER_ID))
                 .asInstanceOf(InstanceOfAssertFactories.type(ConflictException.class))
                 .extracting(ConflictException::getErrorCode)
                 .isEqualTo(SummaryErrorCode.SUMMARY_IN_PROGRESS);
@@ -367,13 +365,12 @@ class SummarySearchServiceTest {
     @Test
     void 세션_ID로_조회_시_감상문이_없으면_NotFoundException_을_던진다() {
         AiChatSession active = AiChatSessionFixture.persistedActiveSession(SESSION_ID, 10L, 3, 100, null);
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(aiChatSessionRepository.findByIdAndOwner(SESSION_ID, USER_ID)).willReturn(Optional.of(active));
         given(summaryJobRepository.existsBlockingSummaryJob(eq(SESSION_ID), any(LocalDateTime.class)))
                 .willReturn(false);
         given(summaryRepository.findByAiChatSessionId(SESSION_ID)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> summarySearchService.findBySessionId(SESSION_ID, USER_SESSION_ID))
+        assertThatThrownBy(() -> summarySearchService.findBySessionId(SESSION_ID, USER_ID))
                 .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
                 .extracting(NotFoundException::getErrorCode)
                 .isEqualTo(SummaryErrorCode.SUMMARY_NOT_YET_CREATED);
@@ -381,10 +378,9 @@ class SummarySearchServiceTest {
 
     @Test
     void 세션_ID로_조회_시_세션이_없거나_소유권이_없으면_NotFoundException_을_던진다() {
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(aiChatSessionRepository.findByIdAndOwner(SESSION_ID, USER_ID)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> summarySearchService.findBySessionId(SESSION_ID, USER_SESSION_ID))
+        assertThatThrownBy(() -> summarySearchService.findBySessionId(SESSION_ID, USER_ID))
                 .asInstanceOf(InstanceOfAssertFactories.type(NotFoundException.class))
                 .extracting(NotFoundException::getErrorCode)
                 .isEqualTo(AiChatErrorCode.SESSION_NOT_FOUND);

--- a/src/test/java/com/readum/domain/user/service/CompleteOnboardingServiceTest.java
+++ b/src/test/java/com/readum/domain/user/service/CompleteOnboardingServiceTest.java
@@ -1,11 +1,8 @@
 package com.readum.domain.user.service;
 
-import com.readum.domain.exception.UnauthorizedException;
 import com.readum.domain.user.dto.CompleteOnboardingResult;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.user.entity.User;
 import com.readum.model.user.repository.UserRepository;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -17,11 +14,12 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class CompleteOnboardingServiceTest {
+
+    private static final Long USER_ID = 1L;
 
     @Mock
     private UserRepository userRepository;
@@ -31,12 +29,11 @@ class CompleteOnboardingServiceTest {
 
     @Test
     void 미완료_사용자에_대해_온보딩을_완료_상태로_변경한다() {
-        UUID sessionId = UUID.randomUUID();
-        User user = User.create(sessionId, "책읽는여우");
+        User user = User.create(UUID.randomUUID(), "책읽는여우");
 
-        given(userRepository.findBySessionId(sessionId.toString())).willReturn(Optional.of(user));
+        given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
 
-        CompleteOnboardingResult result = completeOnboardingService.execute(sessionId.toString());
+        CompleteOnboardingResult result = completeOnboardingService.execute(USER_ID);
 
         assertThat(result.onboardingCompleted()).isTrue();
         assertThat(user.isOnboardingCompleted()).isTrue();
@@ -44,28 +41,16 @@ class CompleteOnboardingServiceTest {
 
     @Test
     void 이미_완료된_사용자에_대해_멱등하게_true_를_반환한다() {
-        UUID sessionId = UUID.randomUUID();
-        User user = User.create(sessionId, "책읽는여우");
+        User user = User.create(UUID.randomUUID(), "책읽는여우");
         user.completeOnboarding();
         LocalDateTime previousUpdatedAt = user.getUpdatedAt();
 
-        given(userRepository.findBySessionId(sessionId.toString())).willReturn(Optional.of(user));
+        given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
 
-        CompleteOnboardingResult result = completeOnboardingService.execute(sessionId.toString());
+        CompleteOnboardingResult result = completeOnboardingService.execute(USER_ID);
 
         assertThat(result.onboardingCompleted()).isTrue();
         assertThat(user.isOnboardingCompleted()).isTrue();
         assertThat(user.getUpdatedAt()).isEqualTo(previousUpdatedAt);
-    }
-
-    @Test
-    void 존재하지_않는_세션이면_INVALID_SESSION_예외가_발생한다() {
-        String unknown = UUID.randomUUID().toString();
-        given(userRepository.findBySessionId(unknown)).willReturn(Optional.empty());
-
-        assertThatThrownBy(() -> completeOnboardingService.execute(unknown))
-                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
-                .extracting(UnauthorizedException::getErrorCode)
-                .isEqualTo(UserErrorCode.INVALID_SESSION);
     }
 }

--- a/src/test/java/com/readum/domain/user/service/UpdateNicknameServiceTest.java
+++ b/src/test/java/com/readum/domain/user/service/UpdateNicknameServiceTest.java
@@ -1,7 +1,6 @@
 package com.readum.domain.user.service;
 
 import com.readum.domain.exception.BadRequestException;
-import com.readum.domain.exception.UnauthorizedException;
 import com.readum.domain.user.dto.UpdateNicknameCommand;
 import com.readum.domain.user.dto.UpdateNicknameResult;
 import com.readum.domain.user.exception.UserErrorCode;
@@ -18,7 +17,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -26,6 +24,8 @@ import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class UpdateNicknameServiceTest {
+
+    private static final Long USER_ID = 1L;
 
     @Mock
     private UserRepository userRepository;
@@ -35,36 +35,21 @@ class UpdateNicknameServiceTest {
 
     @Test
     void 닉네임을_정상적으로_수정한다() {
-        String sessionId = UUID.randomUUID().toString();
-        User user = UserFixture.persistedUser(1L, sessionId, "책읽는여우");
-        given(userRepository.findBySessionId(sessionId)).willReturn(Optional.of(user));
+        User user = UserFixture.persistedUser(USER_ID, "any-session-id", "책읽는여우");
+        given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
 
         UpdateNicknameResult result = updateNicknameService.execute(
-                new UpdateNicknameCommand(sessionId, "새닉네임"));
+                new UpdateNicknameCommand(USER_ID, "새닉네임"));
 
         assertThat(result.nickname()).isEqualTo("새닉네임");
         assertThat(user.getNickname()).isEqualTo("새닉네임");
     }
 
-    @Test
-    void 존재하지_않는_세션이면_예외가_발생한다() {
-        String sessionId = UUID.randomUUID().toString();
-        given(userRepository.findBySessionId(sessionId)).willReturn(Optional.empty());
-
-        assertThatThrownBy(() -> updateNicknameService.execute(
-                new UpdateNicknameCommand(sessionId, "새닉네임")))
-                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
-                .extracting(UnauthorizedException::getErrorCode)
-                .isEqualTo(UserErrorCode.INVALID_SESSION);
-    }
-
     @ParameterizedTest
     @ValueSource(strings = {"", "12345678901", "닉네임 공백", "특수문자!", "nick@name"})
     void 닉네임_형식이_올바르지_않으면_예외가_발생한다(String invalidNickname) {
-        String sessionId = UUID.randomUUID().toString();
-
         assertThatThrownBy(() -> updateNicknameService.execute(
-                new UpdateNicknameCommand(sessionId, invalidNickname)))
+                new UpdateNicknameCommand(USER_ID, invalidNickname)))
                 .asInstanceOf(InstanceOfAssertFactories.type(BadRequestException.class))
                 .extracting(BadRequestException::getErrorCode)
                 .isEqualTo(UserErrorCode.INVALID_NICKNAME);

--- a/src/test/java/com/readum/domain/user/service/UserSearchServiceTest.java
+++ b/src/test/java/com/readum/domain/user/service/UserSearchServiceTest.java
@@ -1,14 +1,11 @@
 package com.readum.domain.user.service;
 
-import com.readum.domain.exception.UnauthorizedException;
 import com.readum.domain.user.dto.UserProfileResult;
 import com.readum.domain.user.dto.UserSessionInfoResult;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.model.user.repository.UserBookRepository;
 import com.readum.model.user.entity.User;
 import com.readum.model.user.entity.UserFixture;
 import com.readum.model.user.repository.UserRepository;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,10 +13,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,14 +30,13 @@ class UserSearchServiceTest {
     private UserSearchService userSearchService;
 
     @Test
-    void 유효한_세션이면_세션_정보를_반환한다() {
-        UUID sessionId = UUID.randomUUID();
-        User user = UserFixture.persistedUser(10L, sessionId.toString(), 7L, false);
+    void 인증된_사용자면_세션_정보를_반환한다() {
+        User user = UserFixture.persistedUser(10L, "any-session-id", 7L, false);
 
-        given(userRepository.findBySessionId(sessionId.toString())).willReturn(Optional.of(user));
+        given(userRepository.findById(10L)).willReturn(Optional.of(user));
         given(userBookRepository.existsByUserId(10L)).willReturn(true);
 
-        UserSessionInfoResult result = userSearchService.findSessionInfo(sessionId.toString());
+        UserSessionInfoResult result = userSearchService.findSessionInfo(10L);
 
         assertThat(result.lastSelectedUserBookId()).isEqualTo(7L);
         assertThat(result.hasRegisteredBooks()).isTrue();
@@ -51,13 +45,12 @@ class UserSearchServiceTest {
 
     @Test
     void 등록된_도서가_없으면_hasRegisteredBooks_가_false_이다() {
-        UUID sessionId = UUID.randomUUID();
-        User user = UserFixture.persistedUser(11L, sessionId.toString(), null, true);
+        User user = UserFixture.persistedUser(11L, "any-session-id", null, true);
 
-        given(userRepository.findBySessionId(sessionId.toString())).willReturn(Optional.of(user));
+        given(userRepository.findById(11L)).willReturn(Optional.of(user));
         given(userBookRepository.existsByUserId(11L)).willReturn(false);
 
-        UserSessionInfoResult result = userSearchService.findSessionInfo(sessionId.toString());
+        UserSessionInfoResult result = userSearchService.findSessionInfo(11L);
 
         assertThat(result.lastSelectedUserBookId()).isNull();
         assertThat(result.hasRegisteredBooks()).isFalse();
@@ -65,48 +58,24 @@ class UserSearchServiceTest {
     }
 
     @Test
-    void 존재하지_않는_세션이면_INVALID_SESSION_예외가_발생한다() {
-        String unknown = UUID.randomUUID().toString();
-        given(userRepository.findBySessionId(unknown)).willReturn(Optional.empty());
+    void 인증된_사용자면_프로필_닉네임을_반환한다() {
+        User user = UserFixture.persistedUser(20L, "any-session-id", "문장수집가");
 
-        assertThatThrownBy(() -> userSearchService.findSessionInfo(unknown))
-                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
-                .extracting(UnauthorizedException::getErrorCode)
-                .isEqualTo(UserErrorCode.INVALID_SESSION);
-    }
+        given(userRepository.findById(20L)).willReturn(Optional.of(user));
 
-    @Test
-    void 유효한_세션이면_프로필_닉네임을_반환한다() {
-        UUID sessionId = UUID.randomUUID();
-        User user = UserFixture.persistedUser(20L, sessionId.toString(), "문장수집가");
-
-        given(userRepository.findBySessionId(sessionId.toString())).willReturn(Optional.of(user));
-
-        UserProfileResult result = userSearchService.findProfile(sessionId.toString());
+        UserProfileResult result = userSearchService.findProfile(20L);
 
         assertThat(result.nickname()).isEqualTo("문장수집가");
     }
 
     @Test
     void 닉네임이_없는_기존_사용자의_프로필은_닉네임이_null_이다() {
-        UUID sessionId = UUID.randomUUID();
-        User user = UserFixture.persistedUser(21L, sessionId.toString(), (String) null);
+        User user = UserFixture.persistedUser(21L, "any-session-id", (String) null);
 
-        given(userRepository.findBySessionId(sessionId.toString())).willReturn(Optional.of(user));
+        given(userRepository.findById(21L)).willReturn(Optional.of(user));
 
-        UserProfileResult result = userSearchService.findProfile(sessionId.toString());
+        UserProfileResult result = userSearchService.findProfile(21L);
 
         assertThat(result.nickname()).isNull();
-    }
-
-    @Test
-    void 존재하지_않는_세션으로_프로필을_조회하면_INVALID_SESSION_예외가_발생한다() {
-        String unknown = UUID.randomUUID().toString();
-        given(userRepository.findBySessionId(unknown)).willReturn(Optional.empty());
-
-        assertThatThrownBy(() -> userSearchService.findProfile(unknown))
-                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
-                .extracting(UnauthorizedException::getErrorCode)
-                .isEqualTo(UserErrorCode.INVALID_SESSION);
     }
 }

--- a/src/test/java/com/readum/domain/user/userbook/service/UserBookCreateServiceTest.java
+++ b/src/test/java/com/readum/domain/user/userbook/service/UserBookCreateServiceTest.java
@@ -11,12 +11,8 @@ import com.readum.model.book.entity.BookFixture;
 import com.readum.model.user.entity.UserBook;
 import com.readum.model.user.entity.UserBookFixture;
 import com.readum.model.book.repository.BookRepository;
-import com.readum.model.user.entity.User;
-import com.readum.model.user.entity.UserFixture;
 import com.readum.model.user.repository.UserBookRepository;
-import com.readum.model.user.repository.UserRepository;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -38,9 +34,6 @@ import static org.mockito.Mockito.verify;
 class UserBookCreateServiceTest {
 
     @Mock
-    private UserRepository userRepository;
-
-    @Mock
     private BookLookupClient bookLookupClient;
 
     @Mock
@@ -56,7 +49,6 @@ class UserBookCreateServiceTest {
     private UserBookCreateService userBookCreateService;
 
     private static final Long USER_ID = 1L;
-    private static final String USER_SESSION_ID = "test-session-id";
     private static final Long BOOK_ID = 10L;
     private static final String EXTERNAL_ID = "9788965700807";
     private static final String TITLE = "테스트 책";
@@ -65,15 +57,8 @@ class UserBookCreateServiceTest {
     private static final Integer PUBLISHED_YEAR = 2024;
     private static final String COVER_URL = "http://example.com/cover.jpg";
 
-    @BeforeEach
-    void setUp() {
-        User testUser = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
-        org.mockito.Mockito.lenient().when(userRepository.findBySessionId(USER_SESSION_ID))
-                .thenReturn(Optional.of(testUser));
-    }
-
     private UserBookCreateCommand command() {
-        return new UserBookCreateCommand(USER_SESSION_ID, EXTERNAL_ID);
+        return new UserBookCreateCommand(USER_ID, EXTERNAL_ID);
     }
 
     private BookResult stubBookResult() {

--- a/src/test/java/com/readum/domain/user/userbook/service/UserBookDeleteServiceCascadeTest.java
+++ b/src/test/java/com/readum/domain/user/userbook/service/UserBookDeleteServiceCascadeTest.java
@@ -84,7 +84,7 @@ class UserBookDeleteServiceCascadeTest {
         long bookMasterCountBefore = bookRepository.count();
 
         UserBookDeleteResult result = userBookDeleteService.execute(
-                new UserBookDeleteCommand(user.getSessionId(), userBook1.getId()));
+                new UserBookDeleteCommand(user.getId(), userBook1.getId()));
 
         // 삭제 카운트가 실제 삭제된 행 수와 일치
         assertThat(result.userBookId()).isEqualTo(userBook1.getId());
@@ -140,7 +140,7 @@ class UserBookDeleteServiceCascadeTest {
         Summary summaryB = persistSummary(userBookB.getId(), sessionB.getId());
 
         userBookDeleteService.execute(
-                new UserBookDeleteCommand(userA.getSessionId(), userBookA.getId()));
+                new UserBookDeleteCommand(userA.getId(), userBookA.getId()));
 
         // A 의 도서와 연관 데이터는 사라짐
         assertThat(userBookRepository.findById(userBookA.getId())).isEmpty();

--- a/src/test/java/com/readum/domain/user/userbook/service/UserBookDeleteServiceTest.java
+++ b/src/test/java/com/readum/domain/user/userbook/service/UserBookDeleteServiceTest.java
@@ -1,8 +1,6 @@
 package com.readum.domain.user.userbook.service;
 
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.domain.user.userbook.dto.UserBookDeleteCommand;
 import com.readum.domain.user.userbook.dto.UserBookDeleteResult;
 import com.readum.domain.user.userbook.exception.UserBookErrorCode;
@@ -10,14 +8,11 @@ import com.readum.model.aiChat.repository.AiChatMessageRepository;
 import com.readum.model.aiChat.repository.AiChatSessionRepository;
 import com.readum.model.summary.repository.SummaryJobRepository;
 import com.readum.model.summary.repository.SummaryRepository;
-import com.readum.model.user.entity.User;
 import com.readum.model.user.entity.UserBook;
 import com.readum.model.user.entity.UserBookFixture;
-import com.readum.model.user.entity.UserFixture;
 import com.readum.model.user.repository.UserBookRepository;
 import com.readum.model.user.repository.UserRepository;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
@@ -60,19 +55,11 @@ class UserBookDeleteServiceTest {
     private UserBookDeleteService userBookDeleteService;
 
     private static final Long USER_ID = 1L;
-    private static final String USER_SESSION_ID = "test-session-id";
     private static final Long BOOK_ID = 10L;
     private static final Long USER_BOOK_ID = 100L;
 
     private UserBookDeleteCommand command() {
-        return new UserBookDeleteCommand(USER_SESSION_ID, USER_BOOK_ID);
-    }
-
-    @BeforeEach
-    void setUp() {
-        User user = UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
-        org.mockito.Mockito.lenient().when(userRepository.findBySessionId(USER_SESSION_ID))
-                .thenReturn(Optional.of(user));
+        return new UserBookDeleteCommand(USER_ID, USER_BOOK_ID);
     }
 
     @Test
@@ -104,18 +91,6 @@ class UserBookDeleteServiceTest {
         assertThat(result.deletedMessages()).isEqualTo(7);
         assertThat(result.deletedSessions()).isEqualTo(3);
         assertThat(result.deletedSummaries()).isEqualTo(2);
-    }
-
-    @Test
-    void 유효하지_않은_세션이면_UnauthorizedException_이_발생하고_어떤_삭제도_실행되지_않는다() {
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.empty());
-
-        assertThatThrownBy(() -> userBookDeleteService.execute(command()))
-                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
-                .satisfies(ex -> assertThat(ex.getErrorCode()).isEqualTo(UserErrorCode.INVALID_SESSION));
-
-        verify(userBookRepository, never()).findByIdAndUserId(anyLong(), anyLong());
-        verifyNoDeletes();
     }
 
     @Test

--- a/src/test/java/com/readum/domain/user/userbook/service/UserBookSearchServiceTest.java
+++ b/src/test/java/com/readum/domain/user/userbook/service/UserBookSearchServiceTest.java
@@ -1,14 +1,8 @@
 package com.readum.domain.user.userbook.service;
 
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.domain.user.userbook.dto.UserBookSearchResult;
-import com.readum.model.user.entity.User;
-import com.readum.model.user.entity.UserFixture;
 import com.readum.model.user.repository.UserBookRepository;
-import com.readum.model.user.repository.UserRepository;
 import com.readum.model.user.repository.projection.UserBookListItemProjection;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,17 +10,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class UserBookSearchServiceTest {
-
-    @Mock
-    private UserRepository userRepository;
 
     @Mock
     private UserBookRepository userBookRepository;
@@ -35,22 +24,16 @@ class UserBookSearchServiceTest {
     private UserBookSearchService userBookSearchService;
 
     private static final Long USER_ID = 1L;
-    private static final String USER_SESSION_ID = "test-session-id";
-
-    private User stubUser() {
-        return UserFixture.persistedUser(USER_ID, USER_SESSION_ID);
-    }
 
     @Test
-    void 유효한_user_session_으로_조회하면_등록한_도서_목록을_반환한다() {
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
+    void 인증된_사용자로_조회하면_등록한_도서_목록을_반환한다() {
         given(userBookRepository.findAllByUserIdOrderByCreatedAtDescIdDesc(USER_ID))
                 .willReturn(List.of(
                         new UserBookListItemProjection(20L, 2L, "최근 등록한 책", "출판사B", 2025, "http://example.com/b.jpg", 3L),
                         new UserBookListItemProjection(10L, 1L, "이전에 등록한 책", "출판사A", 2024, "http://example.com/a.jpg", 0L)
                 ));
 
-        UserBookSearchResult result = userBookSearchService.findMyBooks(USER_SESSION_ID);
+        UserBookSearchResult result = userBookSearchService.findMyBooks(USER_ID);
 
         assertThat(result.books()).hasSize(2);
         assertThat(result.books().get(0).userBookId()).isEqualTo(20L);
@@ -68,21 +51,11 @@ class UserBookSearchServiceTest {
 
     @Test
     void 등록된_도서가_없으면_빈_books_리스트를_반환한다() {
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.of(stubUser()));
         given(userBookRepository.findAllByUserIdOrderByCreatedAtDescIdDesc(USER_ID))
                 .willReturn(List.of());
 
-        UserBookSearchResult result = userBookSearchService.findMyBooks(USER_SESSION_ID);
+        UserBookSearchResult result = userBookSearchService.findMyBooks(USER_ID);
 
         assertThat(result.books()).isEmpty();
-    }
-
-    @Test
-    void 세션이_유효하지_않으면_UnauthorizedException_을_던진다() {
-        given(userRepository.findBySessionId(USER_SESSION_ID)).willReturn(Optional.empty());
-
-        assertThatThrownBy(() -> userBookSearchService.findMyBooks(USER_SESSION_ID))
-                .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))
-                .satisfies(ex -> assertThat(ex.getErrorCode()).isEqualTo(UserErrorCode.INVALID_SESSION));
     }
 }

--- a/src/test/java/com/readum/infrastructure/ai/openai/ratelimit/AiChatRateLimitInterceptorTest.java
+++ b/src/test/java/com/readum/infrastructure/ai/openai/ratelimit/AiChatRateLimitInterceptorTest.java
@@ -1,117 +1,123 @@
 package com.readum.infrastructure.ai.openai.ratelimit;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-@Tag("guardrail")
+@ExtendWith(MockitoExtension.class)
 class AiChatRateLimitInterceptorTest {
 
-    @AfterEach
-    void clearContext() {
-        SecurityContextHolder.clearContext();
+    @Mock
+    private AiChatRateLimiter rateLimiter;
+
+    private AiChatRateLimitInterceptor interceptor;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        interceptor = new AiChatRateLimitInterceptor(rateLimiter);
+        request = new MockHttpServletRequest("POST", "/api/v1/ai-chat/sessions/1/messages");
+        response = new MockHttpServletResponse();
+    }
+
+    private void authenticateAs(long userId) {
+        request.setUserPrincipal(new UsernamePasswordAuthenticationToken(
+                userId, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))));
     }
 
     @Test
-    void 한도_내_요청은_통과한다() throws Exception {
-        AiChatRateLimiter limiter = mock(AiChatRateLimiter.class);
-        given(limiter.isEnabled()).willReturn(true);
-        given(limiter.tryConsume(any())).willReturn(true);
-        AiChatRateLimitInterceptor interceptor = new AiChatRateLimitInterceptor(limiter);
+    void 한도_키는_사용자_userId_기준이다() throws Exception {
+        given(rateLimiter.isEnabled()).willReturn(true);
+        given(rateLimiter.tryConsume(anyString())).willReturn(true);
+        authenticateAs(7L);
 
-        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/ai-chat/stream");
-        request.setRemoteAddr("203.0.113.10");
-        MockHttpServletResponse response = new MockHttpServletResponse();
+        interceptor.preHandle(request, response, new Object());
 
-        boolean proceeded = interceptor.preHandle(request, response, new Object());
-
-        assertThat(proceeded).isTrue();
-        assertThat(response.getStatus()).isEqualTo(200);
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(rateLimiter).tryConsume(keyCaptor.capture());
+        assertThat(keyCaptor.getValue()).isEqualTo("user:7");
     }
 
     @Test
-    void 한도_초과시_429_응답을_반환하고_체인을_중단한다() throws Exception {
-        AiChatRateLimiter limiter = mock(AiChatRateLimiter.class);
-        given(limiter.isEnabled()).willReturn(true);
-        given(limiter.tryConsume(any())).willReturn(false);
-        AiChatRateLimitInterceptor interceptor = new AiChatRateLimitInterceptor(limiter);
+    void 같은_IP_라도_사용자가_다르면_다른_키로_소비한다() throws Exception {
+        // 6/20 사고 재현 방지: 프록시가 IP 를 합쳐도 사용자별 버킷이 분리되어야 한다.
+        given(rateLimiter.isEnabled()).willReturn(true);
+        given(rateLimiter.tryConsume(anyString())).willReturn(true);
 
-        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/ai-chat/stream");
-        request.setRemoteAddr("203.0.113.10");
-        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.setRemoteAddr("13.236.146.104");
+        authenticateAs(1L);
+        interceptor.preHandle(request, response, new Object());
 
-        boolean proceeded = interceptor.preHandle(request, response, new Object());
+        MockHttpServletRequest secondRequest =
+                new MockHttpServletRequest("POST", "/api/v1/ai-chat/sessions/2/messages");
+        secondRequest.setRemoteAddr("13.236.146.104");
+        secondRequest.setUserPrincipal(new UsernamePasswordAuthenticationToken(
+                2L, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+        interceptor.preHandle(secondRequest, response, new Object());
 
-        assertThat(proceeded).isFalse();
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(rateLimiter, times(2)).tryConsume(keyCaptor.capture());
+        assertThat(keyCaptor.getAllValues()).containsExactly("user:1", "user:2");
+    }
+
+    @Test
+    void principal_이_없으면_IP_로_대체하지_않고_설정_버그로_드러낸다() throws Exception {
+        given(rateLimiter.isEnabled()).willReturn(true);
+
+        assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+                .isInstanceOf(IllegalStateException.class);
+        verify(rateLimiter, never()).tryConsume(anyString());
+    }
+
+    @Test
+    void POST_가_아닌_요청은_한도를_소비하지_않는다() throws Exception {
+        given(rateLimiter.isEnabled()).willReturn(true);
+        MockHttpServletRequest getRequest =
+                new MockHttpServletRequest("GET", "/api/v1/ai-chat/sessions/1/messages");
+
+        boolean allowed = interceptor.preHandle(getRequest, response, new Object());
+
+        assertThat(allowed).isTrue();
+        verify(rateLimiter, never()).tryConsume(anyString());
+    }
+
+    @Test
+    void 한도_초과면_429_와_에러_본문을_반환한다() throws Exception {
+        given(rateLimiter.isEnabled()).willReturn(true);
+        given(rateLimiter.tryConsume(anyString())).willReturn(false);
+        authenticateAs(7L);
+
+        boolean allowed = interceptor.preHandle(request, response, new Object());
+
+        assertThat(allowed).isFalse();
         assertThat(response.getStatus()).isEqualTo(429);
-        assertThat(response.getContentAsString()).contains("AI 채팅 호출 한도를 초과했습니다");
+        assertThat(response.getContentAsString()).contains("호출 한도");
     }
 
     @Test
     void enabled_가_false_면_무조건_통과한다() throws Exception {
-        AiChatRateLimiter limiter = mock(AiChatRateLimiter.class);
-        given(limiter.isEnabled()).willReturn(false);
-        AiChatRateLimitInterceptor interceptor = new AiChatRateLimitInterceptor(limiter);
-
-        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/ai-chat/stream");
-        MockHttpServletResponse response = new MockHttpServletResponse();
+        given(rateLimiter.isEnabled()).willReturn(false);
 
         boolean proceeded = interceptor.preHandle(request, response, new Object());
 
         assertThat(proceeded).isTrue();
-    }
-
-    @Test
-    void 인증_principal_이_있으면_user_key_를_사용한다() throws Exception {
-        AiChatRateLimiter limiter = mock(AiChatRateLimiter.class);
-        given(limiter.isEnabled()).willReturn(true);
-        given(limiter.tryConsume("user:42")).willReturn(true);
-        AiChatRateLimitInterceptor interceptor = new AiChatRateLimitInterceptor(limiter);
-
-        SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken(42L, null, List.of())
-        );
-
-        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/ai-chat/stream");
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        boolean proceeded = interceptor.preHandle(request, response, new Object());
-
-        assertThat(proceeded).isTrue();
-    }
-
-    @Test
-    void X_Forwarded_For_헤더는_신뢰하지_않고_getRemoteAddr_만_사용한다() throws Exception {
-        // 클라이언트가 X-Forwarded-For 헤더만 바꿔서 IP bucket 을 갈아치우려 해도,
-        // 실제 식별자는 getRemoteAddr() 기준으로 결정되어야 한다.
-        AiChatRateLimiter limiter = mock(AiChatRateLimiter.class);
-        given(limiter.isEnabled()).willReturn(true);
-        given(limiter.tryConsume("ip:203.0.113.10")).willReturn(true);
-        AiChatRateLimitInterceptor interceptor = new AiChatRateLimitInterceptor(limiter);
-
-        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/ai-chat/stream");
-        request.setRemoteAddr("203.0.113.10");
-        request.addHeader("X-Forwarded-For", "1.2.3.4, 5.6.7.8");      // 무시되어야 함
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        boolean proceeded = interceptor.preHandle(request, response, new Object());
-
-        assertThat(proceeded).isTrue();
-        // limiter.tryConsume("ip:203.0.113.10") 만 매칭되도록 stubbing 했으므로,
-        // XFF 의 "1.2.3.4" 가 사용됐다면 stubbed 된 mock 이 false 를 반환해 429 가 됐을 것.
-        assertThat(response.getStatus()).isEqualTo(200);
     }
 }

--- a/src/test/java/com/readum/model/user/repository/UserBookConcurrencyTest.java
+++ b/src/test/java/com/readum/model/user/repository/UserBookConcurrencyTest.java
@@ -48,7 +48,6 @@ class UserBookConcurrencyTest {
 
     private static final String EXTERNAL_ID = "concurrent-race-condition-test-isbn";
 
-    private String userSessionId;
     private Long userId;
 
     @BeforeEach
@@ -56,10 +55,9 @@ class UserBookConcurrencyTest {
         given(bookLookupClient.execute(EXTERNAL_ID)).willReturn(
                 new BookResult("http://example.com/cover.jpg", "동시성 테스트 책", "저자", "출판사", 2024, EXTERNAL_ID)
         );
-        // 임시 cookie 인증 패턴 — UserRepository 로 User row 를 만들고 그 session_id 를 명령 인자로 쓴다.
+        // 인증된 userId 를 명령 인자로 쓴다 — UserRepository 로 User row 를 만들고 그 id 를 넘긴다.
         // session_id unique 제약을 회피하기 위해 매 실행마다 UUID 로 다른 값을 쓴다.
         User saved = userRepository.save(User.create(UUID.randomUUID(), "책읽는여우"));
-        userSessionId = saved.getSessionId();
         userId = saved.getId();
     }
 
@@ -81,7 +79,7 @@ class UserBookConcurrencyTest {
 
         List<Object> results = new CopyOnWriteArrayList<>();
 
-        UserBookCreateCommand command = new UserBookCreateCommand(userSessionId, EXTERNAL_ID);
+        UserBookCreateCommand command = new UserBookCreateCommand(userId, EXTERNAL_ID);
 
         for (int i = 0; i < threadCount; i++) {
             executor.submit(() -> {

--- a/src/test/java/com/readum/presentation/common/security/AuthenticatedUserIdArgumentResolverTest.java
+++ b/src/test/java/com/readum/presentation/common/security/AuthenticatedUserIdArgumentResolverTest.java
@@ -1,0 +1,64 @@
+package com.readum.presentation.common.security;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AuthenticatedUserIdArgumentResolverTest {
+
+    @RestController
+    static class ProbeController {
+        @GetMapping("/probe/authenticated-user-id")
+        String probe(@AuthenticatedUserId Long userId) {
+            return String.valueOf(userId);
+        }
+    }
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new ProbeController())
+                .setCustomArgumentResolvers(new AuthenticatedUserIdArgumentResolver())
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void principal_의_userId_가_컨트롤러_파라미터로_주입된다() throws Exception {
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                7L, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+
+        mockMvc.perform(get("/probe/authenticated-user-id"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("7"));
+    }
+
+    @Test
+    void principal_이_없으면_보안_설정_버그로_보고_즉시_실패한다() {
+        // 인증 필요 경로는 Security 계층이 먼저 401 을 낸다 — resolver 까지 왔는데 principal 이
+        // 없다는 건 설정 버그이므로, 조용한 대체 동작 없이 IllegalStateException 으로 드러낸다.
+        AuthenticatedUserIdArgumentResolver resolver = new AuthenticatedUserIdArgumentResolver();
+
+        assertThatThrownBy(() -> resolver.resolveArgument(null, null, null, null))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/src/test/java/com/readum/presentation/common/security/SessionCookieAuthenticationFilterTest.java
+++ b/src/test/java/com/readum/presentation/common/security/SessionCookieAuthenticationFilterTest.java
@@ -1,0 +1,101 @@
+package com.readum.presentation.common.security;
+
+import com.readum.domain.auth.service.SessionAuthenticationService;
+import com.readum.domain.exception.UnauthorizedException;
+import com.readum.domain.user.exception.UserErrorCode;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class SessionCookieAuthenticationFilterTest {
+
+    @Mock
+    private SessionAuthenticationService sessionAuthenticationService;
+
+    private SessionCookieAuthenticationFilter filter;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private MockFilterChain chain;
+
+    @BeforeEach
+    void setUp() {
+        filter = new SessionCookieAuthenticationFilter(sessionAuthenticationService);
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        chain = new MockFilterChain();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void 유효한_세션_쿠키면_principal_에_userId_가_채워진다() throws Exception {
+        request.setCookies(new Cookie(SessionCookieAuthenticationFilter.USER_SESSION_COOKIE, "valid-session-id"));
+        given(sessionAuthenticationService.authenticate("valid-session-id")).willReturn(7L);
+
+        filter.doFilter(request, response, chain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.getPrincipal()).isEqualTo(7L);
+        assertThat(authentication.getAuthorities())
+                .extracting(GrantedAuthority::getAuthority)
+                .containsExactly("ROLE_USER");
+        assertThat(chain.getRequest()).as("체인이 계속 진행되어야 한다").isNotNull();
+    }
+
+    @Test
+    void 쿠키가_없으면_principal_을_채우지_않고_통과한다() throws Exception {
+        filter.doFilter(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        assertThat(chain.getRequest()).isNotNull();
+        verifyNoInteractions(sessionAuthenticationService);
+    }
+
+    @Test
+    void 무효한_세션이면_principal_을_비운_채_통과한다() throws Exception {
+        request.setCookies(new Cookie(SessionCookieAuthenticationFilter.USER_SESSION_COOKIE, "invalid-session-id"));
+        given(sessionAuthenticationService.authenticate("invalid-session-id"))
+                .willThrow(new UnauthorizedException(UserErrorCode.INVALID_SESSION));
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        assertThat(chain.getRequest()).isNotNull();
+    }
+
+    @Test
+    void 이미_JWT_인증이_되어_있으면_세션_해석을_시도하지_않는다() throws Exception {
+        UsernamePasswordAuthenticationToken existing = new UsernamePasswordAuthenticationToken(
+                5L, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        SecurityContextHolder.getContext().setAuthentication(existing);
+        request.setCookies(new Cookie(SessionCookieAuthenticationFilter.USER_SESSION_COOKIE, "valid-session-id"));
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isSameAs(existing);
+        verifyNoInteractions(sessionAuthenticationService);
+    }
+}

--- a/src/test/java/com/readum/presentation/common/security/SessionCookieAuthenticationIntegrationTest.java
+++ b/src/test/java/com/readum/presentation/common/security/SessionCookieAuthenticationIntegrationTest.java
@@ -1,0 +1,58 @@
+package com.readum.presentation.common.security;
+
+import com.readum.model.user.entity.User;
+import com.readum.model.user.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class SessionCookieAuthenticationIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void 유효한_세션_쿠키로_인증_필요_경로에_접근하면_200_을_받는다() throws Exception {
+        UUID sessionId = UUID.randomUUID();
+        userRepository.save(User.create(sessionId, "책읽는여우"));
+
+        mockMvc.perform(get("/api/v1/users/me/profile")
+                        .cookie(new Cookie("user_session", sessionId.toString())))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 쿠키_없이_인증_필요_경로에_접근하면_Security_계층이_401_을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/v1/users/me/profile"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 무효한_세션_쿠키면_401_을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/v1/users/me/profile")
+                        .cookie(new Cookie("user_session", "no-such-session")))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 쿠키_발급_엔드포인트는_익명으로_접근할_수_있다() throws Exception {
+        mockMvc.perform(post("/api/v1/users/sessions"))
+                .andExpect(status().isCreated());
+    }
+}

--- a/src/test/java/com/readum/presentation/controller/aiChat/AiChatControllerTest.java
+++ b/src/test/java/com/readum/presentation/controller/aiChat/AiChatControllerTest.java
@@ -27,15 +27,19 @@ import com.readum.domain.exception.NotFoundException;
 import com.readum.domain.exception.UnprocessableEntityException;
 import com.readum.model.aiChat.entity.AiChatMessage;
 import com.readum.presentation.common.GlobalExceptionHandler;
+import com.readum.presentation.common.security.AuthenticatedUserIdArgumentResolver;
 import com.readum.presentation.controller.aiChat.dto.AiChatSessionCreateRequest;
 import com.readum.presentation.controller.aiChat.dto.SendMessageRequest;
-import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -63,8 +67,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(MockitoExtension.class)
 class AiChatControllerTest {
 
-    private static final String USER_SESSION_ID = "test-session-id";
-    private static final Cookie USER_SESSION_COOKIE = new Cookie("user_session", USER_SESSION_ID);
+    private static final Long USER_ID = 1L;
 
     @Mock
     private AiChatSessionCreateService aiChatSessionCreateService;
@@ -114,7 +117,15 @@ class AiChatControllerTest {
         );
         mockMvc = MockMvcBuilders.standaloneSetup(controller)
                 .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(new AuthenticatedUserIdArgumentResolver())
                 .build();
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                USER_ID, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 
     // ── 세션 생성 ──────────────────────────────────────────────────────
@@ -124,7 +135,6 @@ class AiChatControllerTest {
         given(aiChatSessionCreateService.execute(any())).willReturn(new AiChatSessionCreateResult(42L));
 
         mockMvc.perform(post("/api/v1/ai-chat/sessions")
-                        .cookie(USER_SESSION_COOKIE)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new AiChatSessionCreateRequest(10L))))
                 .andExpect(status().isCreated())
@@ -134,7 +144,6 @@ class AiChatControllerTest {
     @Test
     void 세션_생성_userBookId_누락시_400() throws Exception {
         mockMvc.perform(post("/api/v1/ai-chat/sessions")
-                        .cookie(USER_SESSION_COOKIE)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}"))
                 .andExpect(status().isBadRequest())
@@ -144,7 +153,6 @@ class AiChatControllerTest {
     @Test
     void 세션_생성_userBookId_가_음수면_400() throws Exception {
         mockMvc.perform(post("/api/v1/ai-chat/sessions")
-                        .cookie(USER_SESSION_COOKIE)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new AiChatSessionCreateRequest(-1L))))
                 .andExpect(status().isBadRequest())
@@ -157,7 +165,6 @@ class AiChatControllerTest {
                 .willThrow(new NotFoundException(AiChatErrorCode.USER_BOOK_NOT_FOUND));
 
         mockMvc.perform(post("/api/v1/ai-chat/sessions")
-                        .cookie(USER_SESSION_COOKIE)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new AiChatSessionCreateRequest(999_999L))))
                 .andExpect(status().isNotFound())
@@ -183,7 +190,6 @@ class AiChatControllerTest {
                 ));
 
         mockMvc.perform(get("/api/v1/ai-chat/sessions")
-                        .cookie(USER_SESSION_COOKIE)
                         .param("userBookId", "100")
                         .param("page", "1")
                         .param("size", "20"))
@@ -208,7 +214,6 @@ class AiChatControllerTest {
                 .willReturn(new AiChatSessionListResult(List.of(), 1, 20, false));
 
         mockMvc.perform(get("/api/v1/ai-chat/sessions")
-                        .cookie(USER_SESSION_COOKIE)
                         .param("userBookId", "100")
                         .param("page", "1")
                         .param("size", "20"))
@@ -220,7 +225,6 @@ class AiChatControllerTest {
     @Test
     void 세션_목록_조회_userBookId_누락시_400() throws Exception {
         mockMvc.perform(get("/api/v1/ai-chat/sessions")
-                        .cookie(USER_SESSION_COOKIE)
                         .param("page", "1")
                         .param("size", "20"))
                 .andExpect(status().isBadRequest())
@@ -231,7 +235,7 @@ class AiChatControllerTest {
 
     @Test
     void 책별_세션_목록_조회_정상_응답() throws Exception {
-        given(bookChatSessionSearchService.findByUserBook(eq(100L), any()))
+        given(bookChatSessionSearchService.findByUserBook(eq(100L), eq(USER_ID)))
                 .willReturn(new BookChatSessionsResult(
                         new BookChatSessionsResult.BookInfo("데미안", 2020, "민음사", "http://img/x.jpg"),
                         List.of(
@@ -240,8 +244,7 @@ class AiChatControllerTest {
                         )
                 ));
 
-        mockMvc.perform(get("/api/v1/ai-chat/books/100/sessions")
-                        .cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(get("/api/v1/ai-chat/books/100/sessions"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.book.title").value("데미안"))
                 .andExpect(jsonPath("$.data.book.publishedYear").value(2020))
@@ -259,11 +262,10 @@ class AiChatControllerTest {
 
     @Test
     void 책별_세션_목록_조회_본인_책이_아니면_404() throws Exception {
-        given(bookChatSessionSearchService.findByUserBook(eq(100L), any()))
+        given(bookChatSessionSearchService.findByUserBook(eq(100L), eq(USER_ID)))
                 .willThrow(new NotFoundException(AiChatErrorCode.USER_BOOK_NOT_FOUND));
 
-        mockMvc.perform(get("/api/v1/ai-chat/books/100/sessions")
-                        .cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(get("/api/v1/ai-chat/books/100/sessions"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.message").value("등록된 도서가 아닙니다."));
     }
@@ -271,7 +273,6 @@ class AiChatControllerTest {
     @Test
     void 세션_목록_조회_userBookId_가_음수면_400() throws Exception {
         mockMvc.perform(get("/api/v1/ai-chat/sessions")
-                        .cookie(USER_SESSION_COOKIE)
                         .param("userBookId", "-1")
                         .param("page", "1")
                         .param("size", "20"))
@@ -282,7 +283,6 @@ class AiChatControllerTest {
     @Test
     void 세션_목록_조회_size_가_101이면_400() throws Exception {
         mockMvc.perform(get("/api/v1/ai-chat/sessions")
-                        .cookie(USER_SESSION_COOKIE)
                         .param("userBookId", "100")
                         .param("page", "1")
                         .param("size", "101"))
@@ -296,7 +296,6 @@ class AiChatControllerTest {
                 .willThrow(new NotFoundException(AiChatErrorCode.USER_BOOK_NOT_FOUND));
 
         mockMvc.perform(get("/api/v1/ai-chat/sessions")
-                        .cookie(USER_SESSION_COOKIE)
                         .param("userBookId", "999999")
                         .param("page", "1")
                         .param("size", "20"))
@@ -309,7 +308,6 @@ class AiChatControllerTest {
     @Test
     void 메시지_전송_본문_누락시_400() throws Exception {
         mockMvc.perform(post("/api/v1/ai-chat/sessions/7/messages")
-                        .cookie(USER_SESSION_COOKIE)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}"))
                 .andExpect(status().isBadRequest())
@@ -319,7 +317,6 @@ class AiChatControllerTest {
     @Test
     void 메시지_전송_빈_본문이면_400() throws Exception {
         mockMvc.perform(post("/api/v1/ai-chat/sessions/7/messages")
-                        .cookie(USER_SESSION_COOKIE)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new SendMessageRequest(""))))
                 .andExpect(status().isBadRequest());
@@ -328,7 +325,6 @@ class AiChatControllerTest {
     @Test
     void 메시지_전송_whitespace_본문이면_400_변환된다() throws Exception {
         mockMvc.perform(post("/api/v1/ai-chat/sessions/7/messages")
-                        .cookie(USER_SESSION_COOKIE)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new SendMessageRequest("   "))))
                 .andExpect(status().isBadRequest());
@@ -338,7 +334,6 @@ class AiChatControllerTest {
     void 메시지_전송_4001자_본문이면_400() throws Exception {
         String tooLong = "가".repeat(4001);
         mockMvc.perform(post("/api/v1/ai-chat/sessions/7/messages")
-                        .cookie(USER_SESSION_COOKIE)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new SendMessageRequest(tooLong))))
                 .andExpect(status().isBadRequest())
@@ -351,7 +346,6 @@ class AiChatControllerTest {
                 .willThrow(new NotFoundException(AiChatErrorCode.SESSION_NOT_FOUND));
 
         mockMvc.perform(post("/api/v1/ai-chat/sessions/7/messages")
-                        .cookie(USER_SESSION_COOKIE)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new SendMessageRequest("질문"))))
                 .andExpect(status().isNotFound())
@@ -364,7 +358,6 @@ class AiChatControllerTest {
                 .willThrow(new BadRequestException(AiChatErrorCode.SESSION_LOCKED));
 
         mockMvc.perform(post("/api/v1/ai-chat/sessions/7/messages")
-                        .cookie(USER_SESSION_COOKIE)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new SendMessageRequest("질문"))))
                 .andExpect(status().isBadRequest())
@@ -383,7 +376,6 @@ class AiChatControllerTest {
         ));
 
         MvcResult initial = mockMvc.perform(post("/api/v1/ai-chat/sessions/7/messages")
-                        .cookie(USER_SESSION_COOKIE)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.TEXT_EVENT_STREAM)
                         .content(objectMapper.writeValueAsString(new SendMessageRequest("질문"))))
@@ -415,7 +407,6 @@ class AiChatControllerTest {
         ));
 
         MvcResult initial = mockMvc.perform(post("/api/v1/ai-chat/sessions/7/messages")
-                        .cookie(USER_SESSION_COOKIE)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.TEXT_EVENT_STREAM)
                         .content(objectMapper.writeValueAsString(new SendMessageRequest("질문"))))
@@ -464,7 +455,6 @@ class AiChatControllerTest {
                 ));
 
         mockMvc.perform(get("/api/v1/ai-chat/sessions/7/messages")
-                        .cookie(USER_SESSION_COOKIE)
                         .param("page", "1")
                         .param("size", "20"))
                 .andExpect(status().isOk())
@@ -480,7 +470,6 @@ class AiChatControllerTest {
     @Test
     void 메시지_조회_page_가_0이면_400() throws Exception {
         mockMvc.perform(get("/api/v1/ai-chat/sessions/7/messages")
-                        .cookie(USER_SESSION_COOKIE)
                         .param("page", "0")
                         .param("size", "20"))
                 .andExpect(status().isBadRequest())
@@ -490,7 +479,6 @@ class AiChatControllerTest {
     @Test
     void 메시지_조회_size_가_101이면_400() throws Exception {
         mockMvc.perform(get("/api/v1/ai-chat/sessions/7/messages")
-                        .cookie(USER_SESSION_COOKIE)
                         .param("page", "1")
                         .param("size", "101"))
                 .andExpect(status().isBadRequest())
@@ -502,10 +490,9 @@ class AiChatControllerTest {
     @Test
     void 감상문_조회_정상_요청시_200과_감상문을_반환한다() throws Exception {
         SummaryResult result = new SummaryResult(1L, "나의 독서 감상", "깊은 울림을 주는 책이었다.");
-        given(summarySearchService.findBySessionId(eq(1L), any())).willReturn(result);
+        given(summarySearchService.findBySessionId(eq(1L), eq(USER_ID))).willReturn(result);
 
-        mockMvc.perform(get("/api/v1/ai-chat/sessions/1/summary")
-                        .cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(get("/api/v1/ai-chat/sessions/1/summary"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.title").value("나의 독서 감상"))
                 .andExpect(jsonPath("$.data.body").value("깊은 울림을 주는 책이었다."));
@@ -513,22 +500,20 @@ class AiChatControllerTest {
 
     @Test
     void 감상문_조회_생성_요청_전이면_404() throws Exception {
-        given(summarySearchService.findBySessionId(eq(1L), any()))
+        given(summarySearchService.findBySessionId(eq(1L), eq(USER_ID)))
                 .willThrow(new NotFoundException(AiChatErrorCode.SUMMARY_NOT_FOUND));
 
-        mockMvc.perform(get("/api/v1/ai-chat/sessions/1/summary")
-                        .cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(get("/api/v1/ai-chat/sessions/1/summary"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.message").value("아직 생성된 감상문이 없습니다."));
     }
 
     @Test
     void 감상문_조회_생성_중이면_409와_SUMMARY_IN_PROGRESS_메시지() throws Exception {
-        given(summarySearchService.findBySessionId(eq(1L), any()))
+        given(summarySearchService.findBySessionId(eq(1L), eq(USER_ID)))
                 .willThrow(new ConflictException(AiChatErrorCode.SUMMARY_IN_PROGRESS));
 
-        mockMvc.perform(get("/api/v1/ai-chat/sessions/1/summary")
-                        .cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(get("/api/v1/ai-chat/sessions/1/summary"))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error.message").value("감상문을 생성 중입니다. 잠시 후 다시 시도해 주세요."));
     }
@@ -537,18 +522,17 @@ class AiChatControllerTest {
 
     @Test
     void eligibility_정상_요청시_200과_eligible_true를_반환한다() throws Exception {
-        given(summaryDraftSearchService.findEligibility(eq(1L), any()))
+        given(summaryDraftSearchService.findEligibility(eq(1L), eq(USER_ID)))
                 .willReturn(new SummaryDraftEligibilityResult(true, null, null, 100));
 
-        mockMvc.perform(get("/api/v1/ai-chat/sessions/1/summary-draft/eligibility")
-                        .cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(get("/api/v1/ai-chat/sessions/1/summary-draft/eligibility"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.eligible").value(true));
     }
 
     @Test
     void eligibility_잠긴_세션이면_200과_ALREADY_SUMMARIZED를_반환한다() throws Exception {
-        given(summaryDraftSearchService.findEligibility(eq(1L), any()))
+        given(summaryDraftSearchService.findEligibility(eq(1L), eq(USER_ID)))
                 .willReturn(new SummaryDraftEligibilityResult(
                         false,
                         IneligibleReason.ALREADY_SUMMARIZED.name(),
@@ -556,8 +540,7 @@ class AiChatControllerTest {
                         100
                 ));
 
-        mockMvc.perform(get("/api/v1/ai-chat/sessions/1/summary-draft/eligibility")
-                        .cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(get("/api/v1/ai-chat/sessions/1/summary-draft/eligibility"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.eligible").value(false))
                 .andExpect(jsonPath("$.data.reason").value("ALREADY_SUMMARIZED"))
@@ -566,7 +549,7 @@ class AiChatControllerTest {
 
     @Test
     void eligibility_토큰_부족이면_200과_CHAT_VOLUME_NOT_ENOUGH를_반환한다() throws Exception {
-        given(summaryDraftSearchService.findEligibility(eq(1L), any()))
+        given(summaryDraftSearchService.findEligibility(eq(1L), eq(USER_ID)))
                 .willReturn(new SummaryDraftEligibilityResult(
                         false,
                         IneligibleReason.CHAT_VOLUME_NOT_ENOUGH.name(),
@@ -574,8 +557,7 @@ class AiChatControllerTest {
                         20
                 ));
 
-        mockMvc.perform(get("/api/v1/ai-chat/sessions/1/summary-draft/eligibility")
-                        .cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(get("/api/v1/ai-chat/sessions/1/summary-draft/eligibility"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.eligible").value(false))
                 .andExpect(jsonPath("$.data.reason").value("CHAT_VOLUME_NOT_ENOUGH"))
@@ -584,11 +566,10 @@ class AiChatControllerTest {
 
     @Test
     void eligibility_세션이_없으면_404를_반환한다() throws Exception {
-        given(summaryDraftSearchService.findEligibility(eq(1L), any()))
+        given(summaryDraftSearchService.findEligibility(eq(1L), eq(USER_ID)))
                 .willThrow(new NotFoundException(AiChatErrorCode.SESSION_NOT_FOUND));
 
-        mockMvc.perform(get("/api/v1/ai-chat/sessions/1/summary-draft/eligibility")
-                        .cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(get("/api/v1/ai-chat/sessions/1/summary-draft/eligibility"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.message").value("세션을 찾을 수 없습니다."));
     }
@@ -597,18 +578,16 @@ class AiChatControllerTest {
 
     @Test
     void 감상문_초안_정상_요청시_202를_반환한다() throws Exception {
-        mockMvc.perform(post("/api/v1/ai-chat/sessions/1/summary-draft")
-                        .cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(post("/api/v1/ai-chat/sessions/1/summary-draft"))
                 .andExpect(status().isAccepted());
     }
 
     @Test
     void 감상문_초안_누적_토큰이_부족하면_422를_반환한다() throws Exception {
         org.mockito.Mockito.doThrow(new UnprocessableEntityException(AiChatErrorCode.CHAT_VOLUME_NOT_ENOUGH))
-                .when(summaryDraftService).execute(eq(1L), any());
+                .when(summaryDraftService).execute(eq(1L), eq(USER_ID));
 
-        mockMvc.perform(post("/api/v1/ai-chat/sessions/1/summary-draft")
-                        .cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(post("/api/v1/ai-chat/sessions/1/summary-draft"))
                 .andExpect(status().isUnprocessableEntity())
                 .andExpect(jsonPath("$.error.message").value("감상문 초안을 생성하기에 대화량이 부족합니다."));
     }
@@ -616,10 +595,9 @@ class AiChatControllerTest {
     @Test
     void 감상문_초안_종료된_세션이면_409를_반환한다() throws Exception {
         org.mockito.Mockito.doThrow(new ConflictException(AiChatErrorCode.SESSION_ALREADY_SUMMARIZED))
-                .when(summaryDraftService).execute(eq(1L), any());
+                .when(summaryDraftService).execute(eq(1L), eq(USER_ID));
 
-        mockMvc.perform(post("/api/v1/ai-chat/sessions/1/summary-draft")
-                        .cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(post("/api/v1/ai-chat/sessions/1/summary-draft"))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error.message").value("이미 감상문이 생성되어 종료된 세션입니다."));
     }
@@ -627,10 +605,9 @@ class AiChatControllerTest {
     @Test
     void 감상문_초안_존재하지_않는_세션이면_404를_반환한다() throws Exception {
         org.mockito.Mockito.doThrow(new NotFoundException(AiChatErrorCode.SESSION_NOT_FOUND))
-                .when(summaryDraftService).execute(eq(1L), any());
+                .when(summaryDraftService).execute(eq(1L), eq(USER_ID));
 
-        mockMvc.perform(post("/api/v1/ai-chat/sessions/1/summary-draft")
-                        .cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(post("/api/v1/ai-chat/sessions/1/summary-draft"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.message").value("세션을 찾을 수 없습니다."));
     }

--- a/src/test/java/com/readum/presentation/controller/aiChat/AiChatControllerTest.java
+++ b/src/test/java/com/readum/presentation/controller/aiChat/AiChatControllerTest.java
@@ -8,6 +8,7 @@ import com.readum.domain.aiChat.dto.AiChatSessionResult;
 import com.readum.domain.aiChat.dto.MessageListResult;
 import com.readum.domain.aiChat.dto.MessageResult;
 import com.readum.domain.aiChat.dto.MessageStreamEvent;
+import com.readum.domain.aiChat.dto.SummaryDraftCommand;
 import com.readum.domain.aiChat.dto.SummaryDraftEligibility.IneligibleReason;
 import com.readum.domain.aiChat.dto.SummaryDraftEligibilityResult;
 import com.readum.domain.summary.dto.SummaryResult;
@@ -585,7 +586,7 @@ class AiChatControllerTest {
     @Test
     void 감상문_초안_누적_토큰이_부족하면_422를_반환한다() throws Exception {
         org.mockito.Mockito.doThrow(new UnprocessableEntityException(AiChatErrorCode.CHAT_VOLUME_NOT_ENOUGH))
-                .when(summaryDraftService).execute(eq(1L), eq(USER_ID));
+                .when(summaryDraftService).execute(any(SummaryDraftCommand.class));
 
         mockMvc.perform(post("/api/v1/ai-chat/sessions/1/summary-draft"))
                 .andExpect(status().isUnprocessableEntity())
@@ -595,7 +596,7 @@ class AiChatControllerTest {
     @Test
     void 감상문_초안_종료된_세션이면_409를_반환한다() throws Exception {
         org.mockito.Mockito.doThrow(new ConflictException(AiChatErrorCode.SESSION_ALREADY_SUMMARIZED))
-                .when(summaryDraftService).execute(eq(1L), eq(USER_ID));
+                .when(summaryDraftService).execute(any(SummaryDraftCommand.class));
 
         mockMvc.perform(post("/api/v1/ai-chat/sessions/1/summary-draft"))
                 .andExpect(status().isConflict())
@@ -605,7 +606,7 @@ class AiChatControllerTest {
     @Test
     void 감상문_초안_존재하지_않는_세션이면_404를_반환한다() throws Exception {
         org.mockito.Mockito.doThrow(new NotFoundException(AiChatErrorCode.SESSION_NOT_FOUND))
-                .when(summaryDraftService).execute(eq(1L), eq(USER_ID));
+                .when(summaryDraftService).execute(any(SummaryDraftCommand.class));
 
         mockMvc.perform(post("/api/v1/ai-chat/sessions/1/summary-draft"))
                 .andExpect(status().isNotFound())

--- a/src/test/java/com/readum/presentation/controller/aiChat/AiChatStreamGuardrailTest.java
+++ b/src/test/java/com/readum/presentation/controller/aiChat/AiChatStreamGuardrailTest.java
@@ -17,7 +17,6 @@ import com.readum.model.user.entity.UserBookFixture;
 import com.readum.model.user.repository.UserBookRepository;
 import com.readum.model.user.repository.UserRepository;
 import com.readum.presentation.controller.aiChat.dto.SendMessageRequest;
-import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -27,12 +26,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import reactor.core.publisher.Flux;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,6 +42,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -85,13 +88,13 @@ class AiChatStreamGuardrailTest {
 
     private final ObjectMapper objectMapper = JsonMapper.builder().findAndAddModules().build();
 
-    private Cookie cookie;
+    private Long userId;
     private Long sessionId;
 
     @BeforeEach
     void setUp() {
         User user = userRepository.save(User.create(UUID.randomUUID(), "책읽는여우"));
-        cookie = new Cookie("user_session", user.getSessionId());
+        userId = user.getId();
 
         Book book = bookRepository.save(BookFixture.persistedBook(
                 null, "guardrail-ext-" + UUID.randomUUID(), "살인의 추억", "작가", "출판사", 2003, null));
@@ -116,7 +119,8 @@ class AiChatStreamGuardrailTest {
         // (Accept: text/event-stream 만 보내면 JSON 에러 본문이 협상에 실패해 ServletException 으로 샌다.)
         SendMessageRequest body = new SendMessageRequest(content);
         return mockMvc.perform(post("/api/v1/ai-chat/sessions/" + sessionId + "/messages")
-                .cookie(cookie)
+                .with(authentication(new UsernamePasswordAuthenticationToken(
+                        userId, null, List.of(new SimpleGrantedAuthority("ROLE_USER")))))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(body)));
     }

--- a/src/test/java/com/readum/presentation/controller/auth/AuthControllerRefreshTest.java
+++ b/src/test/java/com/readum/presentation/controller/auth/AuthControllerRefreshTest.java
@@ -1,0 +1,44 @@
+package com.readum.presentation.controller.auth;
+
+import com.readum.domain.auth.service.LogoutService;
+import com.readum.domain.auth.service.TokenRefreshService;
+import com.readum.presentation.common.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerRefreshTest {
+
+    private static final String REFRESH_URI = "/api/v1/auth/refresh";
+
+    @Mock
+    private TokenRefreshService tokenRefreshService;
+
+    @Mock
+    private LogoutService logoutService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        AuthController controller = new AuthController(tokenRefreshService, logoutService, true);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void RT_쿠키_없이_재발급을_요청하면_401_을_반환한다() throws Exception {
+        mockMvc.perform(post(REFRESH_URI))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/readum/presentation/controller/summary/SummaryControllerTest.java
+++ b/src/test/java/com/readum/presentation/controller/summary/SummaryControllerTest.java
@@ -1,7 +1,6 @@
 package com.readum.presentation.controller.summary;
 
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
 import com.readum.domain.summary.dto.MonthlyReadingRecordResult;
 import com.readum.domain.summary.dto.SummaryHistoryItemResult;
 import com.readum.domain.summary.dto.SummaryHistoryListResult;
@@ -9,14 +8,17 @@ import com.readum.domain.summary.dto.SummaryResult;
 import com.readum.domain.summary.exception.SummaryErrorCode;
 import com.readum.domain.summary.service.SummaryHistorySearchService;
 import com.readum.domain.summary.service.SummarySearchService;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.presentation.common.GlobalExceptionHandler;
-import jakarta.servlet.http.Cookie;
+import com.readum.presentation.common.security.AuthenticatedUserIdArgumentResolver;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -28,7 +30,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -38,7 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(MockitoExtension.class)
 class SummaryControllerTest {
 
-    private static final Cookie USER_SESSION_COOKIE = new Cookie("user_session", "test-session-id");
+    private static final Long USER_ID = 1L;
 
     @Mock
     private SummaryHistorySearchService summaryHistorySearchService;
@@ -53,7 +54,15 @@ class SummaryControllerTest {
         SummaryController controller = new SummaryController(summaryHistorySearchService, summarySearchService);
         mockMvc = MockMvcBuilders.standaloneSetup(controller)
                 .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(new AuthenticatedUserIdArgumentResolver())
                 .build();
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                USER_ID, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 
     // ===== 전체 감상 기록 목록 (GET /api/v1/summaries) =====
@@ -73,7 +82,6 @@ class SummaryControllerTest {
                 ));
 
         mockMvc.perform(get("/api/v1/summaries")
-                        .cookie(USER_SESSION_COOKIE)
                         .param("page", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.summaries.length()").value(2))
@@ -94,7 +102,6 @@ class SummaryControllerTest {
                 .willReturn(new SummaryHistoryListResult(List.of(), 1, 20, false));
 
         mockMvc.perform(get("/api/v1/summaries")
-                        .cookie(USER_SESSION_COOKIE)
                         .param("page", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.summaries.length()").value(0))
@@ -104,7 +111,6 @@ class SummaryControllerTest {
     @Test
     void 감상_기록_조회_page_가_0이면_400() throws Exception {
         mockMvc.perform(get("/api/v1/summaries")
-                        .cookie(USER_SESSION_COOKIE)
                         .param("page", "0"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error.message", containsString("page는 1 이상")));
@@ -114,13 +120,12 @@ class SummaryControllerTest {
 
     @Test
     void 월별_조회는_독서_기록_리스트를_반환한다() throws Exception {
-        given(summarySearchService.findMonthly(eq(YearMonth.of(2026, 6)), anyString()))
+        given(summarySearchService.findMonthly(eq(YearMonth.of(2026, 6)), eq(USER_ID)))
                 .willReturn(List.of(new MonthlyReadingRecordResult(
                         1000L, 17L, "책 이름", "채팅 제목", LocalDateTime.of(2026, 6, 11, 14, 32, 5))));
 
         mockMvc.perform(get("/api/v1/summaries/calendar")
-                        .param("yearMonth", "2026-06")
-                        .cookie(USER_SESSION_COOKIE))
+                        .param("yearMonth", "2026-06"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.records[0].chatSessionId").value(1000))
                 .andExpect(jsonPath("$.data.records[0].summaryId").value(17))
@@ -131,13 +136,12 @@ class SummaryControllerTest {
 
     @Test
     void 월별_조회는_감상문이_없는_기록의_summaryId_를_null_로_반환한다() throws Exception {
-        given(summarySearchService.findMonthly(eq(YearMonth.of(2026, 6)), anyString()))
+        given(summarySearchService.findMonthly(eq(YearMonth.of(2026, 6)), eq(USER_ID)))
                 .willReturn(List.of(new MonthlyReadingRecordResult(
                         1001L, null, "다른 책", "또 다른 제목", LocalDateTime.of(2026, 6, 10, 9, 15, 40))));
 
         mockMvc.perform(get("/api/v1/summaries/calendar")
-                        .param("yearMonth", "2026-06")
-                        .cookie(USER_SESSION_COOKIE))
+                        .param("yearMonth", "2026-06"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.records[0].chatSessionId").value(1001))
                 .andExpect(jsonPath("$.data.records[0].summaryId").value(nullValue()));
@@ -145,12 +149,11 @@ class SummaryControllerTest {
 
     @Test
     void 월별_조회는_기록이_없으면_빈_배열을_반환한다() throws Exception {
-        given(summarySearchService.findMonthly(eq(YearMonth.of(2026, 6)), anyString()))
+        given(summarySearchService.findMonthly(eq(YearMonth.of(2026, 6)), eq(USER_ID)))
                 .willReturn(List.of());
 
         mockMvc.perform(get("/api/v1/summaries/calendar")
-                        .param("yearMonth", "2026-06")
-                        .cookie(USER_SESSION_COOKIE))
+                        .param("yearMonth", "2026-06"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.records").isArray())
                 .andExpect(jsonPath("$.data.records").isEmpty());
@@ -159,40 +162,25 @@ class SummaryControllerTest {
     @Test
     void yearMonth_형식이_틀리면_400_을_반환한다() throws Exception {
         mockMvc.perform(get("/api/v1/summaries/calendar")
-                        .param("yearMonth", "2026-13")
-                        .cookie(USER_SESSION_COOKIE))
+                        .param("yearMonth", "2026-13"))
                 .andExpect(status().isBadRequest());
     }
 
     @Test
     void yearMonth_가_누락되면_400_을_반환한다() throws Exception {
-        mockMvc.perform(get("/api/v1/summaries/calendar")
-                        .cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(get("/api/v1/summaries/calendar"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error.message").value("필수 요청 값이 없습니다: yearMonth"));
-    }
-
-    @Test
-    void 월별_조회는_세션이_무효하면_401_을_반환한다() throws Exception {
-        given(summarySearchService.findMonthly(eq(YearMonth.of(2026, 6)), anyString()))
-                .willThrow(new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
-        mockMvc.perform(get("/api/v1/summaries/calendar")
-                        .param("yearMonth", "2026-06")
-                        .cookie(USER_SESSION_COOKIE))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.error.message").exists());
     }
 
     // ===== 감상 기록 상세 조회 (GET /api/v1/summaries/{summaryId}) =====
 
     @Test
     void 상세_조회는_채팅_세션_id와_감상문_제목과_본문을_반환한다() throws Exception {
-        given(summarySearchService.findById(eq(17L), anyString()))
+        given(summarySearchService.findById(eq(17L), eq(USER_ID)))
                 .willReturn(new SummaryResult(1000L, "감상문 제목", "감상문 본문"));
 
-        mockMvc.perform(get("/api/v1/summaries/17")
-                        .cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(get("/api/v1/summaries/17"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.summary.aiChatSessionId").value(1000))
                 .andExpect(jsonPath("$.data.summary.title").value("감상문 제목"))
@@ -201,11 +189,10 @@ class SummaryControllerTest {
 
     @Test
     void 상세_조회는_찾을_수_없으면_404_와_메시지를_반환한다() throws Exception {
-        given(summarySearchService.findById(anyLong(), anyString()))
+        given(summarySearchService.findById(anyLong(), eq(USER_ID)))
                 .willThrow(new NotFoundException(SummaryErrorCode.SUMMARY_NOT_FOUND));
 
-        mockMvc.perform(get("/api/v1/summaries/99")
-                        .cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(get("/api/v1/summaries/99"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.message").value("감상문을 찾을 수 없습니다."));
     }

--- a/src/test/java/com/readum/presentation/controller/user/UserBookControllerTest.java
+++ b/src/test/java/com/readum/presentation/controller/user/UserBookControllerTest.java
@@ -3,8 +3,6 @@ package com.readum.presentation.controller.user;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.readum.domain.exception.ConflictException;
 import com.readum.domain.exception.NotFoundException;
-import com.readum.domain.exception.UnauthorizedException;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.domain.user.userbook.dto.UserBookCreateResult;
 import com.readum.domain.user.userbook.dto.UserBookDeleteResult;
 import com.readum.domain.user.userbook.dto.UserBookSearchItemResult;
@@ -14,8 +12,9 @@ import com.readum.domain.user.userbook.service.UserBookCreateService;
 import com.readum.domain.user.userbook.service.UserBookDeleteService;
 import com.readum.domain.user.userbook.service.UserBookSearchService;
 import com.readum.presentation.common.GlobalExceptionHandler;
+import com.readum.presentation.common.security.AuthenticatedUserIdArgumentResolver;
 import com.readum.presentation.controller.user.dto.UserBookCreateRequest;
-import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,6 +22,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -32,7 +34,6 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -44,7 +45,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(MockitoExtension.class)
 class UserBookControllerTest {
 
-    private static final Cookie USER_SESSION_COOKIE = new Cookie("user_session", "test-session-id");
+    private static final Long USER_ID = 1L;
 
     @Mock
     private UserBookCreateService userBookCreateService;
@@ -64,8 +65,16 @@ class UserBookControllerTest {
                 new UserBookController(userBookCreateService, userBookSearchService, userBookDeleteService);
         mockMvc = MockMvcBuilders.standaloneSetup(controller)
                 .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(new AuthenticatedUserIdArgumentResolver())
                 .build();
         objectMapper = new ObjectMapper();
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                USER_ID, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 
     private String validRequestBody() throws Exception {
@@ -82,7 +91,6 @@ class UserBookControllerTest {
         given(userBookCreateService.execute(any())).willReturn(result);
 
         mockMvc.perform(post("/api/v1/user-books")
-                        .cookie(USER_SESSION_COOKIE)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(validRequestBody()))
                 .andExpect(status().isCreated())
@@ -99,19 +107,9 @@ class UserBookControllerTest {
         String bodyWithoutExternalId = objectMapper.writeValueAsString(new UserBookCreateRequest(null));
 
         mockMvc.perform(post("/api/v1/user-books")
-                        .cookie(USER_SESSION_COOKIE)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(bodyWithoutExternalId))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error.message").exists());
-    }
-
-    @Test
-    void user_session_쿠키가_없으면_401을_반환한다() throws Exception {
-        mockMvc.perform(post("/api/v1/user-books")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(validRequestBody()))
-                .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.error.message").exists());
     }
 
@@ -126,7 +124,6 @@ class UserBookControllerTest {
                 .willThrow(new ConflictException(UserBookErrorCode.ALREADY_EXISTS, existingResult));
 
         mockMvc.perform(post("/api/v1/user-books")
-                        .cookie(USER_SESSION_COOKIE)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(validRequestBody()))
                 .andExpect(status().isConflict())
@@ -136,14 +133,14 @@ class UserBookControllerTest {
     }
 
     @Test
-    void 유효한_user_session_쿠키로_GET_요청시_200과_등록_도서_목록을_반환한다() throws Exception {
+    void 인증된_사용자가_GET_요청시_200과_등록_도서_목록을_반환한다() throws Exception {
         UserBookSearchResult searchResult = new UserBookSearchResult(List.of(
                 new UserBookSearchItemResult(20L, 2L, "최근 등록한 책", "출판사B", 2025, "http://example.com/b.jpg", 3L),
                 new UserBookSearchItemResult(10L, 1L, "이전에 등록한 책", "출판사A", 2024, "http://example.com/a.jpg", 0L)
         ));
-        given(userBookSearchService.findMyBooks("test-session-id")).willReturn(searchResult);
+        given(userBookSearchService.findMyBooks(USER_ID)).willReturn(searchResult);
 
-        mockMvc.perform(get("/api/v1/user-books").cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(get("/api/v1/user-books"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.books.length()").value(2))
                 .andExpect(jsonPath("$.data.books[0].userBookId").value(20))
@@ -162,63 +159,27 @@ class UserBookControllerTest {
 
     @Test
     void 등록_도서가_없으면_빈_books_배열을_200과_함께_반환한다() throws Exception {
-        given(userBookSearchService.findMyBooks("test-session-id"))
+        given(userBookSearchService.findMyBooks(USER_ID))
                 .willReturn(new UserBookSearchResult(List.of()));
 
-        mockMvc.perform(get("/api/v1/user-books").cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(get("/api/v1/user-books"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.books.length()").value(0))
                 .andExpect(jsonPath("$.error").doesNotExist());
     }
 
     @Test
-    void GET_요청에_user_session_쿠키가_없으면_401을_반환한다() throws Exception {
-        mockMvc.perform(get("/api/v1/user-books"))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.error.message").exists());
-    }
-
-    @Test
-    void GET_요청에_유효하지_않은_user_session_이면_401을_반환한다() throws Exception {
-        given(userBookSearchService.findMyBooks(any()))
-                .willThrow(new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
-        mockMvc.perform(get("/api/v1/user-books").cookie(USER_SESSION_COOKIE))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.error.message").value("유효하지 않은 세션입니다."));
-    }
-
-    @Test
-    void DELETE_요청_시_204를_본문_없이_반환하고_경로의_userBookId와_쿠키_세션으로_삭제를_위임한다() throws Exception {
+    void DELETE_요청_시_204를_본문_없이_반환하고_경로의_userBookId와_인증된_userId로_삭제를_위임한다() throws Exception {
         given(userBookDeleteService.execute(any()))
                 .willReturn(new UserBookDeleteResult(100L, 3, 7, 2));
 
-        mockMvc.perform(delete("/api/v1/user-books/100").cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(delete("/api/v1/user-books/100"))
                 .andExpect(status().isNoContent())
                 .andExpect(jsonPath("$").doesNotExist());
 
         verify(userBookDeleteService).execute(argThat(command ->
-                command.userSessionId().equals("test-session-id")
+                command.userId().equals(USER_ID)
                         && command.userBookId().equals(100L)));
-    }
-
-    @Test
-    void DELETE_요청에_user_session_쿠키가_없으면_401을_반환하고_삭제를_위임하지_않는다() throws Exception {
-        mockMvc.perform(delete("/api/v1/user-books/100"))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.error.message").exists());
-
-        verify(userBookDeleteService, never()).execute(any());
-    }
-
-    @Test
-    void DELETE_요청에_유효하지_않은_user_session_이면_401을_반환한다() throws Exception {
-        given(userBookDeleteService.execute(any()))
-                .willThrow(new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
-        mockMvc.perform(delete("/api/v1/user-books/100").cookie(USER_SESSION_COOKIE))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.error.message").value("유효하지 않은 세션입니다."));
     }
 
     @Test
@@ -226,7 +187,7 @@ class UserBookControllerTest {
         given(userBookDeleteService.execute(any()))
                 .willThrow(new NotFoundException(UserBookErrorCode.NOT_FOUND));
 
-        mockMvc.perform(delete("/api/v1/user-books/100").cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(delete("/api/v1/user-books/100"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.message").value("등록되지 않은 도서입니다."));
     }

--- a/src/test/java/com/readum/presentation/controller/user/UserControllerTest.java
+++ b/src/test/java/com/readum/presentation/controller/user/UserControllerTest.java
@@ -1,21 +1,25 @@
 package com.readum.presentation.controller.user;
 
-import com.readum.domain.exception.UnauthorizedException;
 import com.readum.domain.user.dto.UserProfileResult;
-import com.readum.domain.user.exception.UserErrorCode;
 import com.readum.domain.user.service.CompleteOnboardingService;
 import com.readum.domain.user.service.CreateUserSessionService;
 import com.readum.domain.user.service.UpdateNicknameService;
 import com.readum.domain.user.service.UserSearchService;
 import com.readum.presentation.common.GlobalExceptionHandler;
-import jakarta.servlet.http.Cookie;
+import com.readum.presentation.common.security.AuthenticatedUserIdArgumentResolver;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
 
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.BDDMockito.given;
@@ -26,7 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(MockitoExtension.class)
 class UserControllerTest {
 
-    private static final Cookie USER_SESSION_COOKIE = new Cookie("user_session", "test-session-id");
+    private static final Long USER_ID = 1L;
 
     @Mock
     private CreateUserSessionService createUserSessionService;
@@ -48,42 +52,34 @@ class UserControllerTest {
                 createUserSessionService, userSearchService, completeOnboardingService, updateNicknameService);
         mockMvc = MockMvcBuilders.standaloneSetup(controller)
                 .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(new AuthenticatedUserIdArgumentResolver())
                 .build();
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                USER_ID, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 
     @Test
-    void 유효한_세션으로_프로필을_조회하면_닉네임을_반환한다() throws Exception {
-        given(userSearchService.findProfile("test-session-id"))
+    void 인증된_사용자가_프로필을_조회하면_닉네임을_반환한다() throws Exception {
+        given(userSearchService.findProfile(USER_ID))
                 .willReturn(new UserProfileResult("문장수집가"));
 
-        mockMvc.perform(get("/api/v1/users/me/profile").cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(get("/api/v1/users/me/profile"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.profile.nickname").value("문장수집가"));
     }
 
     @Test
     void 닉네임이_없는_기존_사용자도_프로필_조회시_닉네임_키가_null_로_노출된다() throws Exception {
-        given(userSearchService.findProfile("test-session-id"))
+        given(userSearchService.findProfile(USER_ID))
                 .willReturn(new UserProfileResult(null));
 
-        mockMvc.perform(get("/api/v1/users/me/profile").cookie(USER_SESSION_COOKIE))
+        mockMvc.perform(get("/api/v1/users/me/profile"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.profile.nickname").value(nullValue()));
-    }
-
-    @Test
-    void 세션_쿠키가_없으면_401_을_반환한다() throws Exception {
-        mockMvc.perform(get("/api/v1/users/me/profile"))
-                .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    void 유효하지_않은_세션이면_401_을_반환한다() throws Exception {
-        given(userSearchService.findProfile("test-session-id"))
-                .willThrow(new UnauthorizedException(UserErrorCode.INVALID_SESSION));
-
-        mockMvc.perform(get("/api/v1/users/me/profile").cookie(USER_SESSION_COOKIE))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.error.message").value(UserErrorCode.INVALID_SESSION.getMessage()));
     }
 }


### PR DESCRIPTION
## 작업 사항

6/20 런칭 체험 시간대의 대량 429 사고는 개별 버그가 아니라 구조 문제였다. 사용자 신원(user_session 쿠키)이 요청에 실려 도착해 있었는데도, 그걸 해석하는 방법이 컴포넌트마다 달랐다 — 서비스 16곳이 각자 `findBySessionId` 를 호출해 인증을 대행했고, 호출 한도 인터셉터는 SecurityContext 를 봤지만 쿠키 인증은 그 자리를 채우지 않아 항상 IP 기준으로 동작했다. 프론트 서버 프록시가 전국 사용자를 소수 IP 로 합치면서, 서로 다른 사용자들이 한 버킷을 공유하다 함께 차단됐다.

이 PR 은 신원 해석을 인증 필터 한 곳으로 모은다. `SessionCookieAuthenticationFilter` 가 쿠키를 `SessionAuthenticationService` 로 해석해 principal 에 userId 를 채우고(기존 `JwtAuthenticationFilter` 와 동일한 모양 — 아래 계층은 신원의 출처를 구분할 수 없다), 컨트롤러는 `@AuthenticatedUserId Long userId` 로만 신원을 받는다. Command 첫 필드는 `String userSessionId` → `Long userId` 로 전환했고, 서비스의 `findBySessionId` 인증 블럭 16곳을 제거했다(소유권 검증 404 는 전부 보존). 소셜 로그인 도입 시에는 이 필터 한 쌍만 교체하면 되고 컨트롤러 아래는 바뀌지 않는다.

인증 강제는 Security 계층으로 옮겼다. API 경로의 permitAll 을 걷어내 `authenticated()` 로 전환했고, 익명 접근이 필요한 경로(쿠키 발급, auth 재발급/로그아웃, 도서 검색, actuator, swagger)만 permitAll 로 남겼다. "어떤 엔드포인트가 인증을 요구하는가"가 SecurityConfig 한 곳에 선언되고, 미인증 요청은 컨트롤러에 도달하기 전에 401 을 받는다.

호출 한도는 사고 분석의 처방 그대로 교정했다. 키를 `user:{userId}` 로 잡고, IP 로 조용히 대체하던 분기는 삭제했다 — 인터셉터가 붙는 경로는 전부 인증 필수이므로 principal 부재는 설정 버그이며, 그 경우 즉시 오류로 드러낸다. 적용 대상도 비싼 LLM 호출 POST 2개(메시지 전송, 감상문 초안 생성)로 줄여, 채팅 화면 진입 시 나가는 조회 GET 들이 한도를 깎지 않게 했다. 한도값(분당 20/일 200)은 사용자 단위가 되면 1인 기준으로 넉넉해 유지했다.

같은 부류의 결함이 재발하지 않도록 규칙을 빌드에 박았다. ArchUnit 규칙 3종(SecurityContext 직접 참조는 security 패키지만, `@CookieValue(user_session)` 금지, `findBySessionId` 호출은 `SessionAuthenticationService` 만)과, 실제 인증 경로(쿠키)로 검증하는 통합 테스트를 뒀다 — JWT 로만 SecurityContext 를 채운 테스트는 이번 결함을 통과시켰기 때문이다. 범위에서 제외한 것: nginx 의 X-Forwarded-For 보존은 프론트 확인·보안 그룹 점검이 선행돼야 해서 별도 인프라 작업으로 분리했다.

### 기능

**인증**
- 쿠키 없음/무효 세션 요청은 컨트롤러에 도달하기 전에 Security 계층에서 401 을 받는다
- 컨트롤러는 `@AuthenticatedUserId Long userId` 로 해석된 신원만 받는다 — 쿠키/헤더를 직접 읽는 코드가 사라짐

**호출 한도**
- 한도가 사용자 단위로 동작한다 — 같은 프록시·와이파이를 쓰는 사용자들이 한도를 공유하다 함께 막히던 문제 해소
- 이력 조회·생성 가능 여부 조회 등 읽기 요청은 한도를 소비하지 않는다

**재발 방지**
- ArchUnit 규칙 3종이 신원 해석 우회 코드를 빌드 단계에서 차단 (규칙마다 위반 주입으로 실제 실패하는지 검증함)
- 같은 IP 에서 서로 다른 두 세션이 요청하면 버킷이 분리되는지 검증하는 테스트 — 6/20 사고의 직접 재현 방지

### 시나리오별 응답

**미인증 (쿠키 없음/무효 세션)** — `GET /api/v1/users/me/profile`
```json
HTTP 401
{ "error": { "message": "인증이 필요합니다." } }
```

**호출 한도 초과** — `POST /api/v1/ai-chat/sessions/{id}/messages`
```json
HTTP 429
{ "error": { "message": "AI 채팅 호출 한도를 초과했습니다. 잠시 후 다시 시도해 주세요." } }
```

## 테스트 결과
- [x] `./gradlew test` 통과 (391 tests, 0 failed)
- [x] 실제 쿠키 경로 통합 테스트 4건 (유효 쿠키 200 / 무쿠키 401 / 무효 쿠키 401 / 쿠키 발급 익명 201)
- [x] ArchUnit 규칙 3종 — 규칙별로 위반을 일시 주입해 실제로 실패하는 것까지 확인 후 원복
- [ ] dev 배포 후 스모크: 채팅 전송·이력 조회·감상문 생성이 기존 클라이언트에서 정상 동작하는지

## 관련 이슈
- closes #113

## 참고 사항
- API 계약 변화: 쿠키 누락 시 401 응답의 message 가 "필수 쿠키가 없습니다: user_session" → "인증이 필요합니다." 로 바뀐다 (상태 코드는 401 로 동일). 클라이언트가 message 문자열에 의존하지 않는다면 영향 없음.
- auth 재발급(`POST /api/v1/auth/refresh`)의 refresh_token 쿠키 누락 401 은 그대로 유지된다 (리뷰 중 회귀를 발견해 핸들러 복원 + 회귀 테스트 추가).
- 후속 인프라 작업: nginx `app.conf` 의 X-Forwarded-For 를 `$proxy_add_x_forwarded_for` 로 교체 (로그·추적 정확성 목적, 프론트 XFF 확인 + 보안 그룹 점검 선행).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 인증된 사용자 ID 기반으로 로그인 사용자 식별 방식이 세션 쿠키에서 전환되었습니다.
  * 세션 쿠키를 확인해 사용자 ID를 주입하는 인증 흐름이 추가되었습니다.
  * 인증 사용자 ID 자동 주입 기능과 관련 보안 설정이 도입되었습니다.
* **Bug Fixes**
  * AI 채팅/요약/사용자 도서 관련 권한·소유 검증이 사용자 ID 기준으로 더 일관되게 처리됩니다.
* **Tests**
  * 인증 경계와 서비스 동작 기준이 사용자 ID 중심으로 재정비되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->