### PR TITLE
feat(infra): 개발 서버 DB 를 RDS 에서 Docker MySQL 로 이관

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,13 +5,14 @@
 # 로컬 컨테이너(MySQL·Redis)는 infra/docker/docker-compose.local.yml 로 띄운다.
 # 주의: SERVER_PORT 를 넣지 말 것 — systemd 유닛의 blue/green 포트 지정을 덮어쓴다.
 
-# MySQL (AWS RDS for dev; leave MYSQL_HOST unset to default to localhost)
-MYSQL_HOST=
-# MYSQL_HOST=your-dev-rds-endpoint.region.rds.amazonaws.com
+# MySQL (개발 서버 = 같은 호스트의 Docker 컨테이너, 로컬 = docker-compose.local.yml)
+MYSQL_HOST=127.0.0.1
 MYSQL_PORT=3306
 MYSQL_DATABASE=readum
 MYSQL_USER=readum
 MYSQL_PASSWORD=your_password
+# 컨테이너 초기화·백업 스크립트(backup-mysql.sh)용 root 비밀번호
+MYSQL_ROOT_PASSWORD=your_root_password
 
 # JWT (Base64-encoded 256bit+ secret, e.g. `openssl rand -base64 48`)
 JWT_SECRET=jsaTiXce4yBit2Qg8JOS8U7qH2kNg8d7+MJTieGkFg67vmSldN/fggYfK2dXR4X+

--- a/infra/docker/docker-compose.dev.yml
+++ b/infra/docker/docker-compose.dev.yml
@@ -4,7 +4,27 @@
 #
 # Redis 는 이번 단계에서는 "서버에 떠 있는 상태"까지만 만든다. 애플리케이션이 Redis 를
 # 사용하는 코드(rate limiter·circuit breaker 상태 공유 등)는 #88 에서 별도 진행.
+# MySQL 은 RDS 에서 이관한 것 (이관 배경·절차는 해당 PR 본문 참조).
 services:
+  mysql:
+    # RDS(MySQL 8.4)와 동일 버전으로 고정해 이관 전후 동작 차이를 없앤다.
+    image: mysql:8.4
+    container_name: readum-mysql
+    restart: unless-stopped
+    # 호스트 밖에서는 접근 불가 — 외부 접속(DataGrip 등)은 SSH 터널로.
+    ports:
+      - "127.0.0.1:3306:3306"
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      TZ: Asia/Seoul
+    volumes:
+      # 데이터는 EBS 상의 고정 경로에 — 컨테이너 재생성/업그레이드에도 유지된다.
+      - /opt/readum/mysql-data:/var/lib/mysql
+      - /opt/readum/mysql/my.cnf:/etc/mysql/conf.d/readum.cnf:ro
+
   redis:
     image: redis:7.4-alpine
     container_name: readum-redis

--- a/infra/mysql/my.cnf
+++ b/infra/mysql/my.cnf
@@ -1,0 +1,22 @@
+# readum 개발 서버 MySQL 컨테이너 설정. 원본은 repo 의 infra/mysql/my.cnf 이고,
+# 서버의 /opt/readum/mysql/my.cnf 로 복사해 컨테이너에 마운트한다 (docker-compose.dev.yml).
+#
+# 관측 설정은 RDS 파라미터 그룹(readum-dev-pg)에서 켜뒀던 것을 이식한 기본값이다.
+# 이관 시 RDS 에서 SHOW VARIABLES 로 실측값을 확인해 다르면 여기를 맞춘다.
+# RDS 전용이던 require_secure_transport 는 가져오지 않는다 — 컨테이너가 127.0.0.1 에만
+# 바인딩되어 외부 접속이 원천 차단되므로 루프백 구간 TLS 는 비용만 있고 얻는 것이 없다.
+
+[mysqld]
+# ---- 관측 (RDS 파라미터 그룹 이식) ----
+slow_query_log = ON
+log_output = TABLE
+long_query_time = 1
+performance_schema = ON
+
+# ---- 문자셋 ----
+character-set-server = utf8mb4
+collation-server = utf8mb4_0900_ai_ci
+
+# ---- 메모리 (t3.small 2GB 기준) ----
+# 기본값 128M 보다 여유를 주되, 앱 JVM 2개(배포 전환 구간)·Redis 와 공존할 수 있는 수준으로 제한.
+innodb_buffer_pool_size = 256M

