### PR TITLE
refactor(book,ai-chat): 외부 API 호출을 트랜잭션 밖으로 분리

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ AI 작업자를 위한 최상단 라우터 문서. 상세 규칙은 링크된 �
 6. **인증 신원**: `SessionCookieAuthenticationFilter` 가 해석해 컨트롤러에 `@AuthenticatedUserId Long userId` 로만 전달. 서비스에서 쿠키/세션을 직접 읽는 패턴 금지 (ArchUnit 으로 강제) → [security-architecture](docs/architecture/security-architecture.md)
 7. **테스트**: 서비스 레이어 단위 테스트 필수, 조회 기능은 DAO 통합 테스트 필수. 테스트 이름은 행위를 주장하는 한글 문장 → [testing](docs/conventions/testing.md)
 8. **API/Swagger**: 경로 `/api/v1/{resource}`, 컨트롤러에 `@Tag`, 메서드에 `@Operation` + `@ApiResponses` 필수. 응답 wrapper 는 `GlobalApiResponse` → [api-and-swagger](docs/conventions/api-and-swagger.md)
-9. **트랜잭션**: 단일 Repository 호출만 하는 조회 서비스에 `@Transactional(readOnly = true)` 를 붙이지 않는다 (붙이는 예외 기준은 문서) → [transaction](docs/conventions/transaction.md)
+9. **트랜잭션**: 단일 Repository 호출만 하는 조회 서비스에 `@Transactional(readOnly = true)` 를 붙이지 않는다. 외부 HTTP 호출(알라딘·LLM 등)은 `@Transactional` 밖에서 하고, 원자적 DB 쓰기만 협력자 빈(`{동작대상}Writer`/`Reader`, package-private)의 선언적 `@Transactional` 에 위임한다. `TransactionTemplate` 금지 (부착·분리·미분리 기준은 문서) → [transaction](docs/conventions/transaction.md)
 10. **설정값**: 시크릿·환경별 값은 환경변수와 `application-{profile}.yml`, 환경 무관 비즈니스 룰은 `application.yml` 직접값 → [configuration](docs/conventions/configuration.md)
 
 이 밖의 규칙(JPQL 작성, 네이밍 표, 로그 레벨 등)은 [docs/conventions/README.md](docs/conventions/README.md) 색인에서 찾는다.

--- a/docs/conventions/README.md
+++ b/docs/conventions/README.md
@@ -11,7 +11,7 @@
 | [dto.md](dto.md) | DTO 규칙과 Entity → Result 변환 책임 |
 | [entity.md](entity.md) | 엔티티 작성 규칙과 테스트 Fixture 규칙 |
 | [jpql.md](jpql.md) | JPQL/쿼리 작성(derived query 우선, alias, 쉼표 위치) |
-| [transaction.md](transaction.md) | `@Transactional(readOnly = true)` 부착 기준 |
+| [transaction.md](transaction.md) | `@Transactional(readOnly = true)` 부착 기준, 외부 I/O 트랜잭션 밖 분리·협력자 빈 기준 (`TransactionTemplate` 금지) |
 | [api-and-swagger.md](api-and-swagger.md) | API 경로/응답 형식과 Swagger 문서화 |
 | [naming.md](naming.md) | 클래스/DTO/Port 등 이름 규칙 |
 | [vocabulary.md](vocabulary.md) | 어휘·용어 작성 규칙 — 글 전반(문서·PR·주석·커밋·로그) 공통 (원본 문서) |

--- a/docs/conventions/naming.md
+++ b/docs/conventions/naming.md
@@ -6,6 +6,7 @@
 |------|------|------|
 | Command 서비스 | `{Action}Service` | `SignUpService` |
 | Query 서비스 | `{Domain}SearchService` | `UserSearchService` |
+| 트랜잭션 경계 협력자 빈 | `{동작대상}Writer`(쓰기) / `{동작대상}Reader`(읽기), package-private | `UserBookRegistrationWriter`, `UserBookConflictReader` |
 | Command DTO | `{Action}Command` | `SignUpCommand` |
 | Result DTO | `{Action}Result` / `{Domain}Result` | `SignUpResult`, `ExampleResult` |
 | Request DTO | `{Action}Request` | `ExampleCreateRequest` |

--- a/docs/conventions/transaction.md
+++ b/docs/conventions/transaction.md
@@ -1,8 +1,28 @@
 # 트랜잭션 규칙
 
-> 적용 대상: 조회/변경 서비스 메서드에 `@Transactional(readOnly = true)` 를 붙일지 정할 때.
+> 적용 대상: 서비스에 트랜잭션 경계를 그을 때 — `@Transactional(readOnly = true)` 부착 여부, 그리고 외부 I/O 를 트랜잭션 밖으로 뺄지 정할 때.
+
+## `@Transactional(readOnly = true)` 부착 기준
 
 - **단순 조회 service 에는 `@Transactional(readOnly = true)` 를 붙이지 않는다.** Spring Data JPA 의 `SimpleJpaRepository` 가 클래스 레벨에서 이미 readOnly 트랜잭션을 감싸므로, service 가 단일 Repository 호출만 하면 효과가 중복된다. 다른 Query 서비스 (`UserSearchService`, `AiChatMessageSearchService`, `AiChatHistorySearchService`) 도 이 컨벤션으로 통일.
 - 명시적으로 `@Transactional(readOnly = true)` 를 붙이는 예외 케이스 — 효과가 실제로 나타날 때만:
   - 한 service 메서드에서 여러 Repository 호출을 한 트랜잭션으로 묶어 일관된 상태로 읽어야 할 때
   - OSIV 가 꺼진 환경에서 service 의 변환 단계가 LAZY 컬렉션을 접근해야 할 때
