### PR TITLE
feat(infra): nginx 설정을 배포 파이프라인이 자동 반영하도록 전환 + dev Swagger 공개

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,12 +59,17 @@ jobs:
           ssh -i ~/.ssh/deploy_key "ubuntu@${DEPLOY_HOST}" \
             'chmod 600 /opt/readum/.env.tmp && mv /opt/readum/.env.tmp /opt/readum/.env'
 
-      - name: jar·배포 스크립트 업로드
+      - name: jar·배포 스크립트·nginx 설정 업로드
         run: |
           scp -i ~/.ssh/deploy_key "readum-${SHORT_SHA}.jar" \
             "ubuntu@${DEPLOY_HOST}:/opt/readum/releases/"
           scp -i ~/.ssh/deploy_key infra/scripts/deploy.sh \
             "ubuntu@${DEPLOY_HOST}:/opt/readum/bin/deploy.sh"
+          # nginx 설정은 스테이징 디렉토리에만 올린다. /etc/nginx 반영(변경분만)과 검증·reload 는
+          # deploy.sh 의 sync_nginx_conf 가 수행한다.
+          ssh -i ~/.ssh/deploy_key "ubuntu@${DEPLOY_HOST}" 'mkdir -p /opt/readum/nginx'
+          scp -i ~/.ssh/deploy_key infra/nginx/app.conf infra/nginx/websocket-upgrade.conf \
+            "ubuntu@${DEPLOY_HOST}:/opt/readum/nginx/"
 
       - name: blue/green 배포 실행
         run: |

--- a/docs/ops/infrastructure.md
+++ b/docs/ops/infrastructure.md
@@ -46,8 +46,8 @@
 
 | 구성물 | 위치 (서버) | 원본 |
 |---|---|---|
-| nginx server 블록 | `/etc/nginx/sites-available/app.conf` | `infra/nginx/app.conf` |
-| nginx WebSocket map | `/etc/nginx/conf.d/websocket-upgrade.conf` | `infra/nginx/websocket-upgrade.conf` — app.conf 가 쓰는 `$connection_upgrade` 를 정의하는 map. map 은 http 컨텍스트에만 둘 수 있어 server 블록 밖 conf.d 조각으로 분리. 없으면 nginx 기동 실패 |
+| nginx server 블록 | `/etc/nginx/sites-available/app.conf` | `infra/nginx/app.conf` — CI 가 배포 때마다 `/opt/readum/nginx/` 로 올리고, `deploy.sh` 의 `sync_nginx_conf` 가 변경분만 반영(검증 실패 시 이전 설정 복구 + 배포 중단) |
+| nginx WebSocket map | `/etc/nginx/conf.d/websocket-upgrade.conf` | `infra/nginx/websocket-upgrade.conf` — app.conf 가 쓰는 `$connection_upgrade` 를 정의하는 map. map 은 http 컨텍스트에만 둘 수 있어 server 블록 밖 conf.d 조각으로 분리. 없으면 nginx 기동 실패. 반영 방식은 app.conf 와 동일(CI 업로드 + `sync_nginx_conf`) |
 | 전환 스위치(upstream) | `/etc/nginx/conf.d/readum-upstream.conf` | 없음 — "지금 어느 색이 활성인가"라는 런타임 상태. `deploy.sh` 가 생성·갱신하며 활성 색 판정도 이 파일에서 읽는다 |
 | systemd 유닛 | `/etc/systemd/system/readum-{blue,green}.service` | `infra/systemd/` |
 | 배포 스크립트 | `/opt/readum/bin/deploy.sh` | `infra/scripts/deploy.sh` (CI 가 배포 때마다 동기화) |
@@ -68,7 +68,7 @@
 
 - ~~**05:50~06:10 배포 회피**~~ (2026-07 해소) — 6시 감상문 적재 스캔과 전환 구간(두 프로세스 동시 상주)이 겹치면 외부 API(OpenAI) 호출 예산이 잠깐 2배가 됐었다. 전역 게이트(Redis) 도입으로 호출 예산이 프로세스 간 공유되어 이 회피는 불필요해졌다.
 - 전환 구간엔 JVM 2개(각 `-Xmx256m`)가 동시에 뜬다. 배포 중 스왑 피크가 계속 커지면 인스턴스 증설을 검토한다.
