### PR TITLE
feat(infra): graceful shutdown + blue/green 롤링 배포 인프라 구성

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,10 @@
+# .env 템플릿. 실제 값을 채운 .env 는 커밋하지 않는다 (.gitignore).
+# 어떤 키가 필요한지의 원본은 src/main/resources/application*.yml 의 ${...} 플레이스홀더다.
+# 개발 서버 값의 원본은 GitHub Actions Secrets 이고, CI 가 배포 때마다 /opt/readum/.env 를
+# 재작성해 systemd(EnvironmentFile)와 docker compose 가 읽는다 (상세: docs/ops/deployment.md).
+# 로컬 컨테이너(MySQL·Redis)는 infra/docker/docker-compose.local.yml 로 띄운다.
+# 주의: SERVER_PORT 를 넣지 말 것 — systemd 유닛의 blue/green 포트 지정을 덮어쓴다.
+
 # MySQL (AWS RDS for dev; leave MYSQL_HOST unset to default to localhost)
 MYSQL_HOST=
 # MYSQL_HOST=your-dev-rds-endpoint.region.rds.amazonaws.com
@@ -8,3 +15,15 @@ MYSQL_PASSWORD=your_password
 
 # JWT (Base64-encoded 256bit+ secret, e.g. `openssl rand -base64 48`)
 JWT_SECRET=jsaTiXce4yBit2Qg8JOS8U7qH2kNg8d7+MJTieGkFg67vmSldN/fggYfK2dXR4X+
+
+# OpenAI (AI 채팅·감상문 생성)
+OPENAI_API_KEY=sk-your-key
+
+# Slack 알림 webhook
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+
+# 알라딘 도서 검색 API
+ALADIN_TTB_KEY=your-ttb-key
+
+# Redis (개발 서버 컨테이너 접속 비밀번호, e.g. `openssl rand -base64 24`)
+REDIS_PASSWORD=your-redis-password

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -5,6 +5,7 @@
 | 파일 | 내용 |
 |------|------|
 | [infrastructure.md](infrastructure.md) | 개발 서버 AWS 인프라 구성 (EC2·RDS·도메인·접속 방법) |
