### PR TITLE
refactor(config): 환경 무관 설정을 application.yml 로 승격하고 프로파일 중복 제거

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,17 +1,6 @@
+# 개발 서버 프로파일 (SPRING_PROFILES_ACTIVE=dev). 환경별 값만 둔다 —
+# 환경 무관 값(openai 옵션·jpa·guardrail·aladin)은 application.yml 이 정본이다.
 spring:
-  ai:
-    openai:
-      api-key: ${OPENAI_API_KEY}
-      chat:
-        options:
-          model: gpt-4o-mini
-          stream-usage: true
-          # max-tokens 를 두지 않는다 — 응답을 중간에 자르는 하드 스톱이라 어느 경로에도 걸지 않는다.
-          # 특히 컨텍스트 누적 요약은 잘리면 정보가 유실되므로 절대 금지(압축 스펙 8절).
-          # 비용 상한은 truncation 이 아니라 사용자 토큰 예산(Redis 4h/20k) + 전역 게이트가 담당한다.
-      moderation:
-        options:
-          model: omni-moderation-latest
   datasource:
     # sslMode 미지정 = PREFERRED (서버가 지원하면 TLS). RDS 시절의 REQUIRED 는 컨테이너 이관으로 제거 —
     # MySQL 이 127.0.0.1 에만 바인딩되어 루프백 구간 강제 TLS 는 실익이 없다.
@@ -26,45 +15,11 @@ spring:
     # (minimum-idle 미지정 시 Hikari 가 max 와 같게 잡아 고정 크기)
     hikari:
       maximum-pool-size: 24
-  jpa:
-    hibernate:
-      ddl-auto: validate
-    properties:
-      hibernate:
-        format_sql: true
   data:
     redis:
       host: ${REDIS_HOST:127.0.0.1}   # 앱은 호스트에서 systemd 로 돌고 Redis 는 루프백 바인딩
       port: 6379
       password: ${REDIS_PASSWORD}
-
-readum:
-  guardrail:
-    input:
-      max-characters: 4000
-      max-tokens: 1500
-    output:
-      max-response-tokens: 1024
-    moderation:
-      model: omni-moderation-latest
-      # 책 맥락 유무와 무관하게 항상 차단. 카테고리 이름 정본은 OpenAiInputModerationClientImpl 레지스트리.
-      always-block-categories:
-        - self-harm
-        - self-harm-intent
-        - self-harm-instructions
-        - sexual-minors
-        - dangerous-and-criminal-content
-      # 책 맥락(독서 토론) 이 있을 때만 통과시키는 카테고리.
-      book-context-relaxed-categories:
-        - violence
-        - violence-graphic
-        - harassment
-        - harassment-threatening
-        - sexual
-        - hate
-        - hate-threatening
-      # 외부 Moderation API 장애 시 차단 우선(503). OPEN 은 개발 환경에서만 명시 전환.
-      failure-policy: CLOSED
 
 # 콘솔(journald)에는 앱 코드 DEBUG 만 살린다. 파일은 logback 필터가 INFO 이상만 남긴다.
 # org.hibernate.SQL DEBUG 는 두지 않는다 — 워커 폴링 SELECT(2초 주기)가 콘솔을 도배하고,
@@ -72,16 +27,6 @@ readum:
 logging:
   level:
     com.readum: DEBUG
-
-aladin:
-  ttb-key: ${ALADIN_TTB_KEY:}
-  base-url: https://www.aladin.co.kr/ttb/api
-  search-target: Book
-  output: JS
-  version: 20131101
-  cover: Big
-  request-timeout: PT3S
-  search-result-limit: 200
 
 springdoc:
   api-docs:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,78 +1,25 @@
-# 로컬 개발 프로파일 (SPRING_PROFILES_ACTIVE=local).
+# 로컬 개발 프로파일 (SPRING_PROFILES_ACTIVE=local). 환경별 값만 둔다 —
+# 환경 무관 값(openai 옵션·jpa·guardrail·aladin)은 application.yml 이 정본이다.
 # 접속 대상은 로컬 컨테이너(infra/docker/docker-compose.local.yml 의 MySQL·Redis)다.
 # logback 은 local 블록(콘솔만)이 켜진다 — 파일(/var/log/readum)도 Slack 알림도 붙지 않으므로
-# 로컬에서 난 ERROR 가 팀 채널로 가지 않는다. 서버(dev 프로파일)와 다른 점은 로그 목적지뿐이고,
-# 그 외 값은 dev 와 같게 유지한다 (로컬-서버 동작 차이 최소화 — 값을 바꿀 땐 application-dev.yml 과 함께 검토).
+# 로컬에서 난 ERROR 가 팀 채널로 가지 않는다. dev 와 다른 점은 접속 대상·로그 목적지·풀 크기뿐이다.
 spring:
