### PR TITLE
ci: PR 테스트 게이트 추가 + 잔여 CI 플래키 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+# PR·dev 푸시 검증 파이프라인 — 빌드(전체 테스트 포함)만 하고 배포는 하지 않는다.
+# 목적: 테스트 실패를 "배포 때 처음"이 아니라 "머지 전 PR"에서 잡는다.
+# 배포(deploy.yml)도 배포 자격 판정용으로 빌드를 다시 하지만, 그 전에 여기서 먼저 걸러진다.
+
+name: ci
+
+on:
+  pull_request:
+    branches: [dev]
+  push:
+    branches: [dev]
+
+# 같은 브랜치의 이전 실행은 취소하고 최신 것만 돌린다 (PR 연속 푸시 시 낭비 방지).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: 빌드 + 전체 테스트
+        run: ./gradlew build

--- a/src/test/java/com/readum/domain/aiChat/service/AiChatMessageSendServiceTest.java
+++ b/src/test/java/com/readum/domain/aiChat/service/AiChatMessageSendServiceTest.java
@@ -383,7 +383,7 @@ class AiChatMessageSendServiceTest {
                 })
                 .verifyComplete();
 
-        assertThat(persisted.await(2, TimeUnit.SECONDS))
+        assertThat(persisted.await(5, TimeUnit.SECONDS))
                 .as("스트림 에러 후 boundedElastic 의 saveAssistantFailed 호출이 일어나야 함")
                 .isTrue();
         verify(persistService, times(1))
@@ -457,7 +457,7 @@ class AiChatMessageSendServiceTest {
                 .thenCancel()
                 .verify();
 
-        assertThat(persisted.await(2, TimeUnit.SECONDS))
+        assertThat(persisted.await(5, TimeUnit.SECONDS))
                 .as("cancel 후 boundedElastic 의 saveAssistantFailed 호출이 일어나야 함")
                 .isTrue();
         verify(persistService, times(1)).saveAssistantFailed(eq(sessionId), eq("부분 응답"), isNull());
@@ -489,7 +489,7 @@ class AiChatMessageSendServiceTest {
                 .thenCancel()
                 .verify();
 
-        assertThat(persisted.await(2, TimeUnit.SECONDS))
+        assertThat(persisted.await(5, TimeUnit.SECONDS))
                 .as("cancel 후 boundedElastic 의 saveAssistantSuccess 호출이 일어나야 함")
                 .isTrue();
         verify(persistService, times(1)).saveAssistantSuccess(eq(sessionId), eq("응답"), any());

--- a/src/test/java/com/readum/infrastructure/security/jwt/JwtTokenGeneratorImplTest.java
+++ b/src/test/java/com/readum/infrastructure/security/jwt/JwtTokenGeneratorImplTest.java
@@ -80,8 +80,14 @@ class JwtTokenGeneratorImplTest {
     @Test
     void 서명이_변조된_토큰을_파싱하면_INVALID_TOKEN_예외가_발생한다() {
         String token = tokenGenerator.generateAccessToken(1L, "USER", "jwt-id");
-        char last = token.charAt(token.length() - 1);
-        String tampered = token.substring(0, token.length() - 1) + (last == 'A' ? 'B' : 'A');
+        // 서명(마지막 세그먼트)의 첫 문자를 바꿔 디코딩된 서명 바이트가 반드시 달라지게 한다.
+        // 마지막 base64url 문자는 유효 비트가 4개뿐(뒤 2비트는 패딩)이라, 그 문자만 뒤집으면
+        // 디코딩 결과가 그대로일 때가 있어(서명 여전히 유효) 예외가 안 나 간헐 실패했다.
+        int signatureStart = token.lastIndexOf('.') + 1;
+        char signatureFirst = token.charAt(signatureStart);
+        String tampered = token.substring(0, signatureStart)
+                + (signatureFirst == 'A' ? 'B' : 'A')
+                + token.substring(signatureStart + 1);
 
         assertThatThrownBy(() -> tokenGenerator.parse(tampered))
                 .asInstanceOf(InstanceOfAssertFactories.type(UnauthorizedException.class))


### PR DESCRIPTION
## 무엇을
1. **PR 테스트 게이트 신설** (`.github/workflows/ci.yml`): PR(→dev)·dev 푸시에서 `./gradlew build`(전체 테스트) 실행. 지금까지는 `deploy.yml` 빌드가 유일한 테스트 실행이라 실패가 **배포 때 처음** 드러났다.
2. **잔여 CI 플래키 2건 제거**
   - `JwtTokenGeneratorImplTest`: 서명 **마지막** base64url 문자는 유효 비트가 4개뿐(뒤 2비트 패딩)이라 뒤집어도 디코딩 서명이 그대로일 수 있어 서명이 유효하게 남았다 → 예외 미발생 → 간헐 실패. 서명 **첫 문자** 변조로 바꿔 서명 바이트가 반드시 달라지게 함.
   - `AiChatMessageSendServiceTest`: boundedElastic 콜백 대기(CountDownLatch)를 2초→5초로 상향 (느린 CI 러너 대비 보험).

## 왜
Flyway 도입(#130) 배포 빌드가 위 플래키들로 연달아 깨졌다 (Flyway 와 무관한 기존 취약점). 시각 정밀도 건은 #132 에서 이미 처리했고, 이 PR 이 나머지를 마무리한다. 전체 테스트의 플래키 패턴(시각 정밀도·서명 변조·컬렉션 순서·시간대/로케일·sleep·난수)을 전수 감사했고 확정 신규 건은 없음.

프로덕션 동작 변경 없음 (테스트/CI 전용). 이 PR 부터 CI 체크가 PR 에 붙는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)