+| [deployment.md](deployment.md) | blue/green 배포 구조·절차·최초 전환(cutover) runbook (#108) |
 | [_template.md](_template.md) | 운영 문서 작성 템플릿 |
 
 ## 이 디렉토리에 적지 않는 것 (2026-07-05 결정)
@@ -14,5 +15,5 @@
 
 ## 아직 없는 문서와 작성 시점
 
-- 배포 절차 문서 — CI/CD 파이프라인을 구성하는 작업에서 함께 작성한다.
+- CI/CD 파이프라인 문서 — GitHub Actions 빌드·배포 워크플로우를 구성하는 작업에서 [deployment.md](deployment.md) 에 절을 추가한다.
 - 운영 로그/모니터링 확인 문서 — 로그 기반 에러 이슈 자동화 작업(Epic #100 계열)에서 함께 작성한다.

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -1,0 +1,109 @@
+# 배포 구조와 절차 (blue/green)
+
+> 적용 대상: 개발 서버(운영 겸용) 배포. 관련 이슈 #108, Epic #107.
+> 인프라 파일의 원본은 repo 의 [`infra/`](../../infra) 디렉토리다. 서버에 직접 적용된 상태가 repo 와 다르면 repo 를 고쳐서 배포하는 것이 원칙이다.
+
+## 개요
+
+단일 EC2 에서 같은 앱을 두 systemd 유닛(blue :8081 / green :8082)으로 번갈아 띄우고, nginx 의 upstream 파일 하나를 갈아끼워 트래픽을 전환한다. 완전 무중단이 아니라 **다운타임을 수십 ms(nginx reload) 수준으로 줄이는 절충안**이다.
+
+```text
+Internet ── nginx(:443, TLS 종료)
+              │  proxy_pass http://readum_backend
+              ▼
+  /etc/nginx/conf.d/readum-upstream.conf   ← 배포 스크립트가 갱신하는 "전환 스위치"
+    upstream readum_backend { server 127.0.0.1:8081; }
+              │
+     ┌────────┴────────┐
+  readum-blue(:8081)  readum-green(:8082)   ← systemd 유닛. 평상시 한쪽만 상주
+```
+
+| 구성물 | 위치 (서버) | 원본 (repo) |
+|---|---|---|
+| nginx server 블록 | `/etc/nginx/sites-available/app.conf` | `infra/nginx/app.conf` |
+| 전환 스위치(upstream) | `/etc/nginx/conf.d/readum-upstream.conf` | 없음 — 런타임 상태라 repo 로 관리하지 않음. `deploy.sh` 가 생성·갱신 |
+| systemd 유닛 | `/etc/systemd/system/readum-{blue,green}.service` | `infra/systemd/` |
+| 배포 스크립트 | `/opt/readum/bin/deploy.sh` | `infra/scripts/deploy.sh` |
+| jar | `/opt/readum/{blue,green}/app.jar`, 보관은 `/opt/readum/releases/` (최근 5개) | CI 가 빌드해 업로드 |
+| 환경 변수 | `/opt/readum/.env` | 원본은 GitHub Actions Secrets — CI 가 배포 때마다 서버 `.env` 를 재작성한다(CI/CD 구성 작업에서 도입, 그 전까지는 서버 파일이 원본). 변경 절차 = Secrets 수정 → 재배포. **`SERVER_PORT` 를 넣지 말 것** (유닛의 포트 지정을 덮어씀) |
+| Redis 컨테이너 | `docker compose` (readum-redis) | `infra/docker/docker-compose.dev.yml` (개발 서버 전용 — 로컬 개발용 아님) |
+| sudo 권한 목록 | `/etc/sudoers.d/readum-deploy` | `infra/sudoers/readum-deploy` |
+
+## 배포 흐름
+
+배포 한 번은 다음 순서로 진행된다 (`deploy.sh deploy <jar>` 가 수행):
+
+1. upstream 파일에서 활성 색을 읽는다 → 반대 색이 배포 대상
+2. jar 를 대상 색 디렉토리에 복사하고 `systemctl start`
+3. `/actuator/health/readiness` 가 통과할 때까지 대기 (최대 90초) — **실패하면 트래픽에 손대지 않고 중단** (기존 서비스 무영향)
+4. upstream 파일 재작성 → `nginx -t` → `systemctl reload nginx` — 이 순간 새 요청이 새 프로세스로 감. 진행 중이던 요청·SSE 는 기존 연결로 계속 처리됨
+5. 구 프로세스 `systemctl stop` — 앱의 graceful shutdown 이 진행 중 요청을 최대 60초 마무리 (`application.yml` 의 `server.shutdown` / `spring.lifecycle.timeout-per-shutdown-phase`, systemd 는 75초 후 강제 종료)
+
+수동 명령 (서버에서):
+
+```bash
+/opt/readum/bin/deploy.sh status                       # 활성 색·양쪽 상태 확인
+/opt/readum/bin/deploy.sh deploy /opt/readum/releases/readum-<sha>.jar
+/opt/readum/bin/deploy.sh rollback                     # 직전 버전(반대 색 jar)으로 되돌리기
+```
+
+롤백은 "반대 색을 재기동해 트래픽을 되돌리는 것"이다. 메모리 제약 때문에 구 프로세스를 상시 살려두지 않으므로, 롤백도 기동 → readiness → 전환의 같은 사이클을 탄다 (약 1분).
+
+## 배포 수칙
+
+- **05:50~06:10 에는 배포를 피한다.** 오전 6시 감상문 적재 스캔·디스패치와 배포의 2-프로세스 구간이 겹치면 스캔과 외부 API(OpenAI) 호출 예산이 잠깐 2배가 된다. 데이터는 멱등이라 안전하지만 호출 한도가 뚫릴 수 있다. 스크립트가 강제하지 않으므로 배포하는 사람이 시간대를 확인한다. rate limiter 상태가 Redis 로 공유되면(#88) 이 수칙은 사실상 불필요해진다.
+- 전환 구간에는 JVM 2개(각 `-Xmx256m`)가 동시에 떠 있으므로 서버 메모리에 여유가 필요하다. 스왑 2GB 를 유지하고, 배포 중 `free -m` 스왑 피크가 계속 커지면 인스턴스 증설을 검토한다.
+
+## 최초 전환(cutover) 절차 — 1회성
+
+기존 "단일 프로세스(:8080) + 수동 deploy.sh" 체계에서 새 체계로 갈아타는 절차. 이 이사 자체가 첫 blue/green 전환이라 순서만 지키면 다운타임이 없다 (인스턴스 증설 정지 1회 제외).
+
+**선행 (콘솔, 계획 정지 1회 — 팀 공지 후):**
+
+1. 탄력적 IP 확인 — 없으면 할당·연결하고 DNS(readum.kr, api.readum.kr)를 새 IP 로 갱신
+2. 인스턴스 증설 (t3.micro → t3.small 권장): stop → 타입 변경 → start
+3. 스왑 2GB 로 증설:
+   ```bash
+   sudo swapoff -a && sudo rm -f /swapfile
+   sudo fallocate -l 2G /swapfile && sudo chmod 600 /swapfile
+   sudo mkswap /swapfile && sudo swapon /swapfile
+   # /etc/fstab 의 스왑 항목도 /swapfile 2G 기준으로 갱신
+   ```
+
+**서버 준비 (기존 :8080 프로세스는 계속 서비스 중 — 무영향):**
+
+4. repo 를 임시로 받아 `sudo ./infra/scripts/setup.sh <repo>/infra` 실행 (디렉토리·유닛·sudoers 설치)
+5. 기존 `.env`(현행 배포가 쓰는 `~/18th-team4-server/.env`)를 새 위치로 복사 — 9단계에서 기존 디렉토리를 지우므로 반드시 그 전에:
+   ```bash
+   cp ~/18th-team4-server/.env /opt/readum/.env
+   chmod 600 /opt/readum/.env
+   vi /opt/readum/.env   # REDIS_PASSWORD=<openssl rand -base64 24> 추가, SERVER_PORT/APP_PORT 줄 제거
+   ```
+   같은 내용을 GitHub Actions Secrets(CI 의 `.env` 재작성용)에도 등록한다. Secrets 는 등록 후 다시 열람할 수 없으므로 팀 비밀 저장소에 사본을 함께 남긴다
+6. Docker 설치 후 Redis 기동:
+   ```bash
+   docker compose --env-file /opt/readum/.env -f <repo>/infra/docker/docker-compose.dev.yml up -d
+   ```
+
+**전환:**
+
+7. CI(workflow_dispatch) 또는 로컬 빌드로 jar 를 `/opt/readum/releases/` 에 올리고 `deploy.sh deploy <jar>` 실행 — upstream 파일이 없으므로 blue 로 기동·전환된다. 단, 이 시점 nginx 는 아직 :8080 을 가리키는 구 설정이므로 전환은 다음 단계에서 완성된다
+8. nginx 설정 교체: 기존 백업 후 repo 판 적용 → 검사 → reload
+   ```bash
+   sudo cp /etc/nginx/sites-available/app.conf /etc/nginx/sites-available/app.conf.bak
+   sudo cp <repo>/infra/nginx/app.conf /etc/nginx/sites-available/app.conf
+   sudo nginx -t && sudo systemctl reload nginx
+   ```
+9. 구 :8080 프로세스 종료 (`kill -TERM $(cat ~/18th-team4-server/app.pid)`) 후 기존 clone 디렉토리(`~/18th-team4-server`) 정리
+10. 검증(아래) 통과 후, CI 의 dev push 자동 배포 트리거 활성화
+
+## 배포 검증 체크리스트
+
+cutover 직후와 배포 방식이 바뀔 때마다 수행:
+
+- [ ] 같은 커밋으로 재배포를 한 번 더 실행해 정규 사이클(활성 판정 → 반대 색 기동 → readiness → 전환 → 구 프로세스 graceful 종료) 전체를 확인
+- [ ] 재배포 도중 1초 간격 `curl https://api.readum.kr/...` 실패 0건
+- [ ] 재배포 도중 열어둔 AI 채팅 SSE 스트림이 끊기지 않음
+- [ ] 외부에서 `curl -i https://api.readum.kr/actuator/prometheus` → 404 (swagger-ui, v3/api-docs 도 동일)
+- [ ] 앱 로그의 `X-Forwarded-For` 에 실제 클라이언트 IP 가 보존됨
+- [ ] 재배포 중 `free -m` 스왑 피크 기록 (다음 배포의 기준선)

--- a/infra/docker/docker-compose.dev.yml
+++ b/infra/docker/docker-compose.dev.yml
@@ -1,0 +1,25 @@
+# readum 개발 서버(EC2)에 상주하는 컨테이너 — 로컬 개발 환경용이 아니다.
+# 원본은 repo 의 infra/docker/ 이고, 서버에서 다음으로 기동한다:
+#   docker compose --env-file /opt/readum/.env -f docker-compose.dev.yml up -d
+#
+# Redis 는 이번 단계에서는 "서버에 떠 있는 상태"까지만 만든다. 애플리케이션이 Redis 를
+# 사용하는 코드(rate limiter·circuit breaker 상태 공유 등)는 #88 에서 별도 진행.
+services:
+  redis:
+    image: redis:7.4-alpine
+    container_name: readum-redis
+    restart: unless-stopped
+    # 호스트 밖에서는 접근 불가 — 루프백에만 바인딩.
+    ports:
+      - "127.0.0.1:6379:6379"
+    # maxmemory 64mb: t3 급 서버 메모리 예산에 맞춘 상한.
+    # noeviction: 한도 초과 시 쓰기를 에러로 거부한다. rate limiter 상태를 조용히 버리는 것(eviction)보다
+    # 시끄럽게 실패하는 쪽이 안전하다.
+    command:
+      - redis-server
+      - --requirepass
+      - ${REDIS_PASSWORD}
+      - --maxmemory
+      - 64mb
+      - --maxmemory-policy
+      - noeviction

--- a/infra/docker/docker-compose.local.yml
+++ b/infra/docker/docker-compose.local.yml
@@ -1,0 +1,36 @@
+# 로컬 개발 환경용 컨테이너 (MySQL + Redis) — 개발 서버용은 docker-compose.dev.yml.
+# repo 루트에서 기동:
+#   docker compose -f infra/docker/docker-compose.local.yml up -d
+#
+# 접속값 기본치는 .env.example 과 맞춰져 있어 별도 설정 없이 앱(dev 프로파일, MYSQL_HOST=localhost)이 붙는다.
+# 값을 바꾸려면 환경변수로 덮어쓴다 (예: MYSQL_PASSWORD=... docker compose ...).
+services:
+  mysql:
+    # 개발 서버(RDS → 이관 후 컨테이너)와 동일한 8.4 로 고정해 로컬-서버 동작 차이를 줄인다.
+    image: mysql:8.4
+    container_name: readum-local-mysql
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:3306:3306"
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-readum}
+      MYSQL_USER: ${MYSQL_USER:-readum}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-your_password}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root_password}
+      TZ: Asia/Seoul
+    volumes:
+      - readum-local-mysql-data:/var/lib/mysql
+
+  redis:
+    image: redis:7.4-alpine
+    container_name: readum-local-redis
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:6379:6379"
+    command:
+      - redis-server
+      - --requirepass
+      - ${REDIS_PASSWORD:-local-redis-password}
+
+volumes:
+  readum-local-mysql-data:

--- a/infra/nginx/app.conf
+++ b/infra/nginx/app.conf
@@ -1,0 +1,81 @@
+# readum 백엔드 nginx 설정. 원본은 repo 의 infra/nginx/app.conf 이고,
+# 서버의 /etc/nginx/sites-available/app.conf 로 복사해 적용한다 (절차는 docs/ops/deployment.md).
+#
+# 트래픽 전환(blue/green)은 이 파일이 아니라 /etc/nginx/conf.d/readum-upstream.conf 가 담당한다.
+# 그 파일은 "지금 어느 포트가 활성인가"라는 서버의 런타임 상태라서 repo 로 관리하지 않고
+# 배포 스크립트(deploy.sh)가 생성·갱신한다. 내용은 한 줄이다:
+#   upstream readum_backend { server 127.0.0.1:8081; }
+
+# 1) HTTP → HTTPS 리다이렉트
+server {
+    listen 80;
+    listen [::]:80;
+    server_name readum.kr api.readum.kr;
+
+    # Let's Encrypt 갱신(ACME http-01)은 리다이렉트 예외
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# 2) HTTPS → 백엔드(upstream readum_backend) 프록시
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name readum.kr api.readum.kr;
+
+    ssl_certificate     /etc/letsencrypt/live/readum.kr/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/readum.kr/privkey.pem;
+
+    ssl_session_timeout 1d;
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_tickets off;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+
+    client_max_body_size 20m;
+
+    # 내부 운영 경로는 외부에 열지 않는다 (Actuator 지표·Swagger 문서).
+    # 서버 내부에서는 nginx 를 거치지 않고 127.0.0.1:808x 로 직접 접근하므로 영향 없다
+    # (배포 스크립트의 readiness 확인, 내부 지표 수집 모두 해당).
+    location ^~ /actuator/ {
+        return 404;
+    }
+    location ^~ /swagger-ui {
+        return 404;
+    }
+    location ^~ /v3/api-docs {
+        return 404;
+    }
+
+    location / {
+        proxy_pass http://readum_backend;
+
+        proxy_http_version 1.1;
+
+        # 백엔드(Spring Boot)가 원래 요청 정보를 알 수 있도록 전달.
+        # X-Forwarded-For 는 들어온 체인에 덧붙여($proxy_add_x_forwarded_for) 실제 사용자 IP 를 보존한다
+        # — 프론트 서버 프록시를 거쳐 오는 요청에서 체인을 덮어쓰면 프록시 IP 만 남는다 (429 사고 #103 계열 교훈).
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $host;
+        proxy_set_header X-Forwarded-Port  $server_port;
+
+        # WebSocket / SSE 사용 시 필요
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        $connection_upgrade;
+
+        # read timeout 은 "총 시간"이 아니라 "다음 데이터 조각까지의 대기"라서,
+        # 토큰이 계속 흘러나오는 SSE 스트림은 60초를 넘겨도 끊기지 않는다.
+        proxy_connect_timeout 60s;
+        proxy_send_timeout    60s;
+        proxy_read_timeout    60s;
+
+        proxy_redirect off;
+    }
+}

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# readum blue/green 배포 스크립트. 원본은 repo 의 infra/scripts/deploy.sh 이고,
+# 서버의 /opt/readum/bin/deploy.sh 로 동기화해 사용한다 (전체 구조는 docs/ops/deployment.md).
+#
+# 사용법:
+#   deploy.sh deploy <jar 경로>   # 비활성 색에 jar 를 올리고 기동 → readiness 통과 → 트래픽 전환 → 구 프로세스 종료
+#   deploy.sh rollback            # 반대 색(직전 버전 jar 보유)을 재기동해 트래픽을 되돌림
+#   deploy.sh status              # 활성 색·양쪽 유닛 상태·readiness 를 출력
+#
+# 설계 원칙:
+# - "지금 어느 색이 활성인가"의 유일한 판단 근거는 nginx upstream 파일이다.
+#   별도 상태 파일을 두면 nginx 실제 라우팅과 어긋나는 두 번째 기록이 생긴다.
+# - readiness 통과 전에는 트래픽에 손대지 않는다. 신 프로세스 기동 실패 시 기존 서비스는 무영향.
+# - 구 프로세스 종료는 systemctl stop → 앱의 graceful shutdown(진행 중 요청 60초 대기)에 맡긴다.
+set -euo pipefail
+
+BASE_DIR="/opt/readum"
+RELEASES_DIR="$BASE_DIR/releases"
+UPSTREAM_CONF="/etc/nginx/conf.d/readum-upstream.conf"
+BLUE_PORT=8081
+GREEN_PORT=8082
+READINESS_TIMEOUT_SECONDS=90
+RELEASE_KEEP_COUNT=5
+
+log() { echo "==> $*"; }
+fail() { echo "!! $*" >&2; exit 1; }
+
+port_of() {
+  case "$1" in
+    blue) echo "$BLUE_PORT" ;;
+    green) echo "$GREEN_PORT" ;;
+    *) fail "알 수 없는 색: $1" ;;
+  esac
+}
+
+other_of() {
+  case "$1" in
+    blue) echo "green" ;;
+    green) echo "blue" ;;
+  esac
+}
+
+# upstream 파일에서 활성 포트를 읽어 색을 판정한다. 파일이 없으면(최초 전환 전) 빈 문자열.
+active_color() {
+  [[ -f "$UPSTREAM_CONF" ]] || { echo ""; return; }
+  local port
+  port="$(grep -oE '127\.0\.0\.1:[0-9]+' "$UPSTREAM_CONF" | cut -d: -f2 || true)"
+  case "$port" in
+    "$BLUE_PORT") echo "blue" ;;
+    "$GREEN_PORT") echo "green" ;;
+    *) fail "upstream 파일($UPSTREAM_CONF)에서 활성 포트를 판정할 수 없음: '$port'" ;;
+  esac
+}
+
+wait_readiness() {
+  local port="$1"
+  log "readiness 대기 (127.0.0.1:$port, 최대 ${READINESS_TIMEOUT_SECONDS}초)"
+  for ((i = 1; i <= READINESS_TIMEOUT_SECONDS; i++)); do
+    if curl -fsS "http://127.0.0.1:${port}/actuator/health/readiness" >/dev/null 2>&1; then
+      log "readiness 통과 (${i}초)"
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+switch_traffic_to() {
+  local port="$1"
+  log "nginx upstream 을 127.0.0.1:$port 로 전환"
+  printf 'upstream readum_backend { server 127.0.0.1:%s; }\n' "$port" \
+    | sudo /usr/bin/tee "$UPSTREAM_CONF" >/dev/null
+  sudo /usr/sbin/nginx -t
+  sudo /usr/bin/systemctl reload nginx
+}
+
+# 대상 색에 기동 → readiness → 전환 → 반대 색 종료. deploy 와 rollback 이 공유하는 본체.
+activate() {
+  local target="$1"
+  local target_port old
+  target_port="$(port_of "$target")"
+  old="$(other_of "$target")"
+
+  [[ -f "$BASE_DIR/$target/app.jar" ]] || fail "$BASE_DIR/$target/app.jar 이 없음"
+
+  # 이전 배포 잔재가 떠 있으면 내리고 새로 기동한다.
+  sudo /usr/bin/systemctl stop "readum-$target" 2>/dev/null || true
+  log "readum-$target 기동"
+  sudo /usr/bin/systemctl start "readum-$target"
+
+  if ! wait_readiness "$target_port"; then
+    sudo /usr/bin/systemctl stop "readum-$target" || true
+    fail "readum-$target 이 ${READINESS_TIMEOUT_SECONDS}초 안에 readiness 를 통과하지 못함. 트래픽은 기존 프로세스에 그대로 남아 있음. 로그: journalctl -u readum-$target"
+  fi
+
+  switch_traffic_to "$target_port"
+
+  # 재부팅 시 활성 색만 자동 기동되도록 enable 을 활성 색으로 맞춘다.
+  sudo /usr/bin/systemctl enable "readum-$target" >/dev/null 2>&1 || true
+  sudo /usr/bin/systemctl disable "readum-$old" >/dev/null 2>&1 || true
+
+  # 구 프로세스는 graceful 종료 (앱이 진행 중 요청을 최대 60초 마무리, systemd 는 75초 대기 후 강제 종료).
+  if systemctl is-active --quiet "readum-$old"; then
+    log "readum-$old graceful 종료"
+    sudo /usr/bin/systemctl stop "readum-$old"
+  fi
+
+  log "완료: $target($target_port) 활성"
+}
+
+cmd_deploy() {
+  local jar="${1:-}"
+  [[ -n "$jar" && -f "$jar" ]] || fail "사용법: deploy.sh deploy <jar 경로>"
+
+  local active target
+  active="$(active_color)"
+  # 최초 전환(cutover) 전에는 upstream 파일이 없다 → blue 부터 시작.
+  target="$([[ -n "$active" ]] && other_of "$active" || echo "blue")"
+  log "활성: ${active:-없음} → 배포 대상: $target"
+
+  cp "$jar" "$BASE_DIR/$target/app.jar"
+  activate "$target"
+
+  # 오래된 릴리스 정리 (최근 N개 유지).
+  ls -1t "$RELEASES_DIR"/*.jar 2>/dev/null | tail -n +$((RELEASE_KEEP_COUNT + 1)) | xargs -r rm -f
+}
+
+cmd_rollback() {
+  local active target
+  active="$(active_color)"
+  [[ -n "$active" ]] || fail "upstream 파일이 없어 활성 색을 알 수 없음. rollback 불가."
+  target="$(other_of "$active")"
+  log "rollback: $active → $target (직전 버전 jar 로 재기동)"
+  activate "$target"
+}
+
+cmd_status() {
+  local active
+  active="$(active_color)"
+  echo "활성 색: ${active:-없음 (upstream 파일 없음)}"
+  for color in blue green; do
+    local state port
+    state="$(systemctl is-active "readum-$color" 2>/dev/null || true)"
+    port="$(port_of "$color")"
+    local ready="-"
+    if curl -fsS "http://127.0.0.1:${port}/actuator/health/readiness" >/dev/null 2>&1; then
+      ready="UP"
+    fi
+    echo "readum-$color (:$port) — unit=$state, readiness=$ready"
+  done
+}
+
+case "${1:-}" in
+  deploy) shift; cmd_deploy "$@" ;;
+  rollback) cmd_rollback ;;
+  status) cmd_status ;;
+  *) fail "사용법: deploy.sh {deploy <jar 경로>|rollback|status}" ;;
+esac

--- a/infra/scripts/setup.sh
+++ b/infra/scripts/setup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# readum 서버 1회성 준비 스크립트 (멱등 — 여러 번 실행해도 안전).
+# 새 서버 세팅이나 기존 서버의 blue/green 전환 준비에 사용한다. sudo 로 실행:
+#   sudo ./setup.sh <repo 의 infra 디렉토리 경로>
+#
+# 이 스크립트가 하는 일: 디렉토리 구조 / systemd 유닛 / sudoers 설치.
+# 하지 않는 일(운영 트래픽에 영향을 주는 것들 — docs/ops/deployment.md 의 절차로 수동 수행):
+#   - nginx 설정 교체와 reload (전환 시점을 사람이 정해야 함)
+#   - Docker·Redis 설치와 기동
+#   - 스왑 증설
+set -euo pipefail
+
+INFRA_DIR="${1:-}"
+[[ -n "$INFRA_DIR" && -d "$INFRA_DIR/systemd" ]] || {
+  echo "사용법: sudo ./setup.sh <repo 의 infra 디렉토리 경로>" >&2
+  exit 1
+}
+[[ "$(id -u)" -eq 0 ]] || { echo "sudo 로 실행해야 한다" >&2; exit 1; }
+
+echo "==> /opt/readum 디렉토리 구조"
+mkdir -p /opt/readum/{blue,green,releases,bin}
+chown -R ubuntu:ubuntu /opt/readum
+
+echo "==> systemd 유닛 설치"
+cp "$INFRA_DIR"/systemd/readum-blue.service /etc/systemd/system/
+cp "$INFRA_DIR"/systemd/readum-green.service /etc/systemd/system/
+systemctl daemon-reload
+
+echo "==> 배포 스크립트 설치"
+install -m 0755 -o ubuntu -g ubuntu "$INFRA_DIR"/scripts/deploy.sh /opt/readum/bin/deploy.sh
+
+echo "==> sudoers 설치 (ubuntu 가 배포에 필요한 명령만 비밀번호 없이 실행)"
+visudo -cf "$INFRA_DIR"/sudoers/readum-deploy
+install -m 0440 -o root -g root "$INFRA_DIR"/sudoers/readum-deploy /etc/sudoers.d/readum-deploy
+
+echo "==> 완료. 다음 단계(.env 배치, nginx 전환, Docker/Redis)는 docs/ops/deployment.md 의 절차를 따른다."

--- a/infra/sudoers/readum-deploy
+++ b/infra/sudoers/readum-deploy
@@ -1,0 +1,15 @@
+# readum 배포 스크립트(deploy.sh)가 필요로 하는 최소 sudo 권한.
+# 설치: sudo visudo -cf 로 검증 후 /etc/sudoers.d/readum-deploy (0440) — setup.sh 가 수행.
+# 명령·인자를 그대로 나열해 이 목록 밖의 조합은 sudo 가 거부한다.
+
+ubuntu ALL=(root) NOPASSWD: /usr/bin/systemctl start readum-blue, \
+  /usr/bin/systemctl stop readum-blue, \
+  /usr/bin/systemctl enable readum-blue, \
+  /usr/bin/systemctl disable readum-blue, \
+  /usr/bin/systemctl start readum-green, \
+  /usr/bin/systemctl stop readum-green, \
+  /usr/bin/systemctl enable readum-green, \
+  /usr/bin/systemctl disable readum-green, \
+  /usr/bin/systemctl reload nginx, \
+  /usr/sbin/nginx -t, \
+  /usr/bin/tee /etc/nginx/conf.d/readum-upstream.conf

--- a/infra/systemd/readum-blue.service
+++ b/infra/systemd/readum-blue.service
@@ -1,0 +1,30 @@
+# readum 백엔드 blue 인스턴스 (포트 8081). 원본은 repo 의 infra/systemd/.
+# 설치: sudo cp → /etc/systemd/system/ 후 daemon-reload (절차는 docs/ops/deployment.md)
+#
+# blue/green 두 유닛은 포트와 jar 경로만 다르다. 평상시에는 한쪽만 떠 있고,
+# 배포 순간에만 잠깐 둘 다 상주한다 (t3 급 메모리 제약 때문에 상시 2개는 두지 않는다).
+
+[Unit]
+Description=readum backend (blue, :8081)
+After=network.target
+
+[Service]
+User=ubuntu
+WorkingDirectory=/opt/readum/blue
+# 힙을 명시해 배포 전환 구간(JVM 2개 동시 상주)의 메모리 사용을 예측 가능하게 고정한다.
+ExecStart=/usr/bin/java -Xmx256m -jar /opt/readum/blue/app.jar
+EnvironmentFile=/opt/readum/.env
+Environment=SERVER_PORT=8081
+
+# 크래시(OOM 등)로 죽으면 자동 재기동. systemctl stop 에 의한 의도적 종료는 재기동하지 않는다.
+Restart=on-failure
+RestartSec=5
+
+# stop 시 SIGTERM → 앱의 graceful shutdown(진행 중 요청 60초 대기)이 끝나기를 기다린 뒤,
+# 그래도 살아 있으면 SIGKILL. 앱의 60초보다 여유 있게 잡아 SIGKILL 이 graceful 을 앞지르지 않게 한다.
+TimeoutStopSec=75
+# SIGTERM 종료 시 JVM 의 관례적 종료 코드(143)를 정상 종료로 취급한다.
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/systemd/readum-green.service
+++ b/infra/systemd/readum-green.service
@@ -1,0 +1,21 @@
+# readum 백엔드 green 인스턴스 (포트 8082). 설명·설치 절차는 readum-blue.service 와 동일.
+
+[Unit]
+Description=readum backend (green, :8082)
+After=network.target
+
+[Service]
+User=ubuntu
+WorkingDirectory=/opt/readum/green
+ExecStart=/usr/bin/java -Xmx256m -jar /opt/readum/green/app.jar
+EnvironmentFile=/opt/readum/.env
+Environment=SERVER_PORT=8082
+
+Restart=on-failure
+RestartSec=5
+
+TimeoutStopSec=75
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,9 +20,17 @@ spring:
     scheduling:
       pool:
         size: 3
+  # graceful shutdown 시 진행 중 HTTP 요청을 기다려 주는 시간 (#108).
+  # AI 채팅 SSE 스트림이 가장 긴 요청이라 기본값 30초 대신 60초.
+  # 배포 시 nginx 가 새 요청을 먼저 새 프로세스로 돌린 뒤 종료하므로, 이 대기는 배포 소요 시간만 늘릴 뿐 사용자 영향이 없다.
+  lifecycle:
+    timeout-per-shutdown-phase: 60s
 
 server:
   forward-headers-strategy: framework
+  # SIGTERM 을 받으면 새 요청은 즉시 거부하고 진행 중 요청만 위 대기 시간 안에서 마무리한다 (#108).
+  # Spring Boot 3.4+ 기본값이지만, 배포 절차(구 프로세스 종료 단계)가 이 동작에 의존하므로 명시해 둔다.
+  shutdown: graceful
 
 auth:
   access-token-ttl: PT30M


### PR DESCRIPTION
## 작업 사항

지금 배포는 프로세스를 죽인 뒤 서버에서 빌드해 다시 띄우는 방식이라, 빌드 시간 내내 서비스가 중단되고 진행 중이던 요청도 잘린다. 이 PR 은 단일 서버에서 같은 앱을 blue(:8081)/green(:8082) 두 systemd 유닛으로 번갈아 띄우고 nginx upstream 파일 하나를 갈아끼워 트래픽을 전환하는 구조로 바꾼다. 완전 무중단이 아니라 다운타임을 nginx reload 수준으로 줄이는 절충안이다.

트래픽 전환 스위치는 `/etc/nginx/conf.d/readum-upstream.conf` 한 파일로 분리했다. 이 파일은 "지금 어느 색이 활성인가"라는 서버의 런타임 상태라서 repo 로 관리하지 않고 배포 스크립트가 생성·갱신하며, 활성 색 판정도 이 파일에서 직접 읽는다 — 별도 상태 파일을 두면 nginx 실제 라우팅과 어긋나는 두 번째 기록이 생기기 때문이다. server 블록 등 정적 설정은 repo 의 `infra/` 가 원본이다.

프로세스 관리는 nohup + pid 파일에서 systemd 유닛으로 바꿨다. 크래시(OOM 등) 시 자동 재기동되고, pid 파일 생사 판정 코드가 사라지며, `.env` 로딩·graceful 종료 대기(TimeoutStopSec=75)를 systemd 가 맡는다. 앱 쪽은 `server.shutdown=graceful` 명시 + 종료 대기 60초 설정이 전부다(#123 흡수) — 백그라운드 작업(제목 스케줄러 daemon+dispose, 감상문 워커 풀 인터럽트 후 Reaper 회수)은 이미 JVM 종료를 막지 않음을 확인했고 코드 변경이 없다.

nginx 설정을 repo 로 이관하면서 세 가지를 함께 고쳤다: ① `/actuator/`·`/swagger-ui`·`/v3/api-docs` 외부 차단 (prometheus 지표가 인터넷에 열려 있었다) ② 80 포트 블록의 `example.com` 잔재를 실제 도메인으로 정정 ③ `X-Forwarded-For` 를 덮어쓰기에서 체인 덧붙이기로 바꿔 프론트 서버 프록시 뒤의 실제 사용자 IP 를 보존.

Redis 는 컨테이너가 서버에 상주하는 상태까지만 만든다(루프백 바인딩 + 비밀번호 + maxmemory 64mb). 앱이 Redis 를 쓰는 코드(rate limiter·circuit breaker 상태 공유)는 #88 에서 별도 진행한다. GitHub Actions 빌드·배포(CI/CD)와 RDS → Docker MySQL 이관도 후속 PR 로 분리했다.

### 기능

**배포**
- 배포 중에도 서비스가 계속 응답한다 (전환은 nginx reload, 진행 중 요청·SSE 는 구 프로세스가 60초 안에서 마무리)
- `deploy.sh rollback` 한 번으로 직전 버전으로 되돌릴 수 있다
- 앱이 크래시로 죽으면 systemd 가 자동 재기동한다
- 05:50~06:10(감상문 적재 스캔 시간대)은 배포를 피한다 — 스크립트가 강제하지 않으며 배포 수칙으로 문서화 (docs/ops/deployment.md)

**보안**
- `/actuator/*`(prometheus 포함)·Swagger 문서가 더 이상 인터넷에서 접근되지 않는다
- 앱 로그·rate limit 에서 실제 클라이언트 IP 를 볼 수 있다 (X-Forwarded-For 체인 보존)
- 배포용 sudo 권한을 필요한 명령 목록으로 한정했다 (`/etc/sudoers.d/readum-deploy`)

**로컬 개발**
- `infra/docker/docker-compose.local.yml` 로 로컬 MySQL 8.4·Redis 를 바로 띄울 수 있다 (기본값이 `.env.example` 과 일치)

## 테스트 결과
- [x] `./gradlew test` 전체 통과
- [x] `bash -n` (deploy.sh·setup.sh), `visudo -cf`(sudoers), `docker compose config`(compose 2종) 문법 검증 통과
- [ ] 로컬 수동 검증: SSE 열어둔 채 SIGTERM → 진행 중 스트림 유지·새 요청 거부·60초 내 종료 확인
- [ ] cutover 후 검증 체크리스트 수행 (docs/ops/deployment.md 하단 — 재배포 사이클·curl 무실패·actuator 404·스왑 피크)

## 관련 이슈
- closes #108

## 참고 사항
- 머지해도 서버 동작은 변하지 않는다. 실제 반영은 `docs/ops/deployment.md` 의 cutover 절차(탄력적 IP 확인 → 인스턴스 증설 → setup.sh → 전환) 실행 시점이다.
- 환경변수 원본은 GitHub Actions Secrets 로 이동 예정(CI/CD PR 에서 도입 — CI 가 배포 때마다 서버 `.env` 를 재작성). cutover 때 Secrets 등록 + `REDIS_PASSWORD` 추가, `SERVER_PORT`/`APP_PORT` 제거가 필요하다.
- 후속: ① GitHub Actions 빌드·배포 PR (신규 이슈) ② RDS → Docker MySQL 이관 PR (신규 이슈) ③ #88 Redis 연동.