### PR TITLE
refactor(ai-chat): 수동 감상문 생성 정식 기능화 — 문턱값 설정 외부화

### DIFF
--- a/src/main/java/com/readum/domain/aiChat/config/AiChatProperties.java
+++ b/src/main/java/com/readum/domain/aiChat/config/AiChatProperties.java
@@ -13,7 +13,8 @@ public record AiChatProperties(
         @Valid ContextWindow contextWindow,
         @Valid MessageRule message,
         @Valid RateLimit rateLimit,
-        @Valid TitleGeneration titleGeneration
+        @Valid TitleGeneration titleGeneration,
+        @Valid SummaryDraft summaryDraft
 ) {
 
     /**
@@ -58,5 +59,12 @@ public record AiChatProperties(
      *               따라서 전역 backlog 상한 = threadCap × queueCap 이므로, 둘의 곱이 의도한 한도가 되도록 잡는다.
      */
     public record TitleGeneration(@Positive int threadCap, @Positive int queueCap) {
+    }
+
+    /**
+     * 감상문 초안 생성 자격 정책.
+     * minAccumulatedTokens: 세션의 ASSISTANT 누적 토큰이 이 값 이상이어야 감상문 생성 가능.
+     */
+    public record SummaryDraft(@Positive int minAccumulatedTokens) {
     }
 }

--- a/src/main/java/com/readum/domain/aiChat/service/SummaryDraftService.java
+++ b/src/main/java/com/readum/domain/aiChat/service/SummaryDraftService.java
@@ -16,9 +16,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * 수동(데모) 감상문 생성 요청 진입점. 직접 생성하지 않고 작업을 적재한다.
- * 실제 생성은 작업 큐 워커(SummaryGenerationWorker)가 처리한다.
- * 자격(ACTIVE + 누적 토큰 ≥ 임계값, 종료 세션 제외)은 SummaryDraftPolicy 가 검증한다.
+ * 감상문 생성 요청 진입점 — 사용자가 채팅 화면에서 직접 생성을 요청하는 정식 기능.
+ * 직접 생성하지 않고 작업을 적재하며, 실제 생성은 작업 큐 워커(SummaryGenerationWorker)가 처리한다.
+ * 자격(ACTIVE + 누적 토큰 ≥ 문턱값, 종료 세션 제외)은 SummaryDraftPolicy 가 검증한다.
  * 중복 적재는 EnqueueSummaryJobService 의 멱등성(active_session_id unique)이 막는다.
  */
 @Slf4j

--- a/src/main/java/com/readum/domain/aiChat/service/policy/SummaryDraftPolicy.java
+++ b/src/main/java/com/readum/domain/aiChat/service/policy/SummaryDraftPolicy.java
@@ -1,23 +1,25 @@
 package com.readum.domain.aiChat.service.policy;
 
