### PR TITLE
chore(nginx): (보일러 플레이트) $connection_upgrade map 을 repo 로 이관 + 인증서 도메인 정리

### DIFF
--- a/docs/ops/infrastructure.md
+++ b/docs/ops/infrastructure.md
@@ -47,6 +47,7 @@
 | 구성물 | 위치 (서버) | 원본 |
 |---|---|---|
 | nginx server 블록 | `/etc/nginx/sites-available/app.conf` | `infra/nginx/app.conf` |
+| nginx WebSocket map | `/etc/nginx/conf.d/websocket-upgrade.conf` | `infra/nginx/websocket-upgrade.conf` — app.conf 가 쓰는 `$connection_upgrade` 를 정의하는 map. map 은 http 컨텍스트에만 둘 수 있어 server 블록 밖 conf.d 조각으로 분리. 없으면 nginx 기동 실패 |
 | 전환 스위치(upstream) | `/etc/nginx/conf.d/readum-upstream.conf` | 없음 — "지금 어느 색이 활성인가"라는 런타임 상태. `deploy.sh` 가 생성·갱신하며 활성 색 판정도 이 파일에서 읽는다 |
 | systemd 유닛 | `/etc/systemd/system/readum-{blue,green}.service` | `infra/systemd/` |
 | 배포 스크립트 | `/opt/readum/bin/deploy.sh` | `infra/scripts/deploy.sh` (CI 가 배포 때마다 동기화) |
@@ -94,7 +95,7 @@
 | DNS 관리 | 가비아 |
 | 프론트엔드 | readum.kr (CloudFront) |
 | 백엔드 API | api.readum.kr → EC2 |
-| SSL 인증서 | Let's Encrypt (Certbot 자동 갱신, nginx 에서 TLS 종료) |
+| SSL 인증서 | Let's Encrypt (Certbot 자동 갱신, nginx 에서 TLS 종료). 이 서버 인증서는 **api.readum.kr 단독** — readum.kr 은 CloudFront 로 가므로 이 서버에서 ACME 검증이 안 돼 인증서에 포함하면 갱신이 실패한다 (2026-07-07 readum.kr 제거) |
 
 서버 공인 IP 는 탄력적 IP 로 고정한다 (미고정 상태에서 인스턴스 stop/start 시 IP 가 바뀌어 DNS 가 끊긴 사고가 2026-07-06 실제로 발생). 배포 대상 주소의 원본은 `deploy.yml` 의 `env.DEPLOY_HOST`.
 

--- a/infra/nginx/app.conf
+++ b/infra/nginx/app.conf
@@ -5,12 +5,15 @@
 # 그 파일은 "지금 어느 포트가 활성인가"라는 서버의 런타임 상태라서 repo 로 관리하지 않고
 # 배포 스크립트(deploy.sh)가 생성·갱신한다. 내용은 한 줄이다:
 #   upstream readum_backend { server 127.0.0.1:8081; }
