### PR TITLE
chore(flyway): Flyway 도입 — 스키마 V1 베이스라인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation 'org.springframework.boot:spring-boot-flyway'
+	implementation 'org.flywaydb:flyway-mysql'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/docs/ops/infrastructure.md
+++ b/docs/ops/infrastructure.md
@@ -81,7 +81,7 @@
 | 관측 설정 | slow_query_log ON · `log_output=TABLE`(`mysql.slow_log`) · performance_schema ON — RDS 파라미터 그룹에서 이식 |
 | 백업 | `backup-mysql.sh` 일일 04:30 cron, `--single-transaction`(무중단), `/opt/readum/mysql-backup/` 로컬 7일 보관. 시점 복구 없음(최대 24시간 유실 감수) — 외부 보관(S3)은 운영 프로세스 분리 시점에 재검토 |
 
-스키마 정본은 JPA 엔티티(`@Table` 의 인덱스·unique 제약 포함)이고 앱은 `ddl-auto: validate` 로 대조만 한다.
+스키마 정본은 Flyway 마이그레이션(`src/main/resources/db/migration/`)이다. 앱 기동 시 Flyway 가 마이그레이션을 적용하고, Hibernate 가 `ddl-auto: validate` 로 엔티티와 대조한다. 엔티티를 바꾸면 반드시 같은 PR 에 마이그레이션 파일(V{n}__...)을 추가한다. 테스트(H2)는 Flyway 를 끄고 `create-drop` 을 유지한다.
 
 ## Redis
 