+
+## 외부 I/O 는 트랜잭션 밖에서 — 트랜잭션 경계 협력자 빈
+
+- **외부 HTTP 호출(알라딘·LLM 등)을 `@Transactional` 구간 안에서 하지 않는다.** 트랜잭션이 열리는 동안 DB 커넥션이 점유되므로, 외부 응답을 기다리는 사이 커넥션이 낭비되고 요청이 몰리면 풀이 고갈된다.
+- **"외부 호출 + 원자적 DB 쓰기" 가 한 흐름에 섞이면**, 외부 호출은 트랜잭션 밖(서비스 본문)에서 하고, 원자적으로 묶여야 하는 DB 쓰기만 별도 협력자 빈의 `@Transactional` 메서드에 위임한다.
+- **메서드 분리가 아니라 클래스(빈) 분리로 한다.** `@Transactional` 은 프록시 기반이라 같은 클래스 안의 `this.method()` 호출은 프록시를 거치지 않아 트랜잭션이 열리지 않는다(self-invocation). 트랜잭션 구간은 반드시 다른 빈으로 뺀다.
+- **`TransactionTemplate` 을 쓰지 않는다.** 트랜잭션 경계는 선언적 `@Transactional` 로만 드러낸다.
+
+### 협력자 빈을 만들지 않는 경우
+
+- 외부 I/O 없이 DB 만 만지는 서비스 → 서비스 메서드에 직접 `@Transactional`. 협력자 빈을 만들지 않는다.
+- 외부 I/O 는 있으나 DB 쓰기가 없거나, 쓰기들이 서로 독립적이라 원자성이 필요 없을 때 → 트랜잭션 자체가 불필요하므로 나누지 않는다.
+
+### 이름·배치
+
+- 이름: `{동작대상}Writer`(쓰기) / `{동작대상}Reader`(읽기).
+- 가시성: package-private (`class`) 로 둔다. 유스케이스 진입점은 여전히 `{Action}Service` 하나이며, 협력자 빈은 그 기능 폴더 안의 내부 부품으로 가둔다.
+- 묶음 단위: 메서드마다 빈을 만들지 말고, 한 기능의 관련 DB 쓰기를 한 협력자 빈에 메서드로 모은다.

--- a/src/main/java/com/readum/domain/aiChat/service/AiChatSessionTitleService.java
+++ b/src/main/java/com/readum/domain/aiChat/service/AiChatSessionTitleService.java
@@ -5,10 +5,9 @@ import com.readum.domain.aiChat.exception.AiChatErrorCode;
 import com.readum.domain.aiChat.out.AiChatTitleClient;
 import com.readum.domain.exception.NotFoundException;
 import com.readum.model.aiChat.repository.AiChatSessionRepository;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * 채팅 세션의 제목을 생성·갱신하는 Command 서비스.
