### PR TITLE
feat(ops): incident 라벨 트리거 장애 분석 워크플로우 신설

### DIFF
--- a/.github/workflows/incident-analysis.yml
+++ b/.github/workflows/incident-analysis.yml
@@ -1,0 +1,113 @@
+# 운영 장애 분석 워크플로우.
+# Slack ERROR 알림의 "분석 이슈 열기" 링크(또는 이슈에 수동으로 incident 라벨 부착)로
+# incident 라벨 이슈가 생기면, 이슈 본문의 배포 커밋을 checkout 해 Claude Code 가
+# 원인 후보를 분석하고 이슈 코멘트로 남긴 뒤 Slack 으로 완료/실패를 알린다.
+# 배포 파이프라인(deploy.yml)과 완전히 독립이다. 전체 흐름: docs/ops/incident-analysis.md
+
+name: incident-analysis
+
+on:
+  issues:
+    types: [labeled]
+
+# 같은 이슈에 라벨이 여러 번 붙어도 분석은 한 번에 하나만 돈다 (뒤 실행은 대기).
+concurrency:
+  group: incident-analysis-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  analyze:
+    if: github.event.label.name == 'incident'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # 배포 커밋이 기본 브랜치보다 뒤에 있을 수 있어 전체 이력을 받는다
+          fetch-depth: 0
+
+      - name: 배포 커밋 checkout (이슈 본문의 deploy-sha 마커)
+        id: deploy_sha
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          SHA=$(printf '%s' "$ISSUE_BODY" \
+            | grep -oE '<!-- deploy-sha: [0-9a-fA-F]{7,40} -->' | head -1 \
+            | grep -oE '[0-9a-fA-F]{7,40}' || true)
+          if [ -n "$SHA" ] && git rev-parse --verify --quiet "${SHA}^{commit}" > /dev/null; then
+            git checkout --quiet "$SHA"
+            echo "note=배포 커밋 ${SHA} 기준" >> "$GITHUB_OUTPUT"
+          else
+            echo "note=본문에서 배포 커밋을 찾지 못해 기본 브랜치 최신 커밋 기준" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Claude Code 분석
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--allowedTools "Bash(gh issue view:*),Bash(gh issue comment:*)"'
+          prompt: |
+            너는 운영 장애 분석 담당이다. GitHub 이슈 #${{ github.event.issue.number }} 는
+            운영 ERROR 로그에서 만들어진 장애 분석 요청이다.
+            현재 checkout 된 코드는 ${{ steps.deploy_sha.outputs.note }}이다.
+
+            절차:
+            1. `gh issue view ${{ github.event.issue.number }}` 로 이슈 본문(메시지·stacktrace·fingerprint·traceId)을 읽는다.
+            2. stacktrace 의 com.readum 프레임을 중심으로 관련 코드를 읽고 원인 후보를 찾는다.
+            3. 분석 결과를 파일로 작성해 `gh issue comment ${{ github.event.issue.number }} --body-file <파일>` 로 남긴다.
+
+            코멘트 형식 (한국어 본문, 코드 식별자는 영문 유지):
+            - 첫 줄: 한 줄 요약 — Slack 완료 알림에 이 줄이 그대로 실린다
+            - `## 원인 후보` — 가능성이 높은 순으로 최대 3개. 각각 근거 코드 경로(`파일:라인`)와 판단 근거를 적는다
+            - `## 재현 조건` — 어떤 상황에서 발생하는지 추정
+            - `## 수정 방향` — 후보별 수정 제안
+            - 분석이 기본 브랜치 기준이면(배포 커밋을 못 찾은 경우) 그 사실을 명시한다
+
+            주의: 코드를 수정하거나 PR 을 만들지 않는다. 분석과 이슈 코멘트만 한다.
+            확신이 없는 부분은 확신이 없다고 적는다.
+
+      - name: Slack 완료 알림
+        if: success()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL 미설정 — 알림을 생략한다"
+            exit 0
+          fi
+          # 마지막 코멘트(방금 남긴 분석)의 첫 줄을 요약으로 싣는다
+          SUMMARY=$(gh issue view "$ISSUE_NUMBER" --json comments \
+            --jq '.comments | last | .body' 2>/dev/null | head -n 1 | cut -c1-300 || true)
+          TEXT=":mag: *장애 분석 완료* — <${ISSUE_URL}|#${ISSUE_NUMBER} ${ISSUE_TITLE}>"
+          if [ -n "$SUMMARY" ]; then
+            TEXT="${TEXT}"$'\n'"${SUMMARY}"
+          fi
+          jq -n --arg text "$TEXT" '{text: $text}' \
+            | curl -sS -X POST -H 'Content-Type: application/json' -d @- "$SLACK_WEBHOOK_URL"
+
+      - name: Slack 실패 알림
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL 미설정 — 알림을 생략한다"
+            exit 0
+          fi
+          TEXT=":rotating_light: *장애 분석 실패* — <${ISSUE_URL}|#${ISSUE_NUMBER}> 분석이 실패했다. <${RUN_URL}|Actions 로그>"
+          jq -n --arg text "$TEXT" '{text: $text}' \
+            | curl -sS -X POST -H 'Content-Type: application/json' -d @- "$SLACK_WEBHOOK_URL"

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -5,6 +5,7 @@
 | 파일 | 내용 |
 |------|------|
 | [infrastructure.md](infrastructure.md) | 개발 서버 구성 일체 — EC2·blue/green 배포 구조·Docker MySQL/Redis·도메인·접속 방법 |