+import com.readum.domain.aiChat.config.AiChatProperties;
 import com.readum.domain.aiChat.dto.SummaryDraftEligibility;
 import com.readum.domain.aiChat.dto.SummaryDraftEligibility.IneligibleReason;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.exception.ConflictException;
 import com.readum.domain.exception.UnprocessableEntityException;
 import com.readum.model.aiChat.entity.AiChatSession;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class SummaryDraftPolicy {
 
-    // TODO: 정책 확정 후 상수값 조정 필요
-    public static final int MIN_ACCUMULATED_TOKENS = 500;
+    private final AiChatProperties aiChatProperties;
 
     public SummaryDraftEligibility evaluate(AiChatSession session) {
         return switch (session.getStatus()) {
             case LOCKED -> SummaryDraftEligibility.fail(IneligibleReason.ALREADY_SUMMARIZED);
-            case ACTIVE -> session.getAccumulatedTokens() < MIN_ACCUMULATED_TOKENS
+            case ACTIVE -> session.getAccumulatedTokens() < minAccumulatedTokens()
                     ? SummaryDraftEligibility.fail(IneligibleReason.CHAT_VOLUME_NOT_ENOUGH)
                     : SummaryDraftEligibility.pass();
         };
@@ -36,10 +38,14 @@ public class SummaryDraftPolicy {
     }
 
     public boolean isEligible(int accumulatedTokensSinceLastSummary) {
-        return accumulatedTokensSinceLastSummary >= MIN_ACCUMULATED_TOKENS;
+        return accumulatedTokensSinceLastSummary >= minAccumulatedTokens();
     }
 
     public int calculateProgressPercent(int accumulatedTokens) {
-        return Math.min(accumulatedTokens * 100 / MIN_ACCUMULATED_TOKENS, 100);
+        return Math.min(accumulatedTokens * 100 / minAccumulatedTokens(), 100);
+    }
+
+    public int minAccumulatedTokens() {
+        return aiChatProperties.summaryDraft().minAccumulatedTokens();
     }
 }

--- a/src/main/java/com/readum/infrastructure/aiChat/scheduler/SummaryScheduler.java
+++ b/src/main/java/com/readum/infrastructure/aiChat/scheduler/SummaryScheduler.java
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 public class SummaryScheduler {
 
     private final SummaryJobRepository summaryJobRepository;
+    private final SummaryDraftPolicy summaryDraftPolicy;
 
     @Scheduled(cron = "0 0 6 * * *")
     @Transactional
@@ -32,7 +33,7 @@ public class SummaryScheduler {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime since = now.minusHours(24);
         int enqueued = summaryJobRepository.enqueuePendingForEligibleSessions(
-                SummaryDraftPolicy.MIN_ACCUMULATED_TOKENS, since, now);
+                summaryDraftPolicy.minAccumulatedTokens(), since, now);
         log.info("감상문 자동 생성 작업 적재 완료 {}건", enqueued);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,8 @@ ai-chat:
     thread-cap: 32                       # 동시 제목 생성 상한. 스레드는 lazy 생성 + 60초 유휴 회수라 평소엔 0 에 수렴.
                                          # 저빈도 백그라운드라 32 면 충분. 전용 ChatClient 의 10초 responseTimeout 이 매달린 호출을 끊어 blast-radius 를 시간으로 제한.
     queue-cap: 64                        # backing thread 1개당 큐 한도(per-thread). 전역 backlog 상한 = thread-cap × queue-cap = 32 × 64 ≈ 2,048. 초과 시 RejectedExecutionException(로그 후 스킵).
+  summary-draft:
+    min-accumulated-tokens: 500          # 감상문 생성에 필요한 최소 누적 토큰 (확정 정책값)
 
 springdoc:
   api-docs:

--- a/src/test/java/com/readum/domain/aiChat/service/AiChatHistorySearchServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/AiChatHistorySearchServiceTest.java
@@ -28,7 +28,8 @@ class AiChatHistorySearchServiceTest {
             new AiChatProperties.ContextWindow(20),
             new AiChatProperties.MessageRule(4000),
             new AiChatProperties.RateLimit(10, 5, 3600, 20),
-            new AiChatProperties.TitleGeneration(4, 2000)
+            new AiChatProperties.TitleGeneration(4, 2000),
+            null
     );
 
     private AiChatHistorySearchService service;

--- a/src/test/java/com/readum/domain/aiChat/service/AiChatMessageSendServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/AiChatMessageSendServiceTest.java
@@ -79,7 +79,8 @@ class AiChatMessageSendServiceTest {
             new AiChatProperties.ContextWindow(20),
             new AiChatProperties.MessageRule(4000),
             new AiChatProperties.RateLimit(10, 5, 3600, 20),
-            new AiChatProperties.TitleGeneration(4, 2000)
+            new AiChatProperties.TitleGeneration(4, 2000),
+            null
     );
 
     private AiChatMessageSendService service;

--- a/src/test/java/com/readum/domain/aiChat/service/SummaryDraftSearchServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/SummaryDraftSearchServiceTest.java
@@ -1,5 +1,6 @@
 package com.readum.domain.aiChat.service;
 
+import com.readum.domain.aiChat.config.AiChatProperties;
 import com.readum.domain.aiChat.dto.SummaryDraftEligibility.IneligibleReason;
 import com.readum.domain.aiChat.dto.SummaryDraftEligibilityResult;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
@@ -45,7 +46,10 @@ class SummaryDraftSearchServiceTest {
     private UserBookRepository userBookRepository;
 
     @Spy
-    private SummaryDraftPolicy summaryDraftPolicy = new SummaryDraftPolicy();
+    private SummaryDraftPolicy summaryDraftPolicy = new SummaryDraftPolicy(new AiChatProperties(
+            null, null, null, null,
+            new AiChatProperties.SummaryDraft(500)
+    ));
 
     @Mock
     private SummaryJobRepository summaryJobRepository;

--- a/src/test/java/com/readum/domain/aiChat/service/policy/SummaryDraftPolicyTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/policy/SummaryDraftPolicyTest.java
@@ -1,5 +1,6 @@
 package com.readum.domain.aiChat.service.policy;
 
+import com.readum.domain.aiChat.config.AiChatProperties;
 import com.readum.domain.aiChat.dto.SummaryDraftEligibility;
 import com.readum.domain.aiChat.dto.SummaryDraftEligibility.IneligibleReason;
 import com.readum.domain.aiChat.exception.AiChatErrorCode;
@@ -19,11 +20,22 @@ class SummaryDraftPolicyTest {
     private static final Long SESSION_ID = 1L;
     private static final Long USER_BOOK_ID = 1L;
 
-    private final SummaryDraftPolicy summaryDraftPolicy = new SummaryDraftPolicy();
+    private SummaryDraftPolicy policyWithThreshold(int minAccumulatedTokens) {
+        return new SummaryDraftPolicy(new AiChatProperties(
+                null, null, null, null,
+                new AiChatProperties.SummaryDraft(minAccumulatedTokens)));
+    }
+
+    private AiChatSession activeSessionWithTokens(int accumulatedTokens) {
+        AiChatSession session = AiChatSession.create(1L);
+        session.addAssistantTokens(accumulatedTokens);
+        return session;
+    }
 
     @Test
     void 정상_세션이면_eligible_상태로_평가된다() {
-        AiChatSession session = activeSession(SummaryDraftPolicy.MIN_ACCUMULATED_TOKENS + 100);
+        SummaryDraftPolicy summaryDraftPolicy = policyWithThreshold(500);
+        AiChatSession session = activeSession(600);
 
         SummaryDraftEligibility result = summaryDraftPolicy.evaluate(session);
 
@@ -34,7 +46,8 @@ class SummaryDraftPolicyTest {
 
     @Test
     void 잠긴_세션이면_ALREADY_SUMMARIZED_사유로_evaluate된다() {
-        AiChatSession session = lockedSession(SummaryDraftPolicy.MIN_ACCUMULATED_TOKENS + 100);
+        SummaryDraftPolicy summaryDraftPolicy = policyWithThreshold(500);
+        AiChatSession session = lockedSession(600);
 
         SummaryDraftEligibility result = summaryDraftPolicy.evaluate(session);
 
@@ -44,6 +57,7 @@ class SummaryDraftPolicyTest {
 
     @Test
     void 종료된_세션은_ALREADY_SUMMARIZED로_막는다() {
+        SummaryDraftPolicy summaryDraftPolicy = policyWithThreshold(500);
         AiChatSession session = AiChatSessionFixture.persistedSummarizedSession(1L, 5L, 2, 600, "제목");
 
         assertThatThrownBy(() -> summaryDraftPolicy.assertEligible(session))
@@ -54,7 +68,8 @@ class SummaryDraftPolicyTest {
 
     @Test
     void 누적_토큰이_부족하면_CHAT_VOLUME_NOT_ENOUGH_사유로_evaluate된다() {
-        AiChatSession session = activeSession(SummaryDraftPolicy.MIN_ACCUMULATED_TOKENS - 1);
+        SummaryDraftPolicy summaryDraftPolicy = policyWithThreshold(500);
+        AiChatSession session = activeSession(499);
 
         SummaryDraftEligibility result = summaryDraftPolicy.evaluate(session);
 
@@ -64,7 +79,8 @@ class SummaryDraftPolicyTest {
 
     @Test
     void 누적_토큰이_부족할때_assertEligible하면_UnprocessableEntityException이_발생한다() {
-        AiChatSession session = activeSession(SummaryDraftPolicy.MIN_ACCUMULATED_TOKENS - 1);
+        SummaryDraftPolicy summaryDraftPolicy = policyWithThreshold(500);
+        AiChatSession session = activeSession(499);
 
         assertThatThrownBy(() -> summaryDraftPolicy.assertEligible(session))
                 .asInstanceOf(InstanceOfAssertFactories.type(UnprocessableEntityException.class))
@@ -74,7 +90,8 @@ class SummaryDraftPolicyTest {
 
     @Test
     void 임계값과_같으면_eligible로_평가된다() {
-        AiChatSession session = activeSession(SummaryDraftPolicy.MIN_ACCUMULATED_TOKENS);
+        SummaryDraftPolicy summaryDraftPolicy = policyWithThreshold(500);
+        AiChatSession session = activeSession(500);
 
         SummaryDraftEligibility result = summaryDraftPolicy.evaluate(session);
 
@@ -83,11 +100,37 @@ class SummaryDraftPolicyTest {
 
     @Test
     void 잠김_상태가_토큰_부족보다_먼저_평가된다() {
-        AiChatSession session = lockedSession(SummaryDraftPolicy.MIN_ACCUMULATED_TOKENS - 1);
+        SummaryDraftPolicy summaryDraftPolicy = policyWithThreshold(500);
+        AiChatSession session = lockedSession(499);
 
         SummaryDraftEligibility result = summaryDraftPolicy.evaluate(session);
 
         assertThat(result.reason()).isEqualTo(IneligibleReason.ALREADY_SUMMARIZED);
+    }
+
+    // --- 경계값 테스트 ---
+
+    @Test
+    void 누적_토큰이_문턱값_미만이면_생성_불가_사유는_CHAT_VOLUME_NOT_ENOUGH_다() {
+        SummaryDraftEligibility eligibility =
+                policyWithThreshold(500).evaluate(activeSessionWithTokens(499));
+
+        assertThat(eligibility.eligible()).isFalse();
+        assertThat(eligibility.reason()).isEqualTo(IneligibleReason.CHAT_VOLUME_NOT_ENOUGH);
+    }
+
+    @Test
+    void 누적_토큰이_문턱값과_같으면_생성_가능하다() {
+        SummaryDraftEligibility eligibility =
+                policyWithThreshold(500).evaluate(activeSessionWithTokens(500));
+
+        assertThat(eligibility.eligible()).isTrue();
+    }
+
+    @Test
+    void 진행률은_문턱값_대비_백분율이고_100_을_넘지_않는다() {
+        assertThat(policyWithThreshold(500).calculateProgressPercent(250)).isEqualTo(50);
+        assertThat(policyWithThreshold(500).calculateProgressPercent(600)).isEqualTo(100);
     }
 
     private AiChatSession activeSession(int accumulatedTokens) {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -41,6 +41,8 @@ ai-chat:
   title-generation:
     thread-cap: 32
     queue-cap: 64
+  summary-draft:
+    min-accumulated-tokens: 500
 
 aladin:
   ttb-key: test-ttb-key


### PR DESCRIPTION
## 작업 사항

수동(데모)으로 표기돼 있던 감상문 생성 요청 기능이 계속 유지할 정식 기능으로 확정됐다. 이 PR 은 동작 변경 없이 임시 흔적만 정리한다.

`SummaryDraftPolicy` 에 하드코딩돼 있던 `MIN_ACCUMULATED_TOKENS = 500` 과 `TODO: 정책 확정 후 상수값 조정 필요` 주석을, 확정 정책값으로서 `AiChatProperties` 의 nested record(`ai-chat.summary-draft.min-accumulated-tokens: 500`)로 외부화했다. 도메인 비즈니스 룰 설정 규칙에 따라 application.yml 직접값으로 두어, 정책 조정 시 재배포로 반영할 수 있다.

문턱값의 출처는 정책 클래스 한 곳으로 유지했다 — 자동 생성 스케줄러(`SummaryScheduler`)도 상수 대신 `SummaryDraftPolicy.minAccumulatedTokens()` 를 경유해 같은 값을 읽는다. `SummaryDraftService` 의 "수동(데모)" 클래스 주석은 정식 기능 서술로 교체했다.

### 기능

**감상문 생성 정책**
- 문턱값(누적 토큰 500)이 코드 상수가 아니라 설정값으로 관리된다 — 값 조정 시 코드 수정 없이 yml 변경으로 가능
- 동작 변경 없음: 자동 스케줄러 병행, 생성 성공 시 세션 영구 잠금, 202 + 폴링 구조 모두 현행 유지

## 테스트 결과
- [x] `./gradlew test` 통과 (391 tests, 0 failed)
- [x] 경계값 테스트 추가: 문턱값 미만(499) 생성 불가 / 문턱값 도달(500) 생성 가능 / 진행률 100% 상한
- [x] 스케줄러가 전달하는 문턱값이 기존과 동일(500)함을 코드 리뷰로 확인

## 관련 이슈
- closes #114

## 참고 사항
- 이 브랜치는 #113 브랜치 위에 적층돼 있다. #113 머지 전에는 diff 에 #113 커밋이 포함돼 보일 수 있으니 리뷰는 마지막 커밋 2개만 보면 된다.
- `AiChatProperties` 생성자에 파라미터가 추가되므로, 이를 직접 생성하는 테스트들은 함께 갱신했다.