@@ -18,27 +17,18 @@ import org.springframework.transaction.support.TransactionTemplate;
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class AiChatSessionTitleService {
 
     private final AiChatSessionRepository aiChatSessionRepository;
     private final AiChatTitleClient aiChatTitleClient;
-    private final TransactionTemplate transactionTemplate;
-
-    public AiChatSessionTitleService(
-            AiChatSessionRepository aiChatSessionRepository,
-            AiChatTitleClient aiChatTitleClient,
-            PlatformTransactionManager transactionManager
-    ) {
-        this.aiChatSessionRepository = aiChatSessionRepository;
-        this.aiChatTitleClient = aiChatTitleClient;
-        this.transactionTemplate = new TransactionTemplate(transactionManager);
-    }
+    private final AiChatSessionTitleWriter aiChatSessionTitleWriter;
 
     /**
      * LLM 호출 동안 DB 커넥션을 잡지 않도록 트랜잭션을 두 단계로 쪼갠다.
      * 1) existsById 로 세션 존재만 짧게 검증 (SimpleJpaRepository 의 자동 readOnly tx)
      * 2) 트랜잭션 밖에서 LLM 호출
-     * 3) findById + updateTitle 만 짧은 트랜잭션으로 묶어 dirty-check flush 를 보장
+     * 3) AiChatSessionTitleWriter 가 findById + updateTitle 만 짧은 트랜잭션으로 수행
      */
     public void execute(GenerateSessionTitleCommand command) {
         if (!aiChatSessionRepository.existsById(command.sessionId())) {
@@ -51,8 +41,6 @@ public class AiChatSessionTitleService {
             return;
         }
 
-        transactionTemplate.executeWithoutResult(status ->
-                aiChatSessionRepository.findById(command.sessionId())
-                        .ifPresent(session -> session.updateTitle(generated)));
+        aiChatSessionTitleWriter.updateTitle(command.sessionId(), generated);
     }
 }

--- a/src/main/java/com/readum/domain/aiChat/service/AiChatSessionTitleWriter.java
+++ b/src/main/java/com/readum/domain/aiChat/service/AiChatSessionTitleWriter.java
@@ -1,0 +1,25 @@
+package com.readum.domain.aiChat.service;
+
+import com.readum.model.aiChat.repository.AiChatSessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 세션 제목 갱신의 DB 쓰기 구간만 트랜잭션으로 묶는 헬퍼.
+ * LLM 호출이 트랜잭션(= DB 커넥션 점유) 안에 들어오지 않도록
+ * AiChatSessionTitleService 에서 분리했다. findById + updateTitle 을
+ * 한 트랜잭션으로 묶어 dirty-check flush 를 보장한다.
+ */
+@Component
+@RequiredArgsConstructor
+class AiChatSessionTitleWriter {
+
+    private final AiChatSessionRepository aiChatSessionRepository;
+
+    @Transactional
+    public void updateTitle(Long sessionId, String title) {
+        aiChatSessionRepository.findById(sessionId)
+                .ifPresent(session -> session.updateTitle(title));
+    }
+}

--- a/src/main/java/com/readum/domain/user/userbook/service/UserBookCreateService.java
+++ b/src/main/java/com/readum/domain/user/userbook/service/UserBookCreateService.java
@@ -2,18 +2,10 @@ package com.readum.domain.user.userbook.service;
 
 import com.readum.domain.book.dto.BookResult;
 import com.readum.domain.book.out.BookLookupClient;
-import com.readum.domain.exception.ConflictException;
 import com.readum.domain.user.userbook.dto.UserBookCreateCommand;
 import com.readum.domain.user.userbook.dto.UserBookCreateResult;
-import com.readum.domain.user.userbook.exception.UserBookErrorCode;
-import com.readum.model.book.entity.Book;
-import com.readum.model.book.repository.BookRepository;
-import com.readum.model.user.entity.UserBook;
-import com.readum.model.user.repository.UserBookRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
@@ -21,40 +13,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserBookCreateService {
 
     private final BookLookupClient bookLookupClient;
-    private final BookRepository bookRepository;
-    private final UserBookRepository userBookRepository;
-    private final UserBookConflictReader userBookConflictReader;
+    private final UserBookRegistrationWriter userBookRegistrationWriter;
 
-    @Transactional
     public UserBookCreateResult execute(UserBookCreateCommand command) {
-        // 1. 알라딘에서 도서 정보 조회 (신뢰할 수 있는 원천 데이터 확보)
+        // 알라딘 도서 정보 조회 (신뢰할 수 있는 원천 데이터 확보).
+        // 외부 HTTP 호출이 DB 커넥션을 점유하지 않도록 트랜잭션 시작 전에 끝낸다.
         BookResult bookInfo = bookLookupClient.execute(command.bookExternalId());
 
-        // 2. Book 마스터 UPSERT (동일 external_id 존재 시 기존 행 재사용, 없으면 신규 생성)
-        bookRepository.upsert(
-                command.bookExternalId(),
-                bookInfo.title(),
-                bookInfo.author(),
-                bookInfo.publisher(),
-                bookInfo.publishedYear(),
-                bookInfo.coverUrl()
-        );
-
-        // 3. Book 엔티티 확보
-        Book book = bookRepository.findByExternalId(command.bookExternalId())
-                .orElseThrow(() -> new IllegalStateException(
-                        "upsert 후 book을 찾을 수 없음: " + command.bookExternalId()));
-
-        // 4. 신규 UserBook 등록
-        // 중복(일반 재등록 또는 race condition) 발생 시 DataIntegrityViolationException을 잡아
-        // 새 트랜잭션으로 재조회 후 409로 전환한다.
-        try {
-            UserBook saved = userBookRepository.save(UserBook.create(command.userId(), book.getId()));
-            return UserBookCreateResult.from(saved, book);
-        } catch (DataIntegrityViolationException ex) {
-            UserBook raced = userBookConflictReader.find(command.userId(), book.getId())
-                    .orElseThrow(() -> ex);
-            throw new ConflictException(UserBookErrorCode.ALREADY_EXISTS, UserBookCreateResult.from(raced, book));
-        }
+        return userBookRegistrationWriter.register(command, bookInfo);
     }
 }

--- a/src/main/java/com/readum/domain/user/userbook/service/UserBookRegistrationWriter.java
+++ b/src/main/java/com/readum/domain/user/userbook/service/UserBookRegistrationWriter.java
@@ -1,0 +1,59 @@
+package com.readum.domain.user.userbook.service;
+
+import com.readum.domain.book.dto.BookResult;
+import com.readum.domain.exception.ConflictException;
+import com.readum.domain.user.userbook.dto.UserBookCreateCommand;
+import com.readum.domain.user.userbook.dto.UserBookCreateResult;
+import com.readum.domain.user.userbook.exception.UserBookErrorCode;
+import com.readum.model.book.entity.Book;
+import com.readum.model.book.repository.BookRepository;
+import com.readum.model.user.entity.UserBook;
+import com.readum.model.user.repository.UserBookRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 도서 등록의 DB 쓰기 구간만 트랜잭션으로 묶는 헬퍼.
+ * 알라딘 HTTP 호출이 트랜잭션(= DB 커넥션 점유) 안에 들어오지 않도록
+ * UserBookCreateService 에서 분리했다.
+ */
+@Component
+@RequiredArgsConstructor
+class UserBookRegistrationWriter {
+
+    private final BookRepository bookRepository;
+    private final UserBookRepository userBookRepository;
+    private final UserBookConflictReader userBookConflictReader;
+
+    @Transactional
+    public UserBookCreateResult register(UserBookCreateCommand command, BookResult bookInfo) {
+        // 1. Book 마스터 UPSERT (동일 external_id 존재 시 기존 행 재사용, 없으면 신규 생성)
+        bookRepository.upsert(
+                command.bookExternalId(),
+                bookInfo.title(),
+                bookInfo.author(),
+                bookInfo.publisher(),
+                bookInfo.publishedYear(),
+                bookInfo.coverUrl()
+        );
+
+        // 2. Book 엔티티 확보
+        Book book = bookRepository.findByExternalId(command.bookExternalId())
+                .orElseThrow(() -> new IllegalStateException(
+                        "upsert 후 book을 찾을 수 없음: " + command.bookExternalId()));
+
+        // 3. 신규 UserBook 등록
+        // 중복(일반 재등록 또는 race condition) 발생 시 DataIntegrityViolationException을 잡아
+        // 새 트랜잭션으로 재조회 후 409로 전환한다.
+        try {
+            UserBook saved = userBookRepository.save(UserBook.create(command.userId(), book.getId()));
+            return UserBookCreateResult.from(saved, book);
+        } catch (DataIntegrityViolationException ex) {
+            UserBook raced = userBookConflictReader.find(command.userId(), book.getId())
+                    .orElseThrow(() -> ex);
+            throw new ConflictException(UserBookErrorCode.ALREADY_EXISTS, UserBookCreateResult.from(raced, book));
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -72,7 +72,7 @@ aladin:
   output: JS
   version: 20131101
   cover: Big
-  request-timeout: PT1S
+  request-timeout: PT3S
   search-result-limit: 200
 
 springdoc:

--- a/src/test/java/com/readum/domain/aiChat/service/AiChatSessionTitleServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/AiChatSessionTitleServiceTest.java
@@ -6,26 +6,20 @@ import com.readum.domain.aiChat.out.AiChatTitleClient;
 import com.readum.domain.exception.NotFoundException;
 import com.readum.model.aiChat.entity.AiChatMessage;
 import com.readum.model.aiChat.entity.AiChatMessageFixture;
-import com.readum.model.aiChat.entity.AiChatSession;
-import com.readum.model.aiChat.entity.AiChatSessionFixture;
 import com.readum.model.aiChat.repository.AiChatSessionRepository;
 
 import java.util.List;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionDefinition;
-import org.springframework.transaction.TransactionStatus;
-import org.springframework.transaction.support.SimpleTransactionStatus;
 
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -39,34 +33,25 @@ class AiChatSessionTitleServiceTest {
     @Mock
     private AiChatTitleClient aiChatTitleClient;
 
+    @Mock
+    private AiChatSessionTitleWriter aiChatSessionTitleWriter;
+
+    @InjectMocks
     private AiChatSessionTitleService titleService;
 
-    @BeforeEach
-    void setUp() {
-        titleService = new AiChatSessionTitleService(
-                aiChatSessionRepository,
-                aiChatTitleClient,
-                new NoopTransactionManager()
-        );
-    }
-
     @Test
-    void 세션이_존재하고_LLM_이_제목을_반환하면_세션_title_이_갱신된다() {
+    void 세션이_존재하고_LLM_이_제목을_반환하면_생성된_제목으로_갱신을_위임한다() {
         Long sessionId = 7L;
-        AiChatSession session = AiChatSessionFixture.persistedActiveSession(
-                sessionId, 100L, 1, 0, null
-        );
         List<AiChatMessage> messages = List.of(
                 AiChatMessageFixture.persistedUserMessage(1L, sessionId, "작가의 의도가 뭐야"),
                 AiChatMessageFixture.persistedAssistantMessage(2L, sessionId, "작가는 ...")
         );
         given(aiChatSessionRepository.existsById(sessionId)).willReturn(true);
-        given(aiChatSessionRepository.findById(sessionId)).willReturn(Optional.of(session));
         given(aiChatTitleClient.generate(messages)).willReturn("작가의 의도 분석");
 
         titleService.execute(new GenerateSessionTitleCommand(sessionId, messages));
 
-        assertThat(session.getTitle()).isEqualTo("작가의 의도 분석");
+        verify(aiChatSessionTitleWriter).updateTitle(sessionId, "작가의 의도 분석");
     }
 
     @Test
@@ -79,56 +64,18 @@ class AiChatSessionTitleServiceTest {
                 .extracting(NotFoundException::getErrorCode)
                 .isEqualTo(AiChatErrorCode.SESSION_NOT_FOUND);
 
-        verify(aiChatTitleClient, never()).generate(org.mockito.ArgumentMatchers.anyList());
+        verify(aiChatTitleClient, never()).generate(anyList());
     }
 
     @Test
-    void LLM_이_빈_제목을_반환하면_기존_title_은_변경되지_않는다() {
+    void LLM_이_빈_제목을_반환하면_갱신을_위임하지_않는다() {
         Long sessionId = 7L;
-        AiChatSession session = AiChatSessionFixture.persistedActiveSession(
-                sessionId, 100L, 1, 0, null
-        );
         List<AiChatMessage> messages = List.of();
         given(aiChatSessionRepository.existsById(sessionId)).willReturn(true);
         given(aiChatTitleClient.generate(messages)).willReturn("   ");
 
         titleService.execute(new GenerateSessionTitleCommand(sessionId, messages));
 
-        assertThat(session.getTitle()).isNull();
-    }
-
-    @Test
-    void LLM_이_길게_제목을_반환해도_엔티티가_컬럼_길이까지_자른다() {
-        Long sessionId = 7L;
-        AiChatSession session = AiChatSessionFixture.persistedActiveSession(
-                sessionId, 100L, 1, 0, null
-        );
-        List<AiChatMessage> messages = List.of();
-        given(aiChatSessionRepository.existsById(sessionId)).willReturn(true);
-        given(aiChatSessionRepository.findById(sessionId)).willReturn(Optional.of(session));
-        String longTitle = "가".repeat(150);
-        given(aiChatTitleClient.generate(messages)).willReturn(longTitle);
-
-        titleService.execute(new GenerateSessionTitleCommand(sessionId, messages));
-
-        assertThat(session.getTitle()).hasSize(100);
-    }
-
-    /**
-     * TransactionTemplate 가 콜백을 그대로 실행하도록 한 테스트 전용 noop 매니저.
-     */
-    private static final class NoopTransactionManager implements PlatformTransactionManager {
-        @Override
-        public TransactionStatus getTransaction(TransactionDefinition definition) {
-            return new SimpleTransactionStatus();
-        }
-
-        @Override
-        public void commit(TransactionStatus status) {
-        }
-
-        @Override
-        public void rollback(TransactionStatus status) {
-        }
+        verify(aiChatSessionTitleWriter, never()).updateTitle(anyLong(), anyString());
     }
 }

--- a/src/test/java/com/readum/domain/aiChat/service/AiChatSessionTitleWriterTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/AiChatSessionTitleWriterTest.java
@@ -1,0 +1,62 @@
+package com.readum.domain.aiChat.service;
+
+import com.readum.model.aiChat.entity.AiChatSession;
+import com.readum.model.aiChat.entity.AiChatSessionFixture;
+import com.readum.model.aiChat.repository.AiChatSessionRepository;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AiChatSessionTitleWriterTest {
+
+    @Mock
+    private AiChatSessionRepository aiChatSessionRepository;
+
+    @InjectMocks
+    private AiChatSessionTitleWriter titleWriter;
+
+    @Test
+    void 세션이_존재하면_title_이_갱신된다() {
+        Long sessionId = 7L;
+        AiChatSession session = AiChatSessionFixture.persistedActiveSession(
+                sessionId, 100L, 1, 0, null
+        );
+        given(aiChatSessionRepository.findById(sessionId)).willReturn(Optional.of(session));
+
+        titleWriter.updateTitle(sessionId, "작가의 의도 분석");
+
+        assertThat(session.getTitle()).isEqualTo("작가의 의도 분석");
+    }
+
+    @Test
+    void 긴_제목도_엔티티가_컬럼_길이까지_자른다() {
+        Long sessionId = 7L;
+        AiChatSession session = AiChatSessionFixture.persistedActiveSession(
+                sessionId, 100L, 1, 0, null
+        );
+        given(aiChatSessionRepository.findById(sessionId)).willReturn(Optional.of(session));
+
+        titleWriter.updateTitle(sessionId, "가".repeat(150));
+
+        assertThat(session.getTitle()).hasSize(100);
+    }
+
+    @Test
+    void 갱신_시점에_세션이_이미_삭제되어_없으면_예외_없이_조용히_끝난다() {
+        Long sessionId = 7L;
+        given(aiChatSessionRepository.findById(sessionId)).willReturn(Optional.empty());
+
+        assertThatCode(() -> titleWriter.updateTitle(sessionId, "작가의 의도 분석"))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/readum/domain/user/userbook/service/UserBookCreateServiceTest.java
+++ b/src/test/java/com/readum/domain/user/userbook/service/UserBookCreateServiceTest.java
@@ -1,34 +1,25 @@
 package com.readum.domain.user.userbook.service;
 
 import com.readum.domain.book.dto.BookResult;
+import com.readum.domain.book.exception.BookErrorCode;
 import com.readum.domain.book.out.BookLookupClient;
-import com.readum.domain.exception.ConflictException;
+import com.readum.domain.exception.NotFoundException;
 import com.readum.domain.user.userbook.dto.UserBookCreateCommand;
 import com.readum.domain.user.userbook.dto.UserBookCreateResult;
-import com.readum.domain.user.userbook.exception.UserBookErrorCode;
-import com.readum.model.book.entity.Book;
-import com.readum.model.book.entity.BookFixture;
-import com.readum.model.user.entity.UserBook;
-import com.readum.model.user.entity.UserBookFixture;
-import com.readum.model.book.repository.BookRepository;
-import com.readum.model.user.repository.UserBookRepository;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.DataIntegrityViolationException;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class UserBookCreateServiceTest {
@@ -37,19 +28,12 @@ class UserBookCreateServiceTest {
     private BookLookupClient bookLookupClient;
 
     @Mock
-    private BookRepository bookRepository;
-
-    @Mock
-    private UserBookRepository userBookRepository;
-
-    @Mock
-    private UserBookConflictReader userBookConflictReader;
+    private UserBookRegistrationWriter userBookRegistrationWriter;
 
     @InjectMocks
     private UserBookCreateService userBookCreateService;
 
     private static final Long USER_ID = 1L;
-    private static final Long BOOK_ID = 10L;
     private static final String EXTERNAL_ID = "9788965700807";
     private static final String TITLE = "테스트 책";
     private static final String AUTHORS = "테스트 저자";
@@ -65,62 +49,33 @@ class UserBookCreateServiceTest {
         return new BookResult(COVER_URL, TITLE, AUTHORS, PUBLISHER, PUBLISHED_YEAR, EXTERNAL_ID);
     }
 
-    private Book stubBook() {
-        return BookFixture.persistedBook(BOOK_ID, EXTERNAL_ID, TITLE, AUTHORS, PUBLISHER, PUBLISHED_YEAR, COVER_URL);
-    }
-
     @Test
-    void 신규_도서_등록_시_알라딘_조회_후_upsert_호출_후_UserBook이_저장되고_올바른_결과를_반환한다() {
-        Book book = stubBook();
-        LocalDateTime savedAt = LocalDateTime.of(2024, 6, 1, 12, 0);
-        UserBook savedUserBook = UserBookFixture.persistedUserBook(100L, USER_ID, BOOK_ID, savedAt);
+    void 도서_등록_시_알라딘_조회_후_그_결과로_DB_쓰기를_위임하고_쓰기_결과를_반환한다() {
+        BookResult bookInfo = stubBookResult();
+        UserBookCreateResult writerResult = new UserBookCreateResult(
+                100L, USER_ID, EXTERNAL_ID, TITLE, AUTHORS, PUBLISHER, PUBLISHED_YEAR, COVER_URL,
+                LocalDateTime.of(2024, 6, 1, 12, 0));
 
-        given(bookLookupClient.execute(EXTERNAL_ID)).willReturn(stubBookResult());
-        given(bookRepository.findByExternalId(EXTERNAL_ID)).willReturn(Optional.of(book));
-        given(userBookRepository.save(any(UserBook.class))).willReturn(savedUserBook);
+        given(bookLookupClient.execute(EXTERNAL_ID)).willReturn(bookInfo);
+        given(userBookRegistrationWriter.register(command(), bookInfo)).willReturn(writerResult);
 
         UserBookCreateResult result = userBookCreateService.execute(command());
 
-        verify(bookLookupClient).execute(EXTERNAL_ID);
-        verify(bookRepository).upsert(EXTERNAL_ID, TITLE, AUTHORS, PUBLISHER, PUBLISHED_YEAR, COVER_URL);
+        assertThat(result).isEqualTo(writerResult);
 
-        ArgumentCaptor<UserBook> userBookCaptor = ArgumentCaptor.forClass(UserBook.class);
-        verify(userBookRepository).save(userBookCaptor.capture());
-        assertThat(userBookCaptor.getValue().getUserId()).isEqualTo(USER_ID);
-        assertThat(userBookCaptor.getValue().getBookId()).isEqualTo(BOOK_ID);
-
-        assertThat(result.id()).isEqualTo(100L);
-        assertThat(result.userId()).isEqualTo(USER_ID);
-        assertThat(result.bookExternalId()).isEqualTo(EXTERNAL_ID);
-        assertThat(result.title()).isEqualTo(TITLE);
-        assertThat(result.authors()).isEqualTo(AUTHORS);
-        assertThat(result.createdAt()).isEqualTo(savedAt);
+        InOrder inOrder = Mockito.inOrder(bookLookupClient, userBookRegistrationWriter);
+        inOrder.verify(bookLookupClient).execute(EXTERNAL_ID);
+        inOrder.verify(userBookRegistrationWriter).register(command(), bookInfo);
     }
 
     @Test
-    void 이미_등록된_도서_재등록_시_ALREADY_EXISTS_ErrorCode와_기존_UserBook_데이터가_payload에_담긴_ConflictException이_발생한다() {
-        Book book = stubBook();
-        LocalDateTime existingCreatedAt = LocalDateTime.of(2024, 1, 1, 0, 0);
-        UserBook existingUserBook = UserBookFixture.persistedUserBook(99L, USER_ID, BOOK_ID, existingCreatedAt);
-
-        given(bookLookupClient.execute(EXTERNAL_ID)).willReturn(stubBookResult());
-        given(bookRepository.findByExternalId(EXTERNAL_ID)).willReturn(Optional.of(book));
-        given(userBookRepository.save(any(UserBook.class))).willThrow(new DataIntegrityViolationException("duplicate"));
-        given(userBookConflictReader.find(USER_ID, BOOK_ID)).willReturn(Optional.of(existingUserBook));
+    void 알라딘_조회가_실패하면_DB_쓰기를_시도하지_않고_예외가_그대로_전파된다() {
+        NotFoundException lookupFailure = new NotFoundException(BookErrorCode.LOOKUP_NOT_FOUND);
+        given(bookLookupClient.execute(EXTERNAL_ID)).willThrow(lookupFailure);
 
         assertThatThrownBy(() -> userBookCreateService.execute(command()))
-                .asInstanceOf(InstanceOfAssertFactories.type(ConflictException.class))
-                .satisfies(ex -> {
-                    assertThat(ex.getErrorCode()).isEqualTo(UserBookErrorCode.ALREADY_EXISTS);
-                    assertThat(ex.getPayload())
-                            .asInstanceOf(InstanceOfAssertFactories.type(UserBookCreateResult.class))
-                            .satisfies(payload -> {
-                                assertThat(payload.id()).isEqualTo(99L);
-                                assertThat(payload.userId()).isEqualTo(USER_ID);
-                                assertThat(payload.bookExternalId()).isEqualTo(EXTERNAL_ID);
-                                assertThat(payload.title()).isEqualTo(TITLE);
-                                assertThat(payload.createdAt()).isEqualTo(existingCreatedAt);
-                            });
-                });
+                .isSameAs(lookupFailure);
+
+        verifyNoInteractions(userBookRegistrationWriter);
     }
 }

--- a/src/test/java/com/readum/domain/user/userbook/service/UserBookRegistrationWriterTest.java
+++ b/src/test/java/com/readum/domain/user/userbook/service/UserBookRegistrationWriterTest.java
@@ -1,0 +1,119 @@
+package com.readum.domain.user.userbook.service;
+
+import com.readum.domain.book.dto.BookResult;
+import com.readum.domain.exception.ConflictException;
+import com.readum.domain.user.userbook.dto.UserBookCreateCommand;
+import com.readum.domain.user.userbook.dto.UserBookCreateResult;
+import com.readum.domain.user.userbook.exception.UserBookErrorCode;
+import com.readum.model.book.entity.Book;
+import com.readum.model.book.entity.BookFixture;
+import com.readum.model.user.entity.UserBook;
+import com.readum.model.user.entity.UserBookFixture;
+import com.readum.model.book.repository.BookRepository;
+import com.readum.model.user.repository.UserBookRepository;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserBookRegistrationWriterTest {
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private UserBookRepository userBookRepository;
+
+    @Mock
+    private UserBookConflictReader userBookConflictReader;
+
+    @InjectMocks
+    private UserBookRegistrationWriter userBookRegistrationWriter;
+
+    private static final Long USER_ID = 1L;
+    private static final Long BOOK_ID = 10L;
+    private static final String EXTERNAL_ID = "9788965700807";
+    private static final String TITLE = "테스트 책";
+    private static final String AUTHORS = "테스트 저자";
+    private static final String PUBLISHER = "테스트 출판사";
+    private static final Integer PUBLISHED_YEAR = 2024;
+    private static final String COVER_URL = "http://example.com/cover.jpg";
+
+    private UserBookCreateCommand command() {
+        return new UserBookCreateCommand(USER_ID, EXTERNAL_ID);
+    }
+
+    private BookResult stubBookResult() {
+        return new BookResult(COVER_URL, TITLE, AUTHORS, PUBLISHER, PUBLISHED_YEAR, EXTERNAL_ID);
+    }
+
+    private Book stubBook() {
+        return BookFixture.persistedBook(BOOK_ID, EXTERNAL_ID, TITLE, AUTHORS, PUBLISHER, PUBLISHED_YEAR, COVER_URL);
+    }
+
+    @Test
+    void 신규_도서_등록_시_upsert_호출_후_UserBook이_저장되고_올바른_결과를_반환한다() {
+        Book book = stubBook();
+        LocalDateTime savedAt = LocalDateTime.of(2024, 6, 1, 12, 0);
+        UserBook savedUserBook = UserBookFixture.persistedUserBook(100L, USER_ID, BOOK_ID, savedAt);
+
+        given(bookRepository.findByExternalId(EXTERNAL_ID)).willReturn(Optional.of(book));
+        given(userBookRepository.save(any(UserBook.class))).willReturn(savedUserBook);
+
+        UserBookCreateResult result = userBookRegistrationWriter.register(command(), stubBookResult());
+
+        verify(bookRepository).upsert(EXTERNAL_ID, TITLE, AUTHORS, PUBLISHER, PUBLISHED_YEAR, COVER_URL);
+
+        ArgumentCaptor<UserBook> userBookCaptor = ArgumentCaptor.forClass(UserBook.class);
+        verify(userBookRepository).save(userBookCaptor.capture());
+        assertThat(userBookCaptor.getValue().getUserId()).isEqualTo(USER_ID);
+        assertThat(userBookCaptor.getValue().getBookId()).isEqualTo(BOOK_ID);
+
+        assertThat(result.id()).isEqualTo(100L);
+        assertThat(result.userId()).isEqualTo(USER_ID);
+        assertThat(result.bookExternalId()).isEqualTo(EXTERNAL_ID);
+        assertThat(result.title()).isEqualTo(TITLE);
+        assertThat(result.authors()).isEqualTo(AUTHORS);
+        assertThat(result.createdAt()).isEqualTo(savedAt);
+    }
+
+    @Test
+    void 이미_등록된_도서_재등록_시_ALREADY_EXISTS_ErrorCode와_기존_UserBook_데이터가_payload에_담긴_ConflictException이_발생한다() {
+        Book book = stubBook();
+        LocalDateTime existingCreatedAt = LocalDateTime.of(2024, 1, 1, 0, 0);
+        UserBook existingUserBook = UserBookFixture.persistedUserBook(99L, USER_ID, BOOK_ID, existingCreatedAt);
+
+        given(bookRepository.findByExternalId(EXTERNAL_ID)).willReturn(Optional.of(book));
+        given(userBookRepository.save(any(UserBook.class))).willThrow(new DataIntegrityViolationException("duplicate"));
+        given(userBookConflictReader.find(USER_ID, BOOK_ID)).willReturn(Optional.of(existingUserBook));
+
+        assertThatThrownBy(() -> userBookRegistrationWriter.register(command(), stubBookResult()))
+                .asInstanceOf(InstanceOfAssertFactories.type(ConflictException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getErrorCode()).isEqualTo(UserBookErrorCode.ALREADY_EXISTS);
+                    assertThat(ex.getPayload())
+                            .asInstanceOf(InstanceOfAssertFactories.type(UserBookCreateResult.class))
+                            .satisfies(payload -> {
+                                assertThat(payload.id()).isEqualTo(99L);
+                                assertThat(payload.userId()).isEqualTo(USER_ID);
+                                assertThat(payload.bookExternalId()).isEqualTo(EXTERNAL_ID);
+                                assertThat(payload.title()).isEqualTo(TITLE);
+                                assertThat(payload.createdAt()).isEqualTo(existingCreatedAt);
+                            });
+                });
+    }
+}


### PR DESCRIPTION
## 배경

`UserBookCreateService.execute()` 가 `@Transactional` 메서드 첫 단계에서 알라딘 HTTP 호출을 수행하고 있었다. `JpaTransactionManager` 는 트랜잭션 시작 시점에 커넥션 풀에서 DB 커넥션을 확보하므로, 알라딘 응답을 기다리는 동안 DB 커넥션 하나가 아무 일도 안 하면서 점유된다. 도서 등록 요청이 몰리면 t3.micro + 작은 DB 풀 환경에서 커넥션 고갈의 원인이 될 수 있다 (AI 채팅 동시성 조사 #103 과 같은 계열의 병목).

같은 패턴을 점검하던 중 `AiChatSessionTitleService` 도 이미 외부(LLM) 호출을 트랜잭션 밖으로 빼두긴 했으나 `TransactionTemplate` 로 구현되어 있어, 팀 컨벤션(선언적 `@Transactional` 헬퍼 사용)에 맞춰 함께 정리했다.

## 변경 사항

- **`UserBookCreateService`**: 알라딘 도서 조회를 트랜잭션 밖(서비스 본문)에서 수행하고, DB 쓰기(upsert → findByExternalId → save, 충돌 시 409 전환)만 신규 `UserBookRegistrationWriter` (`@Transactional`) 에 위임. 알라딘 조회가 실패하면 트랜잭션을 시작하지 않고 예외가 그대로 전파된다.
- **`AiChatSessionTitleService`**: `TransactionTemplate` 제거. 제목 갱신 DB 쓰기(findById + updateTitle dirty-check)를 신규 `AiChatSessionTitleWriter` (`@Transactional`) 에 위임. 동작(존재 검증 → 트랜잭션 밖 LLM 호출 → 짧은 트랜잭션 쓰기)은 동일.
- **알라딘 `request-timeout`**: `PT1S` → `PT3S` (1초는 너무 짧아 정상 응답도 끊길 여지가 있어 완화).

## API 스펙

변경 없음. 순수 내부 구조 리팩토링으로 요청/응답 계약은 그대로다.

## 테스트 시나리오

- `UserBookCreateServiceTest`: 알라딘 조회 후 그 결과로 쓰기를 위임하고 결과를 반환한다 / 알라딘 조회 실패 시 DB 쓰기를 시도하지 않고 예외가 전파된다 (호출 순서·위임 검증)
- `UserBookRegistrationWriterTest`: 신규 등록 시 upsert 후 UserBook 저장·결과 반환 / 중복 시 `ALREADY_EXISTS` payload 를 담은 `ConflictException` (기존 서비스 테스트에서 이관)
- `AiChatSessionTitleServiceTest`: 세션 존재 + LLM 제목 반환 시 갱신 위임 / 세션 없으면 `NotFoundException` 이고 LLM 미호출 / 빈 제목이면 갱신 미위임
- `AiChatSessionTitleWriterTest`: 세션 존재 시 title 갱신 / 긴 제목 컬럼 길이 자름 / 갱신 시점에 세션이 없으면 조용히 종료
- `./gradlew test` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 도서 등록과 AI 세션 제목 갱신 과정에서 쓰기 처리가 분리되어, 더 안정적으로 처리되도록 개선되었습니다.
  * 일부 등록 흐름에서 외부 도서 조회 후 저장까지의 처리가 단순화되었습니다.

* **Bug Fixes**
  * 제목이 비어 있거나 세션이 이미 없는 경우, 불필요한 갱신을 하지 않도록 개선되었습니다.
  * 중복 등록 상황에서 기존 처리 결과를 더 일관되게 반환하도록 수정되었습니다.
  * 개발 환경에서 외부 도서 조회 요청의 대기 시간이 더 길어졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->