### PR TITLE
fix: slack-receiver 배포 시 compose 파일도 서버로 전송

### DIFF
--- a/.github/workflows/slack-receiver-deploy.yml
+++ b/.github/workflows/slack-receiver-deploy.yml
@@ -31,15 +31,15 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts
 
-      - name: 이미지 전송 + load + 재기동
+      - name: compose 파일·이미지 전송 → load → 재기동
         run: |
           scp -i ~/.ssh/deploy_key slack-receiver.tar.gz "ubuntu@${DEPLOY_HOST}:/opt/readum/slack-receiver.tar.gz"
+          scp -i ~/.ssh/deploy_key infra/docker/docker-compose.dev.yml "ubuntu@${DEPLOY_HOST}:/opt/readum/docker-compose.dev.yml"
           ssh -i ~/.ssh/deploy_key "ubuntu@${DEPLOY_HOST}" '
             set -e
             gunzip -f /opt/readum/slack-receiver.tar.gz
             sudo docker load -i /opt/readum/slack-receiver.tar
             rm -f /opt/readum/slack-receiver.tar
-            cd /opt/readum
             sudo docker compose --env-file /opt/readum/.env \
-              -f ~/18th-team4-server/infra/docker/docker-compose.dev.yml up -d slack-receiver
+              -f /opt/readum/docker-compose.dev.yml up -d slack-receiver
           '


### PR DESCRIPTION
## 문제

PR #153 머지 후 `slack-receiver-deploy` 배포가 `no such service: slack-receiver` 로 실패. 이미지는 서버에 정상 load 됐으나, 배포가 `-f ~/18th-team4-server/infra/docker/docker-compose.dev.yml`(서버의 수동 git 체크아웃)로 compose 를 실행하는데 그 사본이 stale 해서 `slack-receiver` 서비스가 없었다.

원인: 배포는 이미지(tar)만 서버로 보내고 compose 파일은 보내지 않았다. 서버 소스 사본은 배포 때 자동 갱신되지 않는다.

## 변경

- 배포 워크플로우가 `infra/docker/docker-compose.dev.yml` 도 `/opt/readum/` 로 scp 하고, 그 경로로 컨테이너를 기동한다. 서버 git 체크아웃 상태에 의존하지 않는다.

## 효과

- 이 PR 이 dev 에 머지되면 (workflow 파일이 paths 트리거에 포함되므로) 배포가 다시 돌며 slack-receiver 가 정상 기동된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)