--- a/infra/scripts/backup-mysql.sh
+++ b/infra/scripts/backup-mysql.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# MySQL 일일 백업 스크립트. 원본은 repo 의 infra/scripts/ 이고, 서버에서 cron 으로 실행한다:
+#   30 4 * * * /opt/readum/bin/backup-mysql.sh >> /opt/readum/mysql-backup/backup.log 2>&1
+# (04:30 — 트래픽 최저 시간대이면서 06:00 감상문 적재 배치와 겹치지 않게)
+#
+# 보관 정책: 로컬 7일. 서버가 통째로 사라지면 백업도 같이 사라지는 한계는
+# 데이터 중요도가 낮은 현 단계에서 수용하기로 한 절충이다 — 운영 프로세스를
+# 분리하는 시점에 외부 보관(S3 등)을 재검토한다.
+set -euo pipefail
+
+ENV_FILE="/opt/readum/.env"
+BACKUP_DIR="/opt/readum/mysql-backup"
+KEEP_DAYS=7
+
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+mkdir -p "$BACKUP_DIR"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+
+# --single-transaction: 백업 중에도 서비스 쿼리를 막지 않는다 (InnoDB 스냅샷 읽기).
+docker exec readum-mysql mysqldump \
+  --single-transaction --routines --triggers \
+  -u root -p"$MYSQL_ROOT_PASSWORD" "$MYSQL_DATABASE" \
+  | gzip > "$BACKUP_DIR/readum-$STAMP.sql.gz"
+
+find "$BACKUP_DIR" -name 'readum-*.sql.gz' -mtime +"$KEEP_DAYS" -delete
+
+echo "$(date '+%F %T') 백업 완료: readum-$STAMP.sql.gz ($(du -h "$BACKUP_DIR/readum-$STAMP.sql.gz" | cut -f1))"

--- a/infra/scripts/setup.sh
+++ b/infra/scripts/setup.sh
@@ -26,8 +26,14 @@ cp "$INFRA_DIR"/systemd/readum-blue.service /etc/systemd/system/
 cp "$INFRA_DIR"/systemd/readum-green.service /etc/systemd/system/
 systemctl daemon-reload
 
-echo "==> 배포 스크립트 설치"
+echo "==> 배포·백업 스크립트 설치"
 install -m 0755 -o ubuntu -g ubuntu "$INFRA_DIR"/scripts/deploy.sh /opt/readum/bin/deploy.sh
+install -m 0755 -o ubuntu -g ubuntu "$INFRA_DIR"/scripts/backup-mysql.sh /opt/readum/bin/backup-mysql.sh
+
+echo "==> MySQL 설정 배치"
+mkdir -p /opt/readum/mysql /opt/readum/mysql-data /opt/readum/mysql-backup
+install -m 0644 -o ubuntu -g ubuntu "$INFRA_DIR"/mysql/my.cnf /opt/readum/mysql/my.cnf
+chown ubuntu:ubuntu /opt/readum/mysql /opt/readum/mysql-backup
 
 echo "==> sudoers 설치 (ubuntu 가 배포에 필요한 명령만 비밀번호 없이 실행)"
 visudo -cf "$INFRA_DIR"/sudoers/readum-deploy

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -11,7 +11,9 @@ spring:
         options:
           model: omni-moderation-latest
   datasource:
-    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT:3306}/${MYSQL_DATABASE}?sslMode=REQUIRED&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    # sslMode 미지정 = PREFERRED (서버가 지원하면 TLS). RDS 시절의 REQUIRED 는 컨테이너 이관으로 제거 —
+    # MySQL 이 127.0.0.1 에만 바인딩되어 루프백 구간 강제 TLS 는 실익이 없다.
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT:3306}/${MYSQL_DATABASE}?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: ${MYSQL_USER}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## 작업 사항

개발 서버 DB 를 AWS RDS(db.t4g.micro)에서 같은 EC2 의 Docker MySQL 컨테이너로 옮긴다. RDS 비용을 인스턴스 증설(t3.small)로 돌리는 결정의 나머지 반쪽이다. 이 PR 은 이관에 필요한 파일 전부(컨테이너 정의·MySQL 설정·백업 스크립트)를 담고, 실제 이관은 머지 후 아래 절차로 실행한다 — **머지 시점에는 서버 동작이 변하지 않는다.**

**데이터는 옮기지 않고 빈 DB 로 시작한다** (런칭 초기 데이터의 중요도가 낮다는 팀 판단 — 실행 전 공지 필요). 스키마도 덤프하지 않는다: 이 프로젝트는 인덱스·unique 제약까지 엔티티의 `@Table` 정의가 정본이라, 첫 기동 1회만 `ddl-auto=create` 로 엔티티에서 직접 생성하고 `validate` 로 복귀한다. RDS 는 최종 스냅샷을 남기고 정지 → 2주 후 삭제한다.