+| [incident-analysis.md](incident-analysis.md) | 운영 장애 분석 흐름 — Slack 알림의 분석 이슈 링크, incident 라벨 워크플로우, 필요한 secrets |
 | [_template.md](_template.md) | 운영 문서 작성 템플릿 |
 
 ## 이 디렉토리에 적지 않는 것 (2026-07-05 결정)

--- a/docs/ops/incident-analysis.md
+++ b/docs/ops/incident-analysis.md
@@ -1,0 +1,46 @@
+# 운영 장애 분석 (수동 트리거)
+
+## 현재 구성
+
+운영 중 ERROR 가 발생하면 사람이 판단해 분석을 요청하는 흐름이다. 자동 실행은 없다.
+
+```
+ERROR 발생
+  → Slack 알림 (fingerprint + "분석 이슈 열기" 프리필 링크 — SlackWebhookAppender)
+  → 사람이 링크 클릭 → 이슈 생성 (incident 라벨, 본문에 배포 커밋·stacktrace 프리필)
+  → incident-analysis.yml 발동 → 배포 커밋 checkout → Claude Code 분석 → 이슈 코멘트
+  → Slack 완료/실패 알림
+```
+
+- **수집·링크 생성**: `com.readum.infrastructure.logging` 의 `SlackWebhookAppender` 가
+  `IncidentFingerprint`(오류 요약 키)와 `IncidentIssueLinkFactory`(프리필 URL)를 사용한다.
+  배포 커밋은 빌드 시 gradle-git-properties 가 jar 에 넣은 `git.properties` 에서 읽는다.
+- **분석 실행**: `.github/workflows/incident-analysis.yml`. `incident` 라벨이 붙은 이슈가
+  트리거다. 이슈 본문의 `<!-- deploy-sha: ... -->` 마커를 파싱해 그 커밋을 checkout 하고,
+  Claude Code(`claude-code-action`)가 원인 후보·재현 조건·수정 방향을 이슈 코멘트로 남긴다.
+  분석은 읽기 전용 — 코드 수정·PR 생성은 하지 않는다.
+- **두 번째 수동 경로**: 링크 없이도 아무 이슈에 `incident` 라벨을 붙이면 분석이 발동한다.
+  본문에 배포 커밋 마커가 없으면 기본 브랜치 최신 커밋 기준으로 분석하고 그 사실을 코멘트에 명시한다.
+- **필요한 GitHub Actions secrets**:
+
+| secret | 용도 | 비고 |
+|---|---|---|
+| `CLAUDE_CODE_OAUTH_TOKEN` | Claude Code 실행 | claude.yml 과 공유, 이미 등록됨 |
+| `SLACK_WEBHOOK_URL` | 완료/실패 알림 | 미등록이면 알림만 조용히 생략되고 분석은 정상 동작 |
+
+## 변경 절차와 주의점
+
+- **deploy.yml 과 섞지 않는다.** 이 워크플로우는 배포와 완전히 독립이며, 배포 파이프라인을 건드리지 않는다.
+- **Logback Appender 를 무겁게 만들지 않는다.** 앱 쪽 책임은 "Slack 메시지에 링크 한 줄"까지다.
+  분석·이슈 조작·상태 관리를 앱에 넣지 않는다. 자동 트리거가 필요해지면 앱이 아니라 이 워크플로우에
+  `repository_dispatch` 트리거를 추가하는 방향으로 확장한다 (Epic #100 코멘트의 확장 계획 참조).
+- **분석 프롬프트 수정**은 `incident-analysis.yml` 의 `prompt` 를 고친다. 앱 재배포가 필요 없다.
+- **비용 제어는 사람이 한다.** 이슈를 만들어야만 분석이 돌므로, 분석이 과하면 그냥 안 누르면 된다.
+  같은 이슈에 라벨을 다시 붙이면 재분석이 돈다 (concurrency 로 동시 실행만 막는다).
+- **민감정보**: 이슈 본문에 실리는 메시지·stacktrace 는 앱에서 마스킹(`SensitiveDataMasker`)을
+  거친 값이다. 마스킹 규칙을 바꾸면 Slack 본문과 이슈 링크 본문에 함께 적용된다.
+
+## 관련 기록
+
+- Epic #100 — 방향 전환 배경(별도 프로세스 설계 폐기 → 수동 트리거 MVP): 이슈 코멘트 참조
+- 서브 이슈: #139 (앱 쪽 링크), #140 (이 워크플로우)


### PR DESCRIPTION
## 작업 사항

Epic #100 수동 트리거 MVP 의 2/2 단계. 앞선 PR(#141)이 Slack ERROR 알림에 넣은 "분석 이슈 열기" 링크로 `incident` 라벨 이슈가 생기면, 이 워크플로우가 받아서 분석을 실행한다. 사람이 이슈를 생성하는 행위가 곧 분석 승인이므로, 워크플로우 쪽에도 별도의 중복 억제 장치 없이 concurrency(이슈 번호 단위)로 동시 실행만 막는다.

분석의 전제는 "배포 시점의 코드를 본다"이다. 이슈 본문의 `<!-- deploy-sha: ... -->` 마커를 파싱해 그 커밋을 checkout 한 뒤 Claude Code 를 실행한다. 마커가 없거나 커밋을 찾지 못하면 기본 브랜치 최신 커밋으로 진행하되, 그 사실이 분석 코멘트에 명시되도록 프롬프트에 지시했다. 이 구조 덕에 `incident` 라벨을 아무 이슈에나 수동으로 붙여도 분석이 동작한다 — 프리필 링크 없이 쓰는 두 번째 수동 경로다.

분석은 읽기 전용이다. 프롬프트로 원인 후보(근거 코드 경로 포함)·재현 조건·수정 방향까지만 이슈 코멘트로 남기게 하고, 코드 수정·PR 생성은 금지했다. 프롬프트는 워크플로우 파일 안에 있으므로 고칠 때 앱 재배포가 필요 없다.

마지막 단계에서 Slack 으로 결과를 알린다. 완료 시 분석 코멘트의 첫 줄(한 줄 요약)과 이슈 링크를, 실패 시 Actions 실행 로그 링크를 보낸다. `SLACK_WEBHOOK_URL` secret 이 없으면 알림만 조용히 생략되고 분석 자체는 정상 동작한다.

기존 워크플로우와의 경계: `deploy.yml`(배포)·`claude.yml`(@claude 멘션 응답)은 건드리지 않았다. 이슈 본문에 `@claude` 멘션이 없으므로 `claude.yml` 과 이중 발동하지 않는다.

### 기능

**장애 분석 실행**
- `incident` 라벨이 붙은 이슈가 열리면(또는 기존 이슈에 라벨을 붙이면) Claude Code 가 배포 시점 코드 기준으로 원인 후보를 분석해 이슈 코멘트로 남긴다
- 분석 코멘트: 한 줄 요약 → 원인 후보(가능성 순 최대 3개, `파일:라인` 근거) → 재현 조건 → 수정 방향

**Slack 알림**
- 분석 완료: 요약 한 줄 + 이슈 링크가 장애 알림과 같은 채널에 도착한다
- 분석 실패: Actions 로그 링크로 바로 이동할 수 있다

**운영 문서**
- `docs/ops/incident-analysis.md` — 전체 흐름, 필요한 secrets, 변경 시 주의점(배포와 섞지 않기, Appender 무겁게 만들지 않기, 확장은 repository_dispatch 방향)

## 테스트 결과
- [x] YAML 문법 검증 통과
- [x] `incident` 라벨 저장소 등록 완료
- [ ] `SLACK_WEBHOOK_URL` Actions secret 등록 (담당자 액션 — 미등록이어도 분석은 동작)
- [ ] 머지 후 테스트 이슈로 워크플로우 실제 발동 1회 검증 (#140 완료 조건)

## 관련 이슈
- closes #140

## 참고 사항
- 워크플로우 트리거(`issues: labeled`)는 기본 브랜치의 워크플로우 파일을 쓰므로, **dev 머지 후부터** 발동한다. 머지 전에는 라벨을 붙여도 아무 일도 일어나지 않는다.
- 앞선 PR #141(프리필 링크)과 독립적으로 머지 가능하다. 이 PR 만 먼저 머지되면 수동 라벨 경로만 동작하고, #141 만 먼저 머지되면 링크로 만든 이슈가 분석 없이 일반 이슈로 남는다.
- 재분석이 필요하면 라벨을 뗐다가 다시 붙이면 된다.

---

## 추가 커밋: Slack 알림을 원본 에러 알림 스레드로 승급 (ee4eba9)

리뷰 중 논의로 범위가 한 가지 늘었다. 분석 시작·완료·실패 알림이 채널에 흩어지는 대신, **그 에러의 원본 Slack 알림 스레드에 모이도록** 개선했다.

**동작 방식** — 워크플로우가 분석 시작 시점에 채널 최근 이력(200건)에서 이슈 본문과 같은 fingerprint 를 담은 에러 알림을 찾아 스레드 ts 를 얻는다. 이때 "ERROR 발생" 마커로 원본 알림만 고르므로 워크플로우 자신이 남긴 분석 메시지(fingerprint 포함)와 혼동하지 않는다. 이후 시작 알림은 스레드에만, 완료/실패는 스레드 + 채널 동시 노출로 게시한다.

**등급 하강 설계** — `SLACK_BOT_TOKEN`/`SLACK_CHANNEL_ID` 가 없거나 원본 알림을 못 찾으면 기존 webhook 채널 일반 메시지로 자동 대체된다. 즉 Slack 앱을 만들기 전에도 이 PR 은 그대로 동작하고(시작 알림이 채널 메시지로 옴), 토큰을 등록하는 순간 스레드 모드로 켜진다. 게시 로직은 `.github/scripts/incident-slack-notify.sh` 한 곳에 모았다.

**주의해서 처리한 부분** — 배포 커밋 checkout 으로 작업 트리가 과거로 가면 새 스크립트 파일이 사라질 수 있어, checkout 전에 `$RUNNER_TEMP` 로 보존해 두고 그 경로로 실행한다. 실패 알림은 보존 step 이전에 죽은 경우를 대비해 저장소 원본 경로 fallback 도 갖는다.

**스레드 모드 활성화에 필요한 것 (선택, 담당자 액션)** — Slack 앱 생성(Bot 권한 `chat:write` + `channels:history`), 봇을 에러 알림 채널에 초대, `SLACK_BOT_TOKEN`·`SLACK_CHANNEL_ID` secret 등록. 상세는 docs/ops/incident-analysis.md 갱신분 참조.