### PR TITLE
test(summary): 적재 테스트 CI 플래키 제거 (next_attempt_at 정밀도)

### DIFF
--- a/src/test/java/com/readum/model/summary/repository/SummaryJobBulkEnqueueTest.java
+++ b/src/test/java/com/readum/model/summary/repository/SummaryJobBulkEnqueueTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -122,7 +123,10 @@ class SummaryJobBulkEnqueueTest {
 
     @Test
     void 적재된_작업은_즉시_처리_가능한_PENDING_상태로_시작한다() {
-        LocalDateTime now = LocalDateTime.now();
+        // next_attempt_at 을 :now 로 그대로 저장하므로, DATETIME(6) 저장 시 나노초가 마이크로초로
+        // 반올림되면 저장값이 캡처한 now 보다 커져 아래 isBeforeOrEqualTo(now) 가 깨진다.
+        // 저장·비교 정밀도를 마이크로초로 맞춰 반올림 자체를 없앤다.
+        LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS);
         Long sessionId = activeSessionWithRecentMessage(MIN_TOKENS, now.minusHours(1));
 
         summaryJobRepository.enqueuePendingForEligibleSessions(MIN_TOKENS, now.minusHours(24), now);


### PR DESCRIPTION
## 무엇을
`SummaryJobBulkEnqueueTest.적재된_작업은_즉시_처리_가능한_PENDING_상태로_시작한다()` 의 `now` 캡처를 마이크로초로 절삭한다.

## 왜
`enqueuePendingForEligibleSessions` 는 `next_attempt_at` 을 넘겨받은 `:now` 로 그대로 저장한다. 그런데 Linux CI 의 `LocalDateTime.now()` 는 나노초 정밀도라, `DATETIME(6)`(마이크로초)로 저장될 때 반올림되면 저장값이 캡처한 `now` 보다 커진다 → `assertThat(...getNextAttemptAt()).isBeforeOrEqualTo(now)` 가 간헐(사실상 CI 에선 상시) 실패한다. 실제로 Flyway 도입 후 dev 배포 빌드가 이 한 건으로 두 번 깨졌다 (Flyway 와 무관한 기존 취약점).

`now` 를 `truncatedTo(MICROS)` 로 맞추면 저장·비교 정밀도가 같아져 반올림 자체가 사라진다. 같은 파일·인접 테스트의 다른 시각 비교(42·57행)는 초/분 단위 여유가 있어 영향 없음.

프로덕션 동작 변경 없음 (테스트 전용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)