+#
+# 아래 proxy_set_header 의 $connection_upgrade 는 infra/nginx/websocket-upgrade.conf 의 map 으로만
+# 정의되는 변수다. 그 파일을 /etc/nginx/conf.d/ 에 함께 배치하지 않으면 nginx 가 기동하지 않는다.
 
 # 1) HTTP → HTTPS 리다이렉트
 server {
     listen 80;
     listen [::]:80;
-    server_name readum.kr api.readum.kr;
+    server_name api.readum.kr;
 
     # Let's Encrypt 갱신(ACME http-01)은 리다이렉트 예외
     location /.well-known/acme-challenge/ {
@@ -26,7 +29,7 @@ server {
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    server_name readum.kr api.readum.kr;
+    server_name api.readum.kr;
 
     ssl_certificate     /etc/letsencrypt/live/readum.kr/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/readum.kr/privkey.pem;

--- a/infra/nginx/websocket-upgrade.conf
+++ b/infra/nginx/websocket-upgrade.conf
@@ -1,0 +1,13 @@
+# WebSocket/SSE 프록시용 map. 서버의 /etc/nginx/conf.d/websocket-upgrade.conf 로 복사해 적용한다
+# (conf.d 는 nginx.conf 의 http 블록에 include 되므로 map 을 여기 둘 수 있다).
+#
+# app.conf 의 `proxy_set_header Connection $connection_upgrade;` 가 이 변수를 참조한다.
+# $connection_upgrade 는 nginx 내장 변수가 아니라 이 map 으로만 정의되므로, 이 파일이 없으면
+# nginx 가 `unknown "connection_upgrade" variable` 로 기동 실패한다. map 은 http 컨텍스트에만
+# 둘 수 있어 server 블록(app.conf) 안에는 넣지 못한다.
+#
+# 요청에 Upgrade 헤더가 있으면(WebSocket 핸드셰이크) Connection: upgrade, 없으면 Connection: close.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}


### PR DESCRIPTION
## 작업 사항

dev 자동 배포 활성화(#131)와 탄력적 IP 재배치 과정에서 드러난, **서버에는 손으로 적용돼 있으나 repo 와 어긋나 있던** nginx/인증서 정합성 두 가지를 repo 에 반영한다. infrastructure.md 의 "서버 상태와 repo 가 다르면 repo 를 고쳐 반영한다" 원칙에 따른 정리다.

**1. `$connection_upgrade` map 을 repo 로 이관** — app.conf 의 `proxy_set_header Connection $connection_upgrade;` 가 참조하는 이 변수는 nginx 내장이 아니라 `map` 으로만 정의된다. 그동안 이 map 이 서버 nginx.conf 에만 수동으로 있었고 repo 에는 없었다 — repo 만 보고 새 서버 nginx 를 세팅하면 map 이 빠져 `unknown "connection_upgrade" variable` 로 기동에 실패하는 구멍이었다. map 은 http 컨텍스트에만 둘 수 있어 server 블록(app.conf) 안에 못 넣으므로, conf.d 조각(`infra/nginx/websocket-upgrade.conf`)으로 분리해 관리한다.

**2. 인증서 도메인을 api.readum.kr 단독으로 정리** — 기존 인증서는 `readum.kr` + `api.readum.kr` 두 도메인을 담았는데, `readum.kr` 은 CloudFront 로 향해 이 서버에서 ACME 검증이 불가능하다. 그 결과 certbot 갱신이 readum.kr 검증 404 로 실패하는 상태였다(만료 10일 전 발견). 인증서를 api.readum.kr 단독으로 재발급하고, app.conf 의 `server_name` 에서도 readum.kr 을 제거해 실제 라우팅과 일치시킨다. cert-name 은 `readum.kr` 로 유지하므로 nginx 인증서 경로(`/etc/letsencrypt/live/readum.kr/`)는 그대로다.

### 기능 (운영/구성)

**nginx 구성 완전성**
- repo 만으로 새 서버 nginx 를 세팅해도 `$connection_upgrade` map 이 딸려가 정상 기동
- infrastructure.md nginx 표에 map 파일 행 추가

**인증서**
- app.conf `server_name` = api.readum.kr 단독 (실제 DNS·인증서와 일치)
- 인증서 도메인 범위·이유를 infrastructure.md 에 명시

## 테스트 결과
- [x] 코드 변경 없음 — 앱 빌드/테스트 무관 (인프라·문서만)
- [x] map 정의 내용은 서버 실 구성(`nginx -T`)에서 그대로 이관
- [ ] 서버 적용 후 `sudo nginx -t` 통과 확인 (아래 절차)
- [ ] 인증서 api.readum.kr 단독 실 재발급 (dry-run 성공 확인, 실 발급은 서버에서 진행 중)

## 관련 이슈
- 없음

## 참고 사항 (서버 적용 절차 — CI 가 반영하지 않음)

nginx·인증서 변경은 CI 배포가 반영하지 않으므로(root 권한 불필요 원칙) 수동 적용한다:

1. map 조각 배치: `sudo cp infra/nginx/websocket-upgrade.conf /etc/nginx/conf.d/`
2. **중복 제거**: 서버 nginx.conf(기존 위치)에 손으로 넣어 둔 동일 map 을 제거 — 안 하면 map 이 두 번 정의돼 `duplicate ... map` 으로 nginx 가 안 뜬다. 위치: `grep -rn connection_upgrade /etc/nginx/`
3. app.conf 갱신 배치: `sudo cp infra/nginx/app.conf /etc/nginx/sites-available/app.conf`
4. 검증·반영: `sudo nginx -t && sudo systemctl reload nginx`

인증서는 api.readum.kr 단독 재발급 후 certbot.timer 자동 갱신이 정상 동작한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기능 개선**
  * WebSocket/SSE 연결을 위한 nginx 업그레이드 설정 안내가 추가되어 프록시 구성이 더 명확해졌습니다.
* **버그 수정**
  * 서버가 잘못된 호스트명으로 동작하지 않도록 HTTPS/HTTP 대상 도메인이 `api.readum.kr`로 정리되었습니다.
  * 인증서 갱신 및 기동 실패 가능성에 대한 안내가 보강되었습니다.
* **문서**
  * 인프라 문서에 nginx 설정 위치, 적용 조건, SSL 인증서 범위에 대한 설명이 추가·수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->