-- nginx·systemd·sudoers 파일 변경은 CI 가 반영하지 않는다(root 권한 불필요 원칙) — `sudo ./infra/scripts/setup.sh <repo>/infra` 재실행 + 필요 시 nginx reload 로 수동 반영한다.
+- nginx 설정(`app.conf`·`websocket-upgrade.conf`)은 배포 파이프라인이 반영한다 — sudo 는 고정 경로 `tee` 두 줄만 추가로 허용(sudoers 에 명시). systemd·sudoers 파일 변경은 여전히 CI 가 반영하지 않는다(root 권한 불필요 원칙) — `sudo ./infra/scripts/setup.sh <repo>/infra` 재실행으로 수동 반영한다. sudoers 갱신 전에는 nginx 설정 자동 반영이 sudo 거부로 실패하므로, 이 구조를 처음 켤 때 setup.sh 재실행이 선행돼야 한다.
 
 새 서버를 처음 준비할 때도 같은 `setup.sh` 가 시작점이다 (디렉토리·유닛·sudoers·MySQL 설정 배치).
 

--- a/infra/nginx/app.conf
+++ b/infra/nginx/app.conf
@@ -1,5 +1,6 @@
 # readum 백엔드 nginx 설정. 원본은 repo 의 infra/nginx/app.conf 이고,
-# 서버의 /etc/nginx/sites-available/app.conf 로 복사해 적용한다 (절차는 docs/ops/infrastructure.md).
+# CI(deploy.yml)가 배포 때마다 /opt/readum/nginx/ 로 올리면 deploy.sh 가 변경분만
+# 서버의 /etc/nginx/sites-available/app.conf 에 반영한다 (구조는 docs/ops/infrastructure.md).
 #
 # 트래픽 전환(blue/green)은 이 파일이 아니라 /etc/nginx/conf.d/readum-upstream.conf 가 담당한다.
 # 그 파일은 "지금 어느 포트가 활성인가"라는 서버의 런타임 상태라서 repo 로 관리하지 않고
