### PR TITLE
feat(config): local 프로파일 도입 + dev 콘솔 로그 INFO 전환

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@
 # 로컬 컨테이너(MySQL·Redis)는 infra/docker/docker-compose.local.yml 로 띄운다.
 # 주의: SERVER_PORT 를 넣지 말 것 — systemd 유닛의 blue/green 포트 지정을 덮어쓴다.
 
+# 프로파일: 로컬은 local (콘솔 로그만, Slack 알림 안 붙음), 개발 서버는 dev (CI 의 ENV_FILE secret 이 지정)
+SPRING_PROFILES_ACTIVE=local
+
 # MySQL (개발 서버 = 같은 호스트의 Docker 컨테이너, 로컬 = docker-compose.local.yml)
 MYSQL_HOST=127.0.0.1
 MYSQL_PORT=3306
@@ -20,8 +23,9 @@ JWT_SECRET=jsaTiXce4yBit2Qg8JOS8U7qH2kNg8d7+MJTieGkFg67vmSldN/fggYfK2dXR4X+
 # OpenAI (AI 채팅·감상문 생성)
 OPENAI_API_KEY=sk-your-key
 
-# Slack 알림 webhook
-SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+# Slack 알림 webhook — 로컬에서는 비워둔다 (local 프로파일은 Slack 이 아예 안 붙고,
+# 실수로 dev 프로파일로 돌려도 빈 값이면 appender 가 기동하지 않아 로컬 ERROR 가 팀 채널로 가지 않는다)
+SLACK_WEBHOOK_URL=
 
 # 알라딘 도서 검색 API
 ALADIN_TTB_KEY=your-ttb-key

--- a/infra/docker/docker-compose.local.yml
+++ b/infra/docker/docker-compose.local.yml
@@ -2,7 +2,7 @@
 # repo 루트에서 기동:
 #   docker compose -f infra/docker/docker-compose.local.yml up -d
 #
-# 접속값 기본치는 .env.example 과 맞춰져 있어 별도 설정 없이 앱(dev 프로파일, MYSQL_HOST=localhost)이 붙는다.
+# 접속값 기본치는 .env.example 과 맞춰져 있어 별도 설정 없이 앱(local 프로파일, MYSQL_HOST=localhost)이 붙는다.
 # 값을 바꾸려면 환경변수로 덮어쓴다 (예: MYSQL_PASSWORD=... docker compose ...).
 services:
   mysql:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -66,11 +66,12 @@ readum:
       # 외부 Moderation API 장애 시 차단 우선(503). OPEN 은 개발 환경에서만 명시 전환.
       failure-policy: CLOSED
 
+# 콘솔(journald)에는 앱 코드 DEBUG 만 살린다. 파일은 logback 필터가 INFO 이상만 남긴다.
+# org.hibernate.SQL DEBUG 는 두지 않는다 — 워커 폴링 SELECT(2초 주기)가 콘솔을 도배하고,
+# 파일에는 어차피 INFO 필터로 안 남아 실익이 없다. SQL 관찰은 MySQL slow_log(TABLE)를 쓴다.
 logging:
   level:
     com.readum: DEBUG
-    org.hibernate.SQL: DEBUG
-    org.hibernate.orm.jdbc.bind: WARN
 
 aladin:
   ttb-key: ${ALADIN_TTB_KEY:}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,86 @@
