### PR TITLE
feat(config): graceful shutdown 명시 및 종료 대기 60초 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,9 +20,17 @@ spring:
     scheduling:
       pool:
         size: 3
+  # graceful shutdown 시 진행 중 HTTP 요청을 기다려 주는 시간 (#108).
+  # AI 채팅 SSE 스트림이 가장 긴 요청이라 기본값 30초 대신 60초.
+  # 배포 시 nginx 가 새 요청을 먼저 새 프로세스로 돌린 뒤 종료하므로, 이 대기는 배포 소요 시간만 늘릴 뿐 사용자 영향이 없다.
+  lifecycle:
+    timeout-per-shutdown-phase: 60s
 
 server:
   forward-headers-strategy: framework
+  # SIGTERM 을 받으면 새 요청은 즉시 거부하고 진행 중 요청만 위 대기 시간 안에서 마무리한다 (#108).
+  # Spring Boot 3.4+ 기본값이지만, 배포 절차(구 프로세스 종료 단계)가 이 동작에 의존하므로 명시해 둔다.
+  shutdown: graceful
 
 auth:
   access-token-ttl: PT30M


### PR DESCRIPTION
## 작업 사항

배포·재시작 때 프로세스를 SIGTERM 으로 끊으면 진행 중이던 HTTP 요청이 잘린다. #108 은 이를 "새 요청 차단 + 진행 중 요청만 마무리"로 바꾸는 것이 첫 단계다. Spring Boot 3.4+ 는 `server.shutdown` 기본값이 이미 graceful 이지만, 곧 도입할 롤링 배포의 "구 프로세스 종료" 단계가 이 동작에 의존하게 되므로 기본값에 맡기지 않고 설정으로 명시했다.

종료 대기 시간은 기본 30초 대신 60초로 정했다. 가장 긴 요청이 AI 채팅 SSE 스트림인데, 롤링 배포에서는 종료 시점에 nginx 가 새 요청을 이미 새 프로세스로 돌린 뒤라서 이 대기는 배포 소요 시간만 늘릴 뿐 사용자 영향이 없다. 60초를 넘겨 잘리는 스트림은 기존 `persistOnClientCancel` 경로로 부분 저장된다.

백그라운드 작업이 JVM 종료를 막지 않는지도 함께 확인했다(코드 변경 없음). 제목 생성 스케줄러는 daemon 스레드 + `destroyMethod = "dispose"` 라 종료를 막지 못하고, 감상문 워커 풀(`ThreadPoolTaskExecutor`)은 컨텍스트 종료 시 실행 중 작업을 인터럽트하는 기본 동작인데, 끊긴 작업은 DB 에 RUNNING 으로 남아 `SummaryJobReaper` 가 회수·재처리하므로 설계 의도("백그라운드 요약은 graceful 대상 아님")와 일치한다.

nginx upstream 전환·systemd 서비스·배포 스크립트·CI 구축은 이 PR 에 넣지 않았다 — #108 의 롤링 배포 PR 과 CI/CD PR 에서 이어서 진행한다.

### 기능

**배포 안정성**
- 배포·재시작 시 진행 중이던 API 요청과 AI 채팅 SSE 스트림이 60초 안에서 잘리지 않고 마무리된다
- 종료가 시작되면 새 요청은 즉시 거부된다

## 테스트 결과
- [x] `./gradlew test` 전체 통과
- [ ] 로컬 수동 검증: SSE 스트림을 열어둔 채 SIGTERM → ① 진행 중 스트림 유지 ② 새 요청 거부 ③ 60초 내 종료 ④ "Commencing graceful shutdown" 로그 확인 (검증 후 결과를 코멘트로 남길 예정)

## 관련 이슈
- 관련: #108 — 완료 조건 중 "graceful shutdown 설정 + timeout 값"과 "백그라운드 executor 확인"에 해당. 이슈 close 는 롤링 배포 PR 에서.

## 참고 사항
- Spring Boot 3.4+ 는 graceful 이 기본값이라, 이 PR 의 실질 변경은 대기 시간 30초 → 60초 상향과 배포 절차가 의존하는 동작의 명시다.
- 후속 예정: ① infra PR(nginx upstream 전환 + systemd 서비스 + 배포 스크립트 + Redis 컨테이너, #108 closes) ② GitHub Actions 빌드·배포 PR ③ RDS → Docker MySQL 이관 PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 서버 종료 시 graceful shutdown이 적용되도록 설정이 추가되었습니다.
  * 종료 시 진행 중인 요청은 최대 60초 동안 마무리할 수 있어, 예기치 않은 중단을 줄입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->