--- a/src/main/resources/db/migration/V1__baseline_schema.sql
+++ b/src/main/resources/db/migration/V1__baseline_schema.sql
@@ -1,0 +1,117 @@
+-- V1 베이스라인: 2026-07-06 기준 전체 스키마 (엔티티 어노테이션이 원본이었던 스키마를 SQL 로 옮김).
+-- 이후 스키마 변경은 V2, V3 ... 마이그레이션 파일로만 한다.
+
+CREATE TABLE `user` (
+    id                         BIGINT       NOT NULL AUTO_INCREMENT,
+    device_id                  VARCHAR(255) NULL,
+    session_id                 VARCHAR(36)  NOT NULL,
+    nickname                   VARCHAR(10)  NULL,
+    last_selected_user_book_id BIGINT       NULL,
+    onboarding_completed       BIT(1)       NOT NULL,
+    created_at                 DATETIME(6)  NOT NULL,
+    updated_at                 DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_user_device_id UNIQUE (device_id),
+    CONSTRAINT uk_user_session_id UNIQUE (session_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE refresh_token (
+    id               BIGINT       NOT NULL AUTO_INCREMENT,
+    user_id          BIGINT       NOT NULL,
+    jwt_id           VARCHAR(64)  NOT NULL,
+    parent_jwt_id    VARCHAR(64)  NULL,
+    issued_at        TIMESTAMP(6) NOT NULL,
+    expires_at       TIMESTAMP(6) NOT NULL,
+    rotated_at       TIMESTAMP(6) NULL,
+    grace_expires_at TIMESTAMP(6) NULL,
+    revoked_at       TIMESTAMP(6) NULL,
+    created_at       DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_refresh_token_jwt_id UNIQUE (jwt_id),
+    CONSTRAINT uk_refresh_token_parent_jwt_id UNIQUE (parent_jwt_id),
+    INDEX idx_refresh_token_user_revoked (user_id, revoked_at)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE ai_chat_session (
+    id                 BIGINT       NOT NULL AUTO_INCREMENT,
+    user_book_id       BIGINT       NOT NULL,
+    status             VARCHAR(20)  NOT NULL,
+    user_message_count INT          NOT NULL,
+    accumulated_tokens INT          NOT NULL,
+    title              VARCHAR(100) NULL,
+    created_at         DATETIME(6)  NOT NULL,
+    updated_at         DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id),
+    INDEX idx_ai_chat_session_user_book (user_book_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE ai_chat_message (
+    id            BIGINT      NOT NULL AUTO_INCREMENT,
+    session_id    BIGINT      NOT NULL,
+    role          VARCHAR(20) NOT NULL,
+    content       TEXT        NOT NULL,
+    quote_text    TEXT        NULL,
+    input_tokens  INT         NULL,
+    output_tokens INT         NULL,
+    total_tokens  INT         NULL,
+    status        VARCHAR(20) NOT NULL,
+    created_at    DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    INDEX idx_ai_chat_message_session_created_id (session_id, created_at, id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE user_book (
+    id         BIGINT      NOT NULL AUTO_INCREMENT,
+    user_id    BIGINT      NOT NULL,
+    book_id    BIGINT      NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_user_book_user_book UNIQUE (user_id, book_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE book (
+    id             BIGINT        NOT NULL AUTO_INCREMENT,
+    external_id    VARCHAR(255)  NOT NULL,
+    title          VARCHAR(500)  NOT NULL,
+    authors        VARCHAR(500)  NULL,
+    publisher      VARCHAR(255)  NULL,
+    published_year INT           NULL,
+    cover_url      VARCHAR(1000) NULL,
+    created_at     DATETIME(6)   NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_book_external_id UNIQUE (external_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE summary (
+    id                 BIGINT       NOT NULL AUTO_INCREMENT,
+    user_book_id       BIGINT       NOT NULL,
+    ai_chat_session_id BIGINT       NOT NULL,
+    quote              TEXT         NULL,
+    title              VARCHAR(500) NULL,
+    body               TEXT         NULL,
+    created_at         DATETIME(6)  NOT NULL,
+    updated_at         DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_summary_session UNIQUE (ai_chat_session_id),
+    INDEX idx_summary_user_book (user_book_id),
+    INDEX idx_summary_session (ai_chat_session_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE summary_job (
+    id                 BIGINT      NOT NULL AUTO_INCREMENT,
+    ai_chat_session_id BIGINT      NOT NULL,
+    active_session_id  BIGINT      NULL,
+    status             VARCHAR(20) NOT NULL,
+    lock_owner         VARCHAR(36) NULL,
+    locked_until       DATETIME(6) NULL,
+    attempt_count      INT         NOT NULL,
+    next_attempt_at    DATETIME(6) NOT NULL,
+    last_error_code    VARCHAR(50) NULL,
+    last_error_message TEXT        NULL,
+    created_at         DATETIME(6) NOT NULL,
+    updated_at         DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_summary_job_active_session UNIQUE (active_session_id),
+    INDEX idx_summary_job_session (ai_chat_session_id, status),
+    INDEX idx_summary_job_claim (status, next_attempt_at)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,6 +5,8 @@ spring:
       chat:
         options:
           model: gpt-4o-mini
+  flyway:
+    enabled: false   # 테스트는 H2 + ddl-auto create-drop (MySQL 전용 V1 SQL 은 H2 에 적용 불가)
   datasource:
     url: jdbc:h2:mem:readum;MODE=MySQL;DB_CLOSE_DELAY=-1
     username: sa


### PR DESCRIPTION
## 무엇을
- Flyway 도입 — Spring Boot 4 는 Flyway 자동설정이 별도 모듈이라 `spring-boot-flyway` + `flyway-mysql` 둘 다 추가
- 현행 스키마 8개 테이블을 `V1__baseline_schema.sql` 베이스라인으로 작성
- 테스트(H2)는 Flyway 비활성 — 기존 `create-drop` 유지
- `docs/ops/infrastructure.md` 의 스키마 정본 서술 갱신 (엔티티 → Flyway 마이그레이션)

## 왜
후속 작업(사용자 토큰 예산·컨텍스트 압축, #120 연관 시리즈)이 새 테이블·컬럼을 필요로 한다. 지금까지는 스키마를 repo 밖에서 손으로 만들었는데, 마이그레이션 파일로 관리해 "엔티티 변경 = 같은 PR 의 V{n} 파일"이 되게 한다.

## 검증
로컬 MySQL 8.4(빈 DB) 기동으로 확인:
- `Successfully applied 1 migration ... now at version v1`
- 8개 테이블 + `flyway_schema_history`(version 1, success) 생성
- Hibernate `ddl-auto: validate` 통과 후 정상 기동
- 엔티티 8개 ↔ V1 SQL 컬럼/타입/nullable/unique/인덱스 전체 대조 일치
- `./gradlew test` BUILD SUCCESSFUL (테스트는 Flyway 꺼져 무영향)

## 배포 절차 (머지 후 1회, 데이터 삭제 승인됨)
현재 dev DB 는 테이블은 있으나 `flyway_schema_history` 가 없어, Flyway V1 이 그대로 돌면 "이미 존재"로 실패한다. 머지 후 빈 DB 로 재생성한 뒤 배포한다:
```
docker exec -it readum-mysql mysql -uroot -p -e "DROP DATABASE readum; CREATE DATABASE readum CHARACTER SET utf8mb4;"
```
(DB 이름은 `/opt/readum/.env` 의 `MYSQL_DATABASE` 값으로 치환) 이후 `workflow_dispatch` 로 배포하면 Flyway 가 V1 을 적용한다. DB 단위 권한은 이름 기준이라 재생성해도 유지된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 데이터베이스 스키마 관리가 마이그레이션 기반으로 전환되어, 앱 시작 시 스키마가 자동으로 적용되도록 개선했습니다.
  * 전체 기준 스키마가 새로 정리되어 주요 테이블과 제약 조건이 일관되게 반영됩니다.

* **Documentation**
  * 운영 문서를 최신 방식에 맞게 업데이트해, 스키마 기준과 테스트 환경 동작을 명확히 했습니다.

* **Tests**
  * 테스트 환경에서는 마이그레이션을 비활성화하도록 설정해 기존 테스트 동작을 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->