RDS 파라미터 그룹에서 켜뒀던 관측 설정(slow_query_log, `log_output=TABLE`, performance_schema)은 `infra/mysql/my.cnf` 로 이식했다 — 기본값으로 작성했고 이관 때 `SHOW VARIABLES` 실측과 대조한다. `require_secure_transport` 는 가져오지 않는다: 컨테이너가 127.0.0.1 에만 바인딩되어 외부 접속이 원천 차단되므로 루프백 구간 강제 TLS 는 실익이 없고, 이에 맞춰 JDBC URL 의 `sslMode=REQUIRED` 도 제거했다 (미지정 시 PREFERRED 라 이관 전 RDS 접속도 TLS 유지 — 배포 순서와 무관하게 안전).

RDS 가 해주던 자동 백업은 mysqldump 일일 백업(04:30, `--single-transaction` 으로 무중단, 로컬 7일 보관)으로 대체한다. 서버 소실 시 백업도 잃는 한계와 최대 24시간 유실은 현 단계에서 수용하고, 운영 프로세스 분리 시점에 외부 보관(S3)을 재검토한다.

### 기능

**DB 운영**
- MySQL 8.4 컨테이너 (RDS 와 동일 버전, 데이터는 EBS 고정 경로 `/opt/readum/mysql-data`) — RDS 요금 소멸
- slow query 로그를 이관 후에도 동일하게 조회할 수 있다 (`mysql.slow_log` 테이블)
- 일일 자동 백업 + 7일 보관 (`backup-mysql.sh`)

**개발 편의**
- DataGrip 접속은 SSH 터널 경유 `127.0.0.1:3306` 으로 전환
- 파라미터 변경이 콘솔 클릭 대신 repo 의 my.cnf 수정으로 이력에 남는다

### 이관 절차 (머지 후 실행 — 1회성이라 repo 문서 대신 여기에 기록)

**준비 (서비스 무영향):**
1. `sudo ./infra/scripts/setup.sh <repo>/infra` 재실행 — mysql 디렉토리·my.cnf·backup-mysql.sh 배치
2. `ENV_FILE` Secret(+비밀 저장소 사본)에 `MYSQL_ROOT_PASSWORD=<생성>` 추가
3. RDS 실측 대조: `SHOW VARIABLES WHERE Variable_name IN ('slow_query_log','log_output','long_query_time','performance_schema')` — my.cnf 와 다르면 수정 커밋
4. 컨테이너 기동: `docker compose --env-file /opt/readum/.env -f <repo>/infra/docker/docker-compose.dev.yml up -d mysql`

**전환:**
5. `ENV_FILE` Secret 수정: `MYSQL_HOST=127.0.0.1` + `SPRING_JPA_HIBERNATE_DDL_AUTO=create` 임시 추가 → 재배포 (첫 기동이 엔티티 정의대로 스키마 생성. 이 순간부터 데이터가 빈 상태로 보임 — 사전 공지 필수)
6. `SPRING_JPA_HIBERNATE_DDL_AUTO` 줄 **즉시 제거** → 재배포 (validate 복귀. 남겨두면 이후 배포마다 테이블이 재생성된다)
7. 확인: 회원가입·채팅 등 쓰기 동작, `SELECT * FROM mysql.slow_log LIMIT 1` 조회

**마무리:**
8. 백업 cron 등록: `30 4 * * * /opt/readum/bin/backup-mysql.sh >> /opt/readum/mysql-backup/backup.log 2>&1` + 익일 파일 확인
9. RDS 최종 스냅샷 → 정지 (삭제 아님 — 되돌릴 보험)
10. 2주 안정 후 RDS 삭제 (스냅샷 보존), `docs/ops/infrastructure.md` 구성도 갱신

## 테스트 결과
- [x] `./gradlew test` 전체 통과 (테스트는 H2 라 JDBC URL 변경 무영향)
- [x] `docker compose config`·`bash -n` 검증 통과
- [ ] 이관 실행 시 7단계 확인 + 익일 백업 파일 생성 확인

## 관련 이슈
- 관련: #107 (Epic — 안정성 개선). 별도 이슈 없이 진행하기로 결정.

## 참고 사항
- base 는 #125 브랜치다 (#124 → #125 → 이 PR 순서로 머지).
- 실행 전제: blue/green 최초 전환 완료 + 인스턴스 증설 (t3.micro 911MB 로는 MySQL 상주 +300MB 와 배포 전환 구간이 공존 불가).
- **실사용자 데이터가 리셋되므로** 이관 실행 일정은 팀·프론트엔드와 공유 후 결정.