### PR TITLE
feat(logging): Slack ERROR 알림에 장애 분석 이슈 프리필 링크 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,13 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '4.0.5'
 	id 'io.spring.dependency-management' version '1.1.7'
+	// jar 안에 git.properties 를 생성해 실행 중인 배포 커밋을 식별한다 (Slack 장애 알림의 분석 이슈 링크에 사용)
+	id 'com.gorylenko.gradle-git-properties' version '4.0.1'
+}
+
+gitProperties {
+	// .git 이 없는 환경(소스 아카이브 등)에서도 빌드가 실패하지 않게 한다. 이때 git.properties 는 생성되지 않는다.
+	failOnNoGitDirectory = false
 }
 
 group = 'com'

--- a/src/main/java/com/readum/infrastructure/logging/IncidentFingerprint.java
+++ b/src/main/java/com/readum/infrastructure/logging/IncidentFingerprint.java
@@ -1,0 +1,54 @@
+package com.readum.infrastructure.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.StackTraceElementProxy;
+
+/**
+ * ERROR 로그 한 건을 "같은 오류인지" 사람이 알아볼 수 있는 짧은 식별 문자열로 요약한다.
+ *
+ * <p>계산 규칙 (Sentry 계열 오류 추적 도구의 fingerprint 방식을 축소한 것):
+ * <ul>
+ *   <li>예외가 있으면 — {@code 예외 클래스 단순명 @ 스택에서 첫 com.readum 프레임(클래스.메서드)}.
+ *       바깥 예외에 com.readum 프레임이 없으면 cause 사슬을 따라 내려가며 찾는다.</li>
+ *   <li>예외가 없으면 — {@code logger 단순명 | 포맷 전 메시지 템플릿}. 템플릿({@code {}} 자리표시자가
+ *       치환되기 전 원문)을 쓰므로 ID 같은 가변 인자가 키를 흔들지 않는다.</li>
+ * </ul>
+ */
+final class IncidentFingerprint {
+
+    private static final String APPLICATION_PACKAGE_PREFIX = "com.readum.";
+
+    private IncidentFingerprint() {
+    }
+
+    static String of(ILoggingEvent event) {
+        IThrowableProxy throwableProxy = event.getThrowableProxy();
+        if (throwableProxy == null) {
+            return simpleName(event.getLoggerName()) + " | " + event.getMessage();
+        }
+        return simpleName(throwableProxy.getClassName())
+                + " @ " + firstApplicationFrame(throwableProxy, event);
+    }
+
+    private static String firstApplicationFrame(IThrowableProxy throwableProxy, ILoggingEvent event) {
+        for (IThrowableProxy current = throwableProxy; current != null; current = current.getCause()) {
+            StackTraceElementProxy[] frames = current.getStackTraceElementProxyArray();
+            if (frames == null) {
+                continue;
+            }
+            for (StackTraceElementProxy frameProxy : frames) {
+                StackTraceElement frame = frameProxy.getStackTraceElement();
+                if (frame.getClassName().startsWith(APPLICATION_PACKAGE_PREFIX)) {
+                    return simpleName(frame.getClassName()) + "." + frame.getMethodName();
+                }
+            }
+        }
+        return simpleName(event.getLoggerName());
+    }
+
+    private static String simpleName(String qualifiedName) {
+        int lastDotIndex = qualifiedName.lastIndexOf('.');
+        return lastDotIndex < 0 ? qualifiedName : qualifiedName.substring(lastDotIndex + 1);
+    }
+}