+# 로컬 개발 프로파일 (SPRING_PROFILES_ACTIVE=local).
+# 접속 대상은 로컬 컨테이너(infra/docker/docker-compose.local.yml 의 MySQL·Redis)다.
+# logback 은 local 블록(콘솔만)이 켜진다 — 파일(/var/log/readum)도 Slack 알림도 붙지 않으므로
+# 로컬에서 난 ERROR 가 팀 채널로 가지 않는다. 서버(dev 프로파일)와 다른 점은 로그 목적지뿐이고,
+# 그 외 값은 dev 와 같게 유지한다 (로컬-서버 동작 차이 최소화 — 값을 바꿀 땐 application-dev.yml 과 함께 검토).
+spring:
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat:
+        options:
+          model: gpt-4o-mini
+          stream-usage: true
+          # max-tokens 를 두지 않는 이유는 application-dev.yml 의 같은 항목 주석 참조.
+      moderation:
+        options:
+          model: omni-moderation-latest
+  datasource:
+    url: jdbc:mysql://${MYSQL_HOST:127.0.0.1}:${MYSQL_PORT:3306}/${MYSQL_DATABASE:readum}?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    username: ${MYSQL_USER:readum}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    # Hikari 풀은 기본값(10)을 그대로 쓴다 — dev 의 24 는 서버의 워커·웹 동시성 계산값이라 로컬엔 불필요.
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+  data:
+    redis:
+      host: ${REDIS_HOST:127.0.0.1}
+      port: 6379
+      password: ${REDIS_PASSWORD}
+
+readum:
+  guardrail:
+    input:
+      max-characters: 4000
+      max-tokens: 1500
+    output:
+      max-response-tokens: 1024
+    moderation:
+      model: omni-moderation-latest
+      # 카테고리 구성은 dev 와 동일하게 둔다 — 로컬에서만 다르면 가드레일 동작을 로컬에서 검증할 수 없다.
+      always-block-categories:
+        - self-harm
+        - self-harm-intent
+        - self-harm-instructions
+        - sexual-minors
+        - dangerous-and-criminal-content
+      book-context-relaxed-categories:
+        - violence
+        - violence-graphic
+        - harassment
+        - harassment-threatening
+        - sexual
+        - hate
+        - hate-threatening
+      failure-policy: CLOSED
+
+# 콘솔에는 앱 코드 DEBUG 만 살린다 (logback local root=INFO 와 짝 — dev 와 같은 원칙).
+logging:
+  level:
+    com.readum: DEBUG
+
+aladin:
+  ttb-key: ${ALADIN_TTB_KEY:}
+  base-url: https://www.aladin.co.kr/ttb/api
+  search-target: Book
+  output: JS
+  version: 20131101
+  cover: Big
+  request-timeout: PT3S
+  search-result-limit: 200
+
+springdoc:
+  api-docs:
+    enabled: true
+    path: /v3/api-docs
+  swagger-ui:
+    enabled: true
+    path: /swagger-ui.html
+    operations-sorter: method
+    tags-sorter: alpha
+    display-request-duration: true

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -52,7 +52,7 @@
         <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
             <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file>
             <append>true</append>
-            <!-- root 가 DEBUG 라도 파일에는 INFO 이상만 남긴다 (DEBUG 는 콘솔에서만 확인) -->
+            <!-- root 레벨과 무관하게 파일에는 INFO 이상만 남긴다 (로거별 DEBUG 는 콘솔에서만 확인) -->
             <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
                 <level>INFO</level>
             </filter>
@@ -110,7 +110,12 @@
             <appender-ref ref="AI_PROMPT_AUDIT_FILE"/>
         </logger>
 
-        <root level="DEBUG">
+        <!--
+            root 는 INFO — 워커 폴링(감상문·컨텍스트 요약, 2초 주기 × 풀 16)이 프레임워크 DEBUG
+            (lettuce·Hibernate·JPA 트랜잭션)를 journald 에 도배해 콘솔 로그를 못 쓰게 만들기 때문.
+            앱 코드 DEBUG 는 application-dev.yml 의 logging.level.com.readum 이 콘솔에 살린다.
+        -->
+        <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>
             <appender-ref ref="ASYNC_SLACK_ERROR"/>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -40,9 +40,11 @@
         </encoder>
     </appender>
 
-    <!-- ================= local : 콘솔만 ================= -->
+    <!-- ================= local : 콘솔만 (파일·Slack 없음 — 로컬 ERROR 가 팀 채널로 가지 않는다) ================= -->
     <springProfile name="local">
-        <root level="DEBUG">
+        <!-- root 는 INFO — dev 와 같은 이유(워커 폴링의 프레임워크 DEBUG 도배).
+             앱 코드 DEBUG 는 application-local.yml 의 logging.level.com.readum 이 살린다. -->
+        <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>
     </springProfile>