@@ -41,16 +42,12 @@ server {
 
     client_max_body_size 20m;
 
-    # 내부 운영 경로는 외부에 열지 않는다 (Actuator 지표·Swagger 문서).
+    # 내부 운영 경로는 외부에 열지 않는다 (Actuator 지표).
     # 서버 내부에서는 nginx 를 거치지 않고 127.0.0.1:808x 로 직접 접근하므로 영향 없다
     # (배포 스크립트의 readiness 확인, 내부 지표 수집 모두 해당).
+    # Swagger(/swagger-ui, /v3/api-docs)는 dev 서버에서 공개한다 — 프론트 협업용 API 문서.
+    # springdoc 은 dev 프로파일에서만 켜져 있어(application-dev.yml) 다른 환경에는 영향 없다.
     location ^~ /actuator/ {
-        return 404;
-    }
-    location ^~ /swagger-ui {
-        return 404;
-    }
-    location ^~ /v3/api-docs {
         return 404;
     }
 

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -83,7 +83,13 @@ sync_nginx_conf() {
     [[ -f "$src" ]] || continue   # 서버에서 수동 실행 등 원본이 없으면 건너뜀
     cmp -s "$src" "$dst" 2>/dev/null && continue
     backup="$NGINX_SYNC_DIR/$name.prev"
-    [[ -f "$dst" ]] && cat "$dst" > "$backup"
+    if [[ -f "$dst" ]]; then
+      cat "$dst" > "$backup"
+    else
+      # 최초 반영(대상 파일이 아직 없음) — 이전 배포의 낡은 백업이 남아 있으면 엉뚱한 내용으로
+      # "복구"하게 되므로 지운다. 백업 없음 = 복구 불가는 아래 검증 실패 분기에서 경고로 드러낸다.
+      rm -f "$backup"
+    fi
     log "nginx 설정 갱신: $dst"
     sudo /usr/bin/tee "$dst" < "$src" >/dev/null
     applied+=("$backup:$dst")
@@ -93,9 +99,14 @@ sync_nginx_conf() {
     log "nginx 설정 검증 실패 — 이전 설정으로 복구"
     for entry in "${applied[@]}"; do
       backup="${entry%%:*}"; dst="${entry#*:}"
-      [[ -f "$backup" ]] && sudo /usr/bin/tee "$dst" < "$backup" >/dev/null
+      if [[ -f "$backup" ]]; then
+        sudo /usr/bin/tee "$dst" < "$backup" >/dev/null
+      else
+        # 최초 반영이라 되돌릴 이전 설정이 없다 — 검증 실패한 새 설정이 그대로 남는다.
+        log "경고: $dst 는 이전 설정이 없어(최초 반영) 복구하지 못함 — 검증 실패한 설정이 남아 있으니 수동 정리 필요"
+      fi
     done
-    fail "새 nginx 설정이 검증에 실패해 이전 설정으로 복구함. 배포 중단 (트래픽은 기존 프로세스 유지)"
+    fail "새 nginx 설정이 검증에 실패함. 배포 중단 (트래픽은 기존 프로세스 유지 — 복구 결과는 위 로그 참조)"
   fi
   sudo /usr/bin/systemctl reload nginx
 }

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -17,6 +17,13 @@ set -euo pipefail
 BASE_DIR="/opt/readum"
 RELEASES_DIR="$BASE_DIR/releases"
 UPSTREAM_CONF="/etc/nginx/conf.d/readum-upstream.conf"
+NGINX_SYNC_DIR="$BASE_DIR/nginx"
+# CI 가 NGINX_SYNC_DIR 에 올려두는 nginx 설정 원본(repo infra/nginx)과 실제 적용 경로의 짝. "파일명:적용경로"
+# 적용 경로를 바꾸면 sudoers(infra/sudoers/readum-deploy)의 tee 허용 경로도 함께 바꿔야 한다.
+NGINX_CONF_TARGETS=(
+  "app.conf:/etc/nginx/sites-available/app.conf"
+  "websocket-upgrade.conf:/etc/nginx/conf.d/websocket-upgrade.conf"
+)
 BLUE_PORT=8081
 GREEN_PORT=8082
 READINESS_TIMEOUT_SECONDS=90
@@ -65,6 +72,34 @@ wait_readiness() {
   return 1
 }
 
+# CI 가 올려둔 nginx 설정을 실제 경로와 비교해 달라진 파일만 반영한다.
+# 반영 후 nginx -t 실패 시 이전 내용으로 복구하고 배포를 중단한다 (reload 전이므로 트래픽 무영향).
+sync_nginx_conf() {
+  local entry name src dst backup
+  local applied=()
+  for entry in "${NGINX_CONF_TARGETS[@]}"; do
+    name="${entry%%:*}"; dst="${entry#*:}"
+    src="$NGINX_SYNC_DIR/$name"
+    [[ -f "$src" ]] || continue   # 서버에서 수동 실행 등 원본이 없으면 건너뜀
+    cmp -s "$src" "$dst" 2>/dev/null && continue
+    backup="$NGINX_SYNC_DIR/$name.prev"
+    [[ -f "$dst" ]] && cat "$dst" > "$backup"
+    log "nginx 설정 갱신: $dst"
+    sudo /usr/bin/tee "$dst" < "$src" >/dev/null
+    applied+=("$backup:$dst")
+  done
+  [[ ${#applied[@]} -gt 0 ]] || return 0
+  if ! sudo /usr/sbin/nginx -t; then
+    log "nginx 설정 검증 실패 — 이전 설정으로 복구"
+    for entry in "${applied[@]}"; do
+      backup="${entry%%:*}"; dst="${entry#*:}"
+      [[ -f "$backup" ]] && sudo /usr/bin/tee "$dst" < "$backup" >/dev/null
+    done
+    fail "새 nginx 설정이 검증에 실패해 이전 설정으로 복구함. 배포 중단 (트래픽은 기존 프로세스 유지)"
+  fi
+  sudo /usr/bin/systemctl reload nginx
+}
+
 switch_traffic_to() {
   local port="$1"
   log "nginx upstream 을 127.0.0.1:$port 로 전환"
@@ -111,6 +146,8 @@ activate() {
 cmd_deploy() {
   local jar="${1:-}"
   [[ -n "$jar" && -f "$jar" ]] || fail "사용법: deploy.sh deploy <jar 경로>"
+
+  sync_nginx_conf
 
   local active target
   active="$(active_color)"

--- a/infra/scripts/setup.sh
+++ b/infra/scripts/setup.sh
@@ -4,8 +4,8 @@
 #   sudo ./setup.sh <repo 의 infra 디렉토리 경로>
 #
 # 이 스크립트가 하는 일: 디렉토리 구조 / systemd 유닛 / sudoers 설치.
-# 하지 않는 일(운영 트래픽에 영향을 주는 것들 — docs/ops/infrastructure.md 의 절차로 수동 수행):
-#   - nginx 설정 교체와 reload (전환 시점을 사람이 정해야 함)
+# 하지 않는 일(docs/ops/infrastructure.md 의 절차로 수행):
+#   - nginx 설정 교체와 reload (배포 파이프라인의 deploy.sh sync_nginx_conf 가 변경분만 반영)
 #   - Docker·Redis 설치와 기동
 #   - 스왑 증설
 set -euo pipefail
@@ -18,7 +18,7 @@ INFRA_DIR="${1:-}"
 [[ "$(id -u)" -eq 0 ]] || { echo "sudo 로 실행해야 한다" >&2; exit 1; }
 
 echo "==> /opt/readum 디렉토리 구조"
-mkdir -p /opt/readum/{blue,green,releases,bin}
+mkdir -p /opt/readum/{blue,green,releases,bin,nginx}
 chown -R ubuntu:ubuntu /opt/readum
 
 echo "==> systemd 유닛 설치"

--- a/infra/sudoers/readum-deploy
+++ b/infra/sudoers/readum-deploy
@@ -12,4 +12,6 @@ ubuntu ALL=(root) NOPASSWD: /usr/bin/systemctl start readum-blue, \
   /usr/bin/systemctl disable readum-green, \
   /usr/bin/systemctl reload nginx, \
   /usr/sbin/nginx -t, \
-  /usr/bin/tee /etc/nginx/conf.d/readum-upstream.conf
+  /usr/bin/tee /etc/nginx/conf.d/readum-upstream.conf, \
+  /usr/bin/tee /etc/nginx/sites-available/app.conf, \
+  /usr/bin/tee /etc/nginx/conf.d/websocket-upgrade.conf


### PR DESCRIPTION
## 작업 사항

dev Swagger 를 외부에 공개하려고 nginx 차단을 걷어내는 김에, "nginx 설정 변경은 서버에 손으로 반영"이라는 기존 구조 자체를 배포 파이프라인 자동 반영으로 바꾼다. 지금까지 nginx 설정(app.conf 등)은 repo 가 원본이지만 서버 반영은 sudo cp + reload 수동 절차였고, PR #146 처럼 "서버와 repo 가 어긋난 상태"가 반복되는 원인이었다.

방식은 기존 upstream 전환과 동일한 패턴이다. CI(deploy.yml)가 infra/nginx/*.conf 를 서버 스테이징 디렉토리(/opt/readum/nginx/)에 올려 두면, deploy.sh 의 sync_nginx_conf 가 실제 경로와 비교해 달라진 파일만 sudo tee 로 반영하고 nginx -t 검증 후 reload 한다. 검증에 실패하면 이전 내용으로 복구하고 배포를 중단하므로 잘못된 설정이 트래픽에 닿지 않는다 (reload 전 중단이라 무영향).

이를 위해 sudoers 의 "root 권한 불필요 원칙"을 한 뼘 완화한다 — 고정 경로 tee 두 줄(sites-available/app.conf, conf.d/websocket-upgrade.conf)만 추가 허용한다. upstream 파일은 이미 같은 방식으로 열려 있어 새로운 종류의 권한은 아니다. systemd·sudoers 파일 자체는 여전히 수동(setup.sh) 반영이다 — sudoers 를 CI 가 갱신하는 구조는 권한 상승이라 두지 않는다.

Swagger 공개는 nginx 의 /swagger-ui·/v3/api-docs 차단(return 404) 삭제만으로 끝난다 — Spring Security 는 이미 permitAll, springdoc 은 dev 프로파일에서만 켜져 있어 다른 환경에 영향이 없다. Actuator 차단은 그대로 유지한다.

### 기능

**nginx 설정 자동 반영**
- infra/nginx/*.conf 를 고치고 dev 에 머지하면 다음 배포에서 서버에 자동 반영된다
- 새 설정이 nginx -t 검증에 실패하면 이전 설정으로 복구하고 배포가 중단된다 (트래픽 무영향)
- 변경이 없으면 아무것도 하지 않는다 (매 배포 불필요한 reload 없음)

**dev Swagger 공개**
- https://api.readum.kr/swagger-ui.html 을 SSH 터널 없이 브라우저에서 바로 볼 수 있다 (프론트 협업용)

## 테스트 결과
- [x] bash -n 으로 deploy.sh·setup.sh 문법 검증
- [x] 앱 코드 변경 없음 — 기존 테스트 영향 없음
- [ ] 서버 sudoers 갱신(아래 선행 절차) 후 첫 배포에서 sync_nginx_conf 동작 확인
- [ ] 배포 후 https://api.readum.kr/swagger-ui.html 접속 확인

## 관련 이슈
- 없음

## 참고 사항

**머지 전 선행 절차 (1회)**: 새 sudoers 가 서버에 깔리기 전에 이 PR 이 배포되면 sync_nginx_conf 의 sudo tee 가 거부돼 배포가 실패한다 (트래픽은 무영향, 기존 프로세스 유지). 머지 전에 서버에서 한 번 실행:

    cd <repo> && git pull && sudo ./infra/scripts/setup.sh ./infra

**보안 트레이드오프**: dev Swagger 가 인증 없이 공개된다 (API 명세 전체 노출). 부담되면 후속으로 nginx allow/deny 로 팀 IP 만 여는 절충안이 있다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 배포 과정에서 Nginx 설정이 함께 자동 반영되도록 개선되었습니다.
  * 설정 검증에 실패하면 이전 상태로 되돌린 뒤 배포를 중단해 안정성이 높아졌습니다.

* **개선**
  * 배포 전에 필요한 Nginx 디렉토리가 자동 생성되도록 정리되었습니다.
  * WebSocket 관련 설정이 배포 흐름에 포함되었습니다.

* **문서**
  * 배포 및 인프라 안내 문서가 최신 동작에 맞게 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->