-  ai:
-    openai:
-      api-key: ${OPENAI_API_KEY}
-      chat:
-        options:
-          model: gpt-4o-mini
-          stream-usage: true
-          # max-tokens 를 두지 않는 이유는 application-dev.yml 의 같은 항목 주석 참조.
-      moderation:
-        options:
-          model: omni-moderation-latest
   datasource:
     url: jdbc:mysql://${MYSQL_HOST:127.0.0.1}:${MYSQL_PORT:3306}/${MYSQL_DATABASE:readum}?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: ${MYSQL_USER:readum}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
     # Hikari 풀은 기본값(10)을 그대로 쓴다 — dev 의 24 는 서버의 워커·웹 동시성 계산값이라 로컬엔 불필요.
-  jpa:
-    hibernate:
-      ddl-auto: validate
-    properties:
-      hibernate:
-        format_sql: true
   data:
     redis:
       host: ${REDIS_HOST:127.0.0.1}
       port: 6379
       password: ${REDIS_PASSWORD}
 
-readum:
-  guardrail:
-    input:
-      max-characters: 4000
-      max-tokens: 1500
-    output:
-      max-response-tokens: 1024
-    moderation:
-      model: omni-moderation-latest
-      # 카테고리 구성은 dev 와 동일하게 둔다 — 로컬에서만 다르면 가드레일 동작을 로컬에서 검증할 수 없다.
-      always-block-categories:
-        - self-harm
-        - self-harm-intent
-        - self-harm-instructions
-        - sexual-minors
-        - dangerous-and-criminal-content
-      book-context-relaxed-categories:
-        - violence
-        - violence-graphic
-        - harassment
-        - harassment-threatening
-        - sexual
-        - hate
-        - hate-threatening
-      failure-policy: CLOSED
-
 # 콘솔에는 앱 코드 DEBUG 만 살린다 (logback local root=INFO 와 짝 — dev 와 같은 원칙).
 logging:
   level:
     com.readum: DEBUG
-
-aladin:
-  ttb-key: ${ALADIN_TTB_KEY:}
-  base-url: https://www.aladin.co.kr/ttb/api
-  search-target: Book
-  output: JS
-  version: 20131101
-  cover: Big
-  request-timeout: PT3S
-  search-result-limit: 200
 
 springdoc:
   api-docs:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,12 @@ spring:
   # 엔티티에 JPA 연관관계가 0개라 트랜잭션 밖 LAZY 접근이 없어 LazyInitializationException 위험이 없다.
   jpa:
     open-in-view: false
+    # 스키마 정본은 Flyway. Hibernate 는 엔티티와 대조만 한다(환경 무관). 테스트는 자체 yml 에서 create-drop.
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
   # 블로킹 I/O(입력 moderation 동기 호출 등)를 값싸게 대량 동시 처리 (#103). Java 25 라 synchronized 핀닝은 사실상 해소됨.
   threads:
     virtual:
@@ -15,6 +21,19 @@ spring:
         log-prompt: false
         log-completion: false
         include-error-logging: true
+    # 모델·옵션은 환경 무관(코드 동작). api-key 만 환경변수. (프로파일별로 다르지 않다)
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat:
+        options:
+          model: gpt-4o-mini
+          stream-usage: true
+          # max-tokens 를 두지 않는다 — 응답을 중간에 자르는 하드 스톱이라 어느 경로에도 걸지 않는다.
+          # 특히 컨텍스트 누적 요약은 잘리면 정보가 유실되므로 절대 금지(압축 스펙 8절).
+          # 비용 상한은 truncation 이 아니라 사용자 토큰 예산(Redis 4h/20k) + 전역 게이트가 담당한다.
+      moderation:
+        options:
+          model: omni-moderation-latest
   # @Scheduled 3개(6시 적재 · dispatch · reaper)가 단일 스레드에서 직렬화되지 않도록 풀 분리.
   task:
     scheduling:
@@ -65,6 +84,46 @@ ai-chat:
     thread-cap: 32                       # 동시 제목 생성 상한. 스레드는 lazy 생성 + 60초 유휴 회수라 평소엔 0 에 수렴.
                                          # 저빈도 백그라운드라 32 면 충분. 전용 ChatClient 의 10초 responseTimeout 이 매달린 호출을 끊어 blast-radius 를 시간으로 제한.
     queue-cap: 64                        # backing thread 1개당 큐 한도(per-thread). 전역 backlog 상한 = thread-cap × queue-cap = 32 × 64 ≈ 2,048. 초과 시 RejectedExecutionException(로그 후 스킵).