### PR DESCRIPTION
## 작업 사항

dev 서버 journalctl 을 열면 2초 주기 워커 폴링(감상문 12 + 컨텍스트 요약 4 스레드)이 찍는 lettuce Redis 프로토콜·Hibernate SQL·JPA 트랜잭션 DEBUG 가 초당 수십 줄씩 쏟아져, 정작 봐야 할 앱 로그를 콘솔에서 찾을 수 없는 상태다 (Slack 알림 미수신 원인을 조사하다 확인). 원인은 두 겹 — logback dev 프로파일의 root 가 DEBUG 라 모든 프레임워크 DEBUG 가 콘솔(journald)로 가고, application-dev.yml 의 org.hibernate.SQL DEBUG 가 폴링 SELECT 전문을 추가로 찍는다. 파일 로그는 INFO 필터 + 롤링 상한(20MB × 총 500MB)이 있어 무사하지만, journald 는 이 볼륨을 그대로 받고 있었다.

고침: dev root 를 INFO 로 내리고 org.hibernate.SQL DEBUG 를 제거한다. 앱 코드 DEBUG(com.readum)는 콘솔에 그대로 살린다 — "DEBUG 는 콘솔에서만"이라는 기존 의도를 앱 코드에 한해 유지한다. SQL 관찰이 필요하면 콘솔이 아니라 MySQL slow_log(TABLE, 이미 켜져 있음)를 쓴다.

이어서 local 프로파일을 실체화한다. logback 에는 처음부터 local 블록(콘솔만)이 준비돼 있었지만 application-local.yml 이 없어 죽은 설정이었고, 로컬 개발도 dev 프로파일로 돌리고 있었다. 이 상태에서는 logback dev 블록이 로컬에서도 켜져 — 로컬 .env 에 진짜 SLACK_WEBHOOK_URL 이 들어가면 로컬 테스트 중 난 ERROR 가 팀 채널로 날아가고, /var/log/readum 파일 로그 시도가 기동 경고를 낸다. application-local.yml 을 추가해 로컬은 local 프로파일로 돌린다: 접속값은 로컬 컨테이너(docker-compose.local.yml) 기준, 그 외 값(가드레일·알라딘·springdoc)은 dev 와 동일하게 유지해 로컬-서버 동작 차이를 만들지 않는다.

### 기능 (운영/개발 환경)

**dev 서버 콘솔 로그 가독성**
- journalctl 에서 워커 폴링 도배가 사라져 앱 로그(com.readum DEBUG 포함)를 눈으로 볼 수 있다
- journald 디스크 쓰기 볼륨이 크게 줄어든다

**로컬 개발 환경 분리**
- SPRING_PROFILES_ACTIVE=local 로 로컬 실행 — 콘솔 로그만 사용, Slack 알림·파일 로그가 아예 붙지 않아 로컬 ERROR 가 팀 채널로 가지 않는다
- .env.example 에 프로파일 안내와 "로컬은 SLACK_WEBHOOK_URL 비워두기" 명시

## 테스트 결과
- [x] 빌드 통과 (설정 파일만 변경, 앱 코드 무변경)
- [ ] 배포 후 journalctl 에서 폴링 DEBUG 가 사라지고 com.readum DEBUG 는 남는지 확인
- [ ] 로컬에서 SPRING_PROFILES_ACTIVE=local + docker-compose.local.yml 로 기동 확인

## 관련 이슈
- 없음

## 참고 사항

- 팀원 각자 로컬 .env 에 `SPRING_PROFILES_ACTIVE=local` 로 바꿔야 local 프로파일이 적용된다 (dev 로 두면 기존과 동일하게 동작하되, SLACK_WEBHOOK_URL 이 비어 있는 한 알림은 나가지 않는다).
- 이미 쌓인 journald 용량은 이 PR 로 줄지 않는다. 확인: `journalctl --disk-usage` / 정리: `sudo journalctl --vacuum-size=300M`