--- a/src/main/java/com/readum/infrastructure/logging/IncidentIssueLinkFactory.java
+++ b/src/main/java/com/readum/infrastructure/logging/IncidentIssueLinkFactory.java
@@ -1,0 +1,136 @@
+package com.readum.infrastructure.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.ThrowableProxyUtil;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Properties;
+
+/**
+ * ERROR 로그 한 건을 GitHub "분석 이슈 생성" 프리필 링크로 변환한다.
+ *
+ * <p>링크를 누르면 이슈 생성 화면이 제목/본문/{@code incident} 라벨이 채워진 상태로 열리고,
+ * 사람이 생성 버튼을 누르는 순간(=분석 승인) {@code incident-analysis.yml} 워크플로우가 발동한다.
+ * 본문 끝의 {@code <!-- deploy-sha: ... -->} 주석은 워크플로우가 분석 대상 커밋을
+ * checkout 할 때 파싱하는 마커다.
+ *
+ * <p>GitHub 프리필 URL 은 길이 한계가 있어(넉넉히 8KB 안팎에서 거부) stacktrace 를 절단해 싣고,
+ * 한글 URL 인코딩 팽창까지 감안해 최종 URL 이 상한을 넘으면 stacktrace 를 더 줄여 다시 만든다.
+ */
+final class IncidentIssueLinkFactory {
+
+    static final String UNKNOWN_DEPLOY_COMMIT = "unknown";
+
+    private static final int MAX_TITLE_CHARS = 80;
+    private static final int MAX_STACK_TRACE_CHARS = 1000;
+    private static final int MIN_STACK_TRACE_CHARS = 200;
+    private static final int MAX_URL_CHARS = 6500;
+
+    private final String repositoryUrl;
+    private final String environment;
+    private final String deployCommit;
+
+    IncidentIssueLinkFactory(String repositoryUrl, String environment, String deployCommit) {
+        this.repositoryUrl = stripTrailingSlash(repositoryUrl);
+        this.environment = environment;
+        this.deployCommit = deployCommit;
+    }
+
+    /**
+     * 빌드 시 gradle-git-properties 플러그인이 jar 에 넣어 준 git.properties 에서
+     * 배포 커밋(짧은 SHA)을 읽는다. 파일이 없으면(테스트, .git 없는 빌드) {@value #UNKNOWN_DEPLOY_COMMIT}.
+     */
+    static String readDeployCommitFromClasspath() {
+        try (InputStream propertiesStream =
+                     IncidentIssueLinkFactory.class.getResourceAsStream("/git.properties")) {
+            if (propertiesStream == null) {
+                return UNKNOWN_DEPLOY_COMMIT;
+            }
+            Properties gitProperties = new Properties();
+            gitProperties.load(propertiesStream);
+            return gitProperties.getProperty("git.commit.id.abbrev", UNKNOWN_DEPLOY_COMMIT);
+        } catch (IOException e) {
+            return UNKNOWN_DEPLOY_COMMIT;
+        }
+    }
+
+    String create(ILoggingEvent event, String fingerprint) {
+        String title = truncate("[장애] " + fingerprint, MAX_TITLE_CHARS);
+        String maskedMessage = SensitiveDataMasker.mask(event.getFormattedMessage());
+        String maskedStackTrace = maskedStackTrace(event);
+
+        String stackTrace = truncate(maskedStackTrace, MAX_STACK_TRACE_CHARS);
+        String url = buildUrl(title, buildBody(event, fingerprint, maskedMessage, stackTrace));
+        while (url.length() > MAX_URL_CHARS && stackTrace.length() > MIN_STACK_TRACE_CHARS) {
+            stackTrace = truncate(stackTrace, stackTrace.length() / 2);
+            url = buildUrl(title, buildBody(event, fingerprint, maskedMessage, stackTrace));
+        }
+        return url;
+    }
+
+    private String maskedStackTrace(ILoggingEvent event) {
+        if (event.getThrowableProxy() == null) {
+            return "(예외 없음)";
+        }
+        return SensitiveDataMasker.mask(ThrowableProxyUtil.asString(event.getThrowableProxy()));
+    }
+
+    private String buildBody(ILoggingEvent event, String fingerprint, String maskedMessage, String stackTrace) {
+        String traceId = event.getMDCPropertyMap().getOrDefault("traceId", "-");
+        return """
+                ## 장애 정보
+                - 발생 시각: %s
+                - 환경: `%s`
+                - 배포 커밋: `%s`
+                - fingerprint: `%s`
+                - traceId: `%s`
+                - logger: `%s`
+
+                ## 메시지
+                ```
+                %s
+                ```
+
+                ## Stacktrace
+                ```
+                %s
+                ```
+
+                <!-- deploy-sha: %s -->
+                """.formatted(
+                Instant.ofEpochMilli(event.getTimeStamp()),
+                environment,
+                deployCommit,
+                fingerprint,
+                traceId,
+                event.getLoggerName(),
+                maskedMessage,
+                stackTrace,
+                deployCommit
+        );
+    }
+
+    private String buildUrl(String title, String body) {
+        return repositoryUrl + "/issues/new"
+                + "?labels=incident"
+                + "&title=" + encode(title)
+                + "&body=" + encode(body);
+    }
+
+    private static String encode(String value) {
+        // URLEncoder 는 공백을 '+' 로 바꾸는데, GitHub 프리필은 '%20' 이 안전하다.
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+
+    private static String truncate(String value, int maxChars) {
+        return value.length() <= maxChars ? value : value.substring(0, maxChars);
+    }
+
+    private static String stripTrailingSlash(String url) {
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+}

--- a/src/main/java/com/readum/infrastructure/logging/SensitiveDataMasker.java
+++ b/src/main/java/com/readum/infrastructure/logging/SensitiveDataMasker.java
@@ -1,0 +1,24 @@
+package com.readum.infrastructure.logging;
+
+/**
+ * 로그 문자열 안의 민감 값(토큰, Authorization 헤더, API 키)을 마스킹한다.
+ *
+ * <p>Slack 알림 본문과 분석 이슈 프리필 링크 본문이 함께 사용한다. 두 곳 모두
+ * 외부(Slack 채널, GitHub 이슈)로 나가는 텍스트이므로 반드시 이 마스킹을 거친다.
+ */
+final class SensitiveDataMasker {
+
+    private SensitiveDataMasker() {
+    }
+
+    static String mask(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value
+                .replace("Bearer ", "Bearer ***")
+                .replaceAll("(?i)(authorization:)[^\\n\\r]+", "$1 ***")
+                .replaceAll("(?i)(api[_-]?key=)[^\\s&]+", "$1***")
+                .replaceAll("(?i)(token=)[^\\s&]+", "$1***");
+    }
+}

--- a/src/main/java/com/readum/infrastructure/logging/SlackWebhookAppender.java
+++ b/src/main/java/com/readum/infrastructure/logging/SlackWebhookAppender.java
@@ -4,7 +4,6 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.ThrowableProxyUtil;
 import ch.qos.logback.core.AppenderBase;
 import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -24,16 +23,21 @@ import java.util.concurrent.ConcurrentMap;
  *
  * <p>Slack 으로 보내기 전 같은 오류(logger + level + 예외 클래스 + 메시지)는 일정 시간 동안
  * 중복 전송을 억제하고, 토큰/Authorization 등 민감 문자열은 마스킹한다.
+ *
+ * <p>메시지에는 오류 식별용 fingerprint({@link IncidentFingerprint})와, 사람이 분석을 승인할 때
+ * 누르는 GitHub 분석 이슈 프리필 링크({@link IncidentIssueLinkFactory})가 함께 실린다.
  */
-@Slf4j
 @Setter
 public class SlackWebhookAppender extends AppenderBase<ILoggingEvent> {
 
     private String webhookUrl;
     private String appName = "readum";
     private String env = "unknown";
+    private String issueRepositoryUrl;
     private long duplicateSuppressMillis = 60_000;
     private int maxStackTraceChars = 1800;
+
+    private IncidentIssueLinkFactory issueLinkFactory;
 
     private final HttpClient httpClient = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(2))
@@ -47,7 +51,10 @@ public class SlackWebhookAppender extends AppenderBase<ILoggingEvent> {
             addWarn("Slack webhookUrl is empty. SlackWebhookAppender will not start.");
             return;
         }
-        log.info("Starting SlackWebhookAppender with webhookUrl: {}", webhookUrl);
+        if (issueRepositoryUrl != null && !issueRepositoryUrl.isBlank()) {
+            issueLinkFactory = new IncidentIssueLinkFactory(
+                    issueRepositoryUrl, env, IncidentIssueLinkFactory.readDeployCommitFromClasspath());
+        }
 
         super.start();
     }
@@ -103,6 +110,7 @@ public class SlackWebhookAppender extends AppenderBase<ILoggingEvent> {
     private String buildSlackPayload(ILoggingEvent event) {
         String traceId = event.getMDCPropertyMap().getOrDefault("traceId", "-");
         String spanId = event.getMDCPropertyMap().getOrDefault("spanId", "-");
+        String fingerprint = IncidentFingerprint.of(event);
 
         String stackTrace = "";
         if (event.getThrowableProxy() != null) {
@@ -116,6 +124,7 @@ public class SlackWebhookAppender extends AppenderBase<ILoggingEvent> {
                 :rotating_light: *%s ERROR 발생*
                 *env*: `%s`
                 *logger*: `%s`
+                *fingerprint*: `%s`
                 *traceId*: `%s`
                 *spanId*: `%s`
                 *time*: `%s`
@@ -126,28 +135,22 @@ public class SlackWebhookAppender extends AppenderBase<ILoggingEvent> {
                 *stacktrace*
                 ```%s```
                 """.formatted(
-                escape(appName),
-                escape(env),
-                escape(event.getLoggerName()),
-                escape(traceId),
-                escape(spanId),
+                SensitiveDataMasker.mask(appName),
+                SensitiveDataMasker.mask(env),
+                SensitiveDataMasker.mask(event.getLoggerName()),
+                SensitiveDataMasker.mask(fingerprint),
+                SensitiveDataMasker.mask(traceId),
+                SensitiveDataMasker.mask(spanId),
                 Instant.ofEpochMilli(event.getTimeStamp()),
-                escape(event.getFormattedMessage()),
-                escape(stackTrace)
+                SensitiveDataMasker.mask(event.getFormattedMessage()),
+                SensitiveDataMasker.mask(stackTrace)
         );
 
-        return "{\"text\":\"" + escapeJson(text) + "\"}";
-    }
-
-    private String escape(String value) {
-        if (value == null) {
-            return "";
+        if (issueLinkFactory != null) {
+            text += "\n:mag: <" + issueLinkFactory.create(event, fingerprint) + "|분석 이슈 열기>";
         }
-        return value
-                .replace("Bearer ", "Bearer ***")
-                .replaceAll("(?i)(authorization:)[^\\n\\r]+", "$1 ***")
-                .replaceAll("(?i)(api[_-]?key=)[^\\s&]+", "$1***")
-                .replaceAll("(?i)(token=)[^\\s&]+", "$1***");
+
+        return "{\"text\":\"" + escapeJson(text) + "\"}";
     }
 
     private String escapeJson(String value) {

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -73,6 +73,8 @@
             <webhookUrl>${SLACK_WEBHOOK_URL}</webhookUrl>
             <appName>${APP_NAME}</appName>
             <env>${APP_ENV}</env>
+            <!-- 분석 이슈 프리필 링크가 가리키는 저장소. 환경 무관 상수라 직접 둔다 -->
+            <issueRepositoryUrl>https://github.com/depromeet/18th-team4-server</issueRepositoryUrl>
             <duplicateSuppressMillis>60000</duplicateSuppressMillis>
             <maxStackTraceChars>1800</maxStackTraceChars>
             <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
@@ -140,6 +142,8 @@
             <webhookUrl>${SLACK_WEBHOOK_URL}</webhookUrl>
             <appName>${APP_NAME}</appName>
             <env>${APP_ENV}</env>
+            <!-- 분석 이슈 프리필 링크가 가리키는 저장소. 환경 무관 상수라 직접 둔다 -->
+            <issueRepositoryUrl>https://github.com/depromeet/18th-team4-server</issueRepositoryUrl>
             <duplicateSuppressMillis>60000</duplicateSuppressMillis>
             <maxStackTraceChars>1800</maxStackTraceChars>
             <filter class="ch.qos.logback.classic.filter.ThresholdFilter">

--- a/src/test/java/com/readum/infrastructure/logging/IncidentFingerprintTest.java
+++ b/src/test/java/com/readum/infrastructure/logging/IncidentFingerprintTest.java
@@ -1,0 +1,64 @@
+package com.readum.infrastructure.logging;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IncidentFingerprintTest {
+
+    @Test
+    void 예외가_있으면_예외클래스와_첫_readum_프레임으로_요약한다() {
+        IllegalStateException exception = new IllegalStateException("적재 실패");
+
+        String fingerprint = IncidentFingerprint.of(errorEvent("적재 실패", null, exception));
+
+        // 이 테스트 클래스(com.readum.*)에서 예외를 만들었으므로 첫 애플리케이션 프레임은 이 테스트 메서드다
+        assertThat(fingerprint).startsWith("IllegalStateException @ IncidentFingerprintTest.");
+    }
+
+    @Test
+    void 바깥_예외에_readum_프레임이_없으면_cause_사슬에서_찾는다() {
+        IllegalStateException inner = new IllegalStateException("원인");
+        RuntimeException outer = new RuntimeException("감싼 예외", inner);
+        outer.setStackTrace(new StackTraceElement[]{
+                new StackTraceElement("org.springframework.SomeFramework", "invoke", "SomeFramework.java", 10)
+        });
+
+        String fingerprint = IncidentFingerprint.of(errorEvent("실패", null, outer));
+
+        assertThat(fingerprint).startsWith("RuntimeException @ IncidentFingerprintTest.");
+    }
+
+    @Test
+    void readum_프레임이_전혀_없으면_logger_이름으로_대신한다() {
+        IllegalStateException exception = new IllegalStateException("실패");
+        exception.setStackTrace(new StackTraceElement[]{
+                new StackTraceElement("org.springframework.SomeFramework", "invoke", "SomeFramework.java", 10)
+        });
+
+        String fingerprint = IncidentFingerprint.of(errorEvent("실패", null, exception));
+
+        assertThat(fingerprint).isEqualTo("IllegalStateException @ SomeLogger");
+    }
+
+    @Test
+    void 예외가_없으면_logger_와_포맷_전_메시지_템플릿을_쓴다() {
+        ILoggingEvent event = errorEvent("summary_job {} 적재 실패", new Object[]{42L}, null);
+
+        String fingerprint = IncidentFingerprint.of(event);
+
+        // 가변 인자(42)가 아니라 자리표시자({}) 원문이 키가 된다
+        assertThat(fingerprint).isEqualTo("SomeLogger | summary_job {} 적재 실패");
+    }
+
+    private ILoggingEvent errorEvent(String message, Object[] arguments, Throwable throwable) {
+        LoggerContext loggerContext = new LoggerContext();
+        Logger logger = loggerContext.getLogger("com.readum.test.SomeLogger");
+        return new LoggingEvent("", logger, Level.ERROR, message, throwable, arguments);
+    }
+}

--- a/src/test/java/com/readum/infrastructure/logging/IncidentIssueLinkFactoryTest.java
+++ b/src/test/java/com/readum/infrastructure/logging/IncidentIssueLinkFactoryTest.java
@@ -1,0 +1,94 @@
+package com.readum.infrastructure.logging;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.classic.util.LogbackMDCAdapter;
+import org.junit.jupiter.api.Test;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IncidentIssueLinkFactoryTest {
+
+    private final IncidentIssueLinkFactory factory =
+            new IncidentIssueLinkFactory("https://github.com/depromeet/18th-team4-server", "dev", "abc1234");
+
+    @Test
+    void 링크는_incident_라벨이_붙은_이슈_생성_화면을_가리킨다() {
+        String url = factory.create(errorEvent("적재 실패", null), "fp");
+
+        assertThat(url).startsWith("https://github.com/depromeet/18th-team4-server/issues/new?labels=incident");
+        assertThat(url).contains("&title=");
+        assertThat(url).contains("&body=");
+    }
+
+    @Test
+    void 본문에_배포_커밋_마커와_장애_정보가_들어간다() {
+        String body = decodedBody(factory.create(errorEvent("적재 실패", new IllegalStateException("원인")), "fp"));
+
+        assertThat(body).contains("<!-- deploy-sha: abc1234 -->");
+        assertThat(body).contains("- 배포 커밋: `abc1234`");
+        assertThat(body).contains("- 환경: `dev`");
+        assertThat(body).contains("- fingerprint: `fp`");
+        assertThat(body).contains("IllegalStateException");
+    }
+
+    @Test
+    void 예외가_없으면_stacktrace_자리에_예외_없음을_적는다() {
+        String body = decodedBody(factory.create(errorEvent("적재 실패", null), "fp"));
+
+        assertThat(body).contains("(예외 없음)");
+    }
+
+    @Test
+    void 민감정보는_본문에서_마스킹된다() {
+        String body = decodedBody(factory.create(
+                errorEvent("호출 실패 url=https://api.example.com?token=secret123", null), "fp"));
+
+        assertThat(body).contains("token=***");
+        assertThat(body).doesNotContain("secret123");
+    }
+
+    @Test
+    void stacktrace_가_아무리_길어도_url_은_상한을_넘지_않는다() {
+        IllegalStateException exception = new IllegalStateException("아주 긴 예외 메시지 ".repeat(500));
+
+        String url = factory.create(errorEvent("실패", exception), "fp");
+
+        assertThat(url.length()).isLessThanOrEqualTo(6500);
+    }
+
+    @Test
+    void 제목은_80자에서_절단된다() {
+        String url = factory.create(errorEvent("실패", null), "긴 fingerprint ".repeat(20));
+
+        String title = decodedParameter(url, "title");
+        assertThat(title.length()).isLessThanOrEqualTo(80);
+        assertThat(title).startsWith("[장애] ");
+    }
+
+    private String decodedBody(String url) {
+        return decodedParameter(url, "body");
+    }
+
+    private String decodedParameter(String url, String name) {
+        for (String parameter : url.substring(url.indexOf('?') + 1).split("&")) {
+            if (parameter.startsWith(name + "=")) {
+                return URLDecoder.decode(parameter.substring(name.length() + 1), StandardCharsets.UTF_8);
+            }
+        }
+        throw new AssertionError(name + " 파라미터가 없다: " + url);
+    }
+
+    private ILoggingEvent errorEvent(String message, Throwable throwable) {
+        LoggerContext loggerContext = new LoggerContext();
+        loggerContext.setMDCAdapter(new LogbackMDCAdapter()); // getMDCPropertyMap() 이 어댑터를 요구한다
+        Logger logger = loggerContext.getLogger("com.readum.test.SomeLogger");
+        return new LoggingEvent("", logger, Level.ERROR, message, throwable, null);
+    }
+}

--- a/src/test/java/com/readum/infrastructure/logging/SensitiveDataMaskerTest.java
+++ b/src/test/java/com/readum/infrastructure/logging/SensitiveDataMaskerTest.java
@@ -1,0 +1,35 @@
+package com.readum.infrastructure.logging;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SensitiveDataMaskerTest {
+
+    @Test
+    void null_은_빈_문자열이_된다() {
+        assertThat(SensitiveDataMasker.mask(null)).isEmpty();
+    }
+
+    @Test
+    void bearer_토큰_값이_가려진다() {
+        assertThat(SensitiveDataMasker.mask("Bearer abc.def.ghi")).startsWith("Bearer ***");
+    }
+
+    @Test
+    void authorization_헤더_값이_가려진다() {
+        assertThat(SensitiveDataMasker.mask("Authorization: Basic abc123"))
+                .isEqualTo("Authorization: ***");
+    }
+
+    @Test
+    void 쿼리스트링의_api_key_와_token_값이_가려진다() {
+        String masked = SensitiveDataMasker.mask("GET /x?api_key=secret&token=hidden&page=1");
+
+        assertThat(masked).contains("api_key=***");
+        assertThat(masked).contains("token=***");
+        assertThat(masked).doesNotContain("secret");
+        assertThat(masked).doesNotContain("hidden");
+        assertThat(masked).contains("page=1");
+    }
+}


### PR DESCRIPTION
## 작업 사항

운영 중 ERROR 가 발생하면 지금은 Slack 알림에서 흐름이 끝난다. 이 PR 은 그 알림에 "분석 이슈 열기" 링크 하나를 더해, 사람이 판단해서 누르면 GitHub 이슈 생성 화면이 제목·본문·`incident` 라벨이 채워진 상태로 열리게 만든다. 이슈를 생성하는 행위가 곧 분석 승인이고, 후속 PR(#140)의 `incident-analysis.yml` 워크플로우가 그 이슈를 받아 Claude Code 분석을 실행한다. Epic #100 의 방향 전환(별도 프로세스 분리 → 수동 트리거 MVP, 상세는 https://github.com/depromeet/18th-team4-server/issues/100#issuecomment-4896014173) 이후 첫 단계다.

자동 실행이 전혀 없다는 점이 설계의 핵심이다. 사람이 이슈를 만들어야만 분석이 시작되므로 중복 억제·요청 폭주 제어 같은 장치가 앱에 필요 없고, Appender 는 메시지에 링크 한 줄을 더하는 것 외에 무거워지지 않는다. 링크 생성 로직은 로그 발생 경로에 있으므로 Spring 빈 의존 없는 순수 클래스로 분리하고 단위 테스트를 붙였다.

"같은 오류인지"를 사람이 알아볼 수 있게 fingerprint 를 도입했다. 계산 규칙은 오류 추적 도구(Sentry 계열)의 방식을 축소한 것으로 — 예외가 있으면 `예외 클래스 @ 스택의 첫 com.readum 프레임`, 없으면 `logger | 포맷 전 메시지 템플릿`. 메시지 전문 대신 템플릿(`{}` 치환 전 원문)을 쓰므로 ID 같은 가변 인자가 키를 흔들지 않는다.

분석은 "배포 시점의 코드" 기준이어야 의미가 있으므로, `gradle-git-properties` 플러그인으로 jar 안에 `git.properties` 를 넣고 Appender 시작 시 배포 커밋(짧은 SHA)을 1회 읽는다. 이 값은 이슈 본문의 `<!-- deploy-sha: ... -->` 마커로 들어가고, 후속 워크플로우가 이 마커를 파싱해 해당 커밋을 checkout 한다. `deploy.yml` 은 건드리지 않았다.

부수 수정으로, `SlackWebhookAppender.start()` 가 webhook URL 전문을 INFO 로그로 남기던 것을 제거했다. Incoming Webhook URL 은 그 자체가 비밀값이라 로그에 남으면 안 된다.

### 기능

**Slack 장애 알림**
- ERROR 알림에 fingerprint 가 표시되어 "전에 본 오류"인지 한눈에 알 수 있다
- "분석 이슈 열기" 링크를 누르면 제목·본문·`incident` 라벨이 채워진 이슈 생성 화면이 열린다 (생성 버튼 = 분석 승인)
- 이슈 본문에 발생 시각·환경·배포 커밋·fingerprint·traceId·마스킹된 메시지/stacktrace 가 미리 담긴다

**안전장치**
- 링크 본문도 Slack 본문과 같은 마스킹(`SensitiveDataMasker`)을 거친다 — 토큰·Authorization·API 키 값 가림
- 프리필 URL 은 길이 한계가 있어 stacktrace 를 1,000자에서 절단하고, 최종 URL 이 6,500자를 넘으면 더 줄여 다시 만든다
- `git.properties` 가 없는 환경(테스트, .git 없는 빌드)에서는 배포 커밋이 `unknown` 으로 동작하고 빌드도 실패하지 않는다

## 테스트 결과
- [x] `./gradlew test` 통과 (419 tests, 0 failed)
- [x] `git.properties` 생성 확인 (`git.commit.id.abbrev=a0d9868`)
- [x] fingerprint 계산·프리필 URL 조립·마스킹 단위 테스트 15건 추가
- [ ] dev 배포 후 실제 Slack 알림에서 링크 클릭 → 이슈 생성 화면 프리필 확인 (워크플로우 PR 머지 후 함께 검증)

## 관련 이슈
- closes #139

## 참고 사항
- 후속 PR(#140)이 `incident` 라벨 트리거 워크플로우를 추가하기 전까지, 링크로 만든 이슈는 분석 없이 일반 이슈로만 남는다 (라벨은 저장소에 아직 없어도 이슈 생성은 정상 동작).
- `com.gorylenko.gradle-git-properties` 4.0.1 이 빌드에 추가됐다. CI(GitHub Actions)는 checkout 으로 .git 이 있으므로 그대로 동작한다.