+
+# 입출력 가드레일 — 환경 무관 비즈니스 룰. moderation 카테고리 정본은 OpenAiInputModerationClientImpl 레지스트리.
+readum:
+  guardrail:
+    input:
+      max-characters: 4000
+      max-tokens: 1500
+    output:
+      max-response-tokens: 1024
+    moderation:
+      model: omni-moderation-latest
+      # 책 맥락 유무와 무관하게 항상 차단.
+      always-block-categories:
+        - self-harm
+        - self-harm-intent
+        - self-harm-instructions
+        - sexual-minors
+        - dangerous-and-criminal-content
+      # 책 맥락(독서 토론) 이 있을 때만 통과시키는 카테고리.
+      book-context-relaxed-categories:
+        - violence
+        - violence-graphic
+        - harassment
+        - harassment-threatening
+        - sexual
+        - hate
+        - hate-threatening
+      # 외부 Moderation API 장애 시 차단 우선(503). OPEN 은 개발 환경에서만 명시 전환(프로파일에서 override).
+      failure-policy: CLOSED
+
+# 알라딘 도서 검색 API — 외부 스펙이라 환경 무관. ttb-key 만 환경변수.
+aladin:
+  ttb-key: ${ALADIN_TTB_KEY:}
+  base-url: https://www.aladin.co.kr/ttb/api
+  search-target: Book
+  output: JS
+  version: 20131101
+  cover: Big
+  request-timeout: PT3S
+  search-result-limit: 200
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## 작업 사항

local 프로파일을 도입하면서(#150) application-local.yml 이 application-dev.yml 을 거의 복제하게 됐고, 그 과정에서 openai 옵션·guardrail·aladin 같은 **환경별로 다르지 않은 값**이 두 프로파일에 중복으로 들어갔다. 근본 원인은 dev 프로파일 하나만 있던 시절 environment-agnostic 값까지 application-dev.yml 에 모여 있던 것 — CLAUDE.md 규칙 10("환경 무관 비즈니스 룰은 application.yml, 환경별 값은 application-{profile}.yml")과 어긋난 상태였다.

환경 무관 값을 application.yml 로 승격해 정본을 하나로 모으고, 프로파일 파일에는 실제로 환경마다 다른 값만 남긴다. 이러면 중복이 사라질 뿐 아니라, 프로파일에서 키가 누락돼도 다른 환경 값으로 새지 않는다(datasource 처럼 환경별 값은 각 프로파일이 완결적으로 소유).

분류 기준:
- **환경 무관 → application.yml**: `spring.ai.openai`(모델·옵션·api-key 플레이스홀더), `spring.jpa.hibernate`(ddl-auto·format_sql), `readum.guardrail`, `aladin`(외부 API 스펙)
- **환경별 → 프로파일 유지**: `datasource`·`redis`(접속 대상이 환경마다 다름), `hikari` 풀 크기(dev=24 / local=기본 10), `logging.level`, `springdoc`(dev/local=on, application.yml 기본=off)

테스트는 `src/test/resources/application.yml` 로 자체 완결(H2·create-drop)이라 메인 application.yml 을 대체하므로, 이 이동의 영향을 받지 않는다.

### 기능 (설정 구조)

**중복 제거**
- openai 옵션·guardrail·aladin 이 local/dev 두 곳에 복제돼 있던 것을 application.yml 한 곳으로 통합
- 가드레일 카테고리 목록처럼 긴 블록을 한 벌만 유지 — 한쪽만 고쳐 어긋날 위험 제거

**누락 안전성**
- 프로파일 파일이 환경별 값만 담아, 키 누락 시 다른 환경 값으로 조용히 fallback 하지 않는다

## 테스트 결과
- [x] `./gradlew test` 전체 통과 (설정 이동만, 앱 코드 무변경)
- [x] 세 yml 파일 YAML 파싱 검증
- [x] 이동 대상 값이 삭제가 아니라 application.yml 로 이동했음을 diff 로 확인

## 관련 이슈
- 없음

## 참고 사항

런타임 동작은 동일하다 — dev 프로파일은 application.yml + application-dev.yml 이 겹쳐 로드되므로, 승격한 값들을 그대로 상속받는다(`OPENAI_API_KEY` 등 환경변수 주입 경로도 동일). 서버 재배포만으로 반영되며 추가 조치가 필요 없다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI 응답과 책 검색 관련 기본 설정이 추가되어 챗봇 및 도서 검색 기능이 더 안정적으로 동작합니다.
  * 입력/출력 제한과 콘텐츠 필터링 기준이 적용되어 안전성이 강화되었습니다.

* **Bug Fixes**
  * 개발·로컬 환경 설정을 정리해 환경별 동작 차이를 줄이고, 로그 및 데이터베이스 설정이 더 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->