### PR TITLE
fix(exception): NoResourceFoundException 을 404 로 처리해 불필요한 ERROR 알림 방지

### DIFF
--- a/src/main/java/com/readum/presentation/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/readum/presentation/common/GlobalExceptionHandler.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -60,6 +61,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<GlobalApiResponse<?>> handleNotFound(NotFoundException ex) {
         log.warn("Not found: {}", ex.getErrorCode().getMessage());
         return GlobalApiResponse.error(HttpStatus.NOT_FOUND, ex.getErrorCode().getMessage());
+    }
+
+    // Spring MVC - 매핑되지 않은 경로 요청 (외부 봇의 .env, .git 스캔 등)
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<GlobalApiResponse<?>> handleNoResourceFound(NoResourceFoundException ex) {
+        log.warn("존재하지 않는 리소스 요청: {}", ex.getResourcePath());
+        return GlobalApiResponse.error(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다.");
     }
 
     // 도메인 비즈니스 예외 - 처리 불가 엔티티 (422)


### PR DESCRIPTION
## 문제
Spring 의 `NoResourceFoundException`(존재하지 않는 경로 요청)이 전용 핸들러 없이 catch-all `Exception` 핸들러로 빠져 **500 응답 + ERROR 로그 → Slack 장애 알림**이 발생했다. 외부 봇이 `/api/.env` 같은 경로를 스캔할 때마다 장애가 아닌데 장애 알림이 오는 상태.

## 변경
- `GlobalExceptionHandler` 에 `NoResourceFoundException` 전용 핸들러 추가
- **404 응답 + WARN 로그**로 처리 → Slack ERROR 알림 대상에서 제외

## 효과
- 외부 봇 스캔 등 존재하지 않는 경로 요청이 더 이상 Slack 장애 알림을 발생시키지 않는다
- catch-all 핸들러에는 진짜 예기치 못한 서버 오류만 남는다

🤖 Generated with [Claude Code](https://claude.com/claude-code)