### PR TITLE
fix(logging): Slack 장애 분석 버튼이 분석 요청을 건너뛰던 문제 해결

### DIFF
--- a/infra/slack-receiver/README.md
+++ b/infra/slack-receiver/README.md
@@ -7,6 +7,14 @@ Slack 장애 알림의 "분석 이슈 만들기" 버튼 클릭을 받아 GitHub 
 Slack 버튼 → nginx `/slack/incident-actions` → 이 서비스(:8090) → GitHub repository_dispatch
 → `.github/workflows/incident-analysis.yml`
 
+## 장애 필드는 버튼 value 에서 읽는다
+fingerprint·deploy·traceId·message·stacktrace 는 앱(`SlackWebhookAppender`)이 "분석 이슈 만들기"
+버튼의 `value` 에 구조화 JSON 으로 실어 보내고, 이 수신기는 클릭된 버튼의 `value` 를 그대로 읽는다.
+Slack 상호작용 payload 의 `message.text`(사람이 보는 표시 본문)를 regex 로 긁던 옛 방식은 실제
+payload 에서 `message.text` 를 신뢰할 수 없어 fingerprint·deploy 가 비어 dispatch 가 건너뛰어졌다.
+`value` 는 클릭된 버튼에 Slack 이 항상 실어 보내므로 견고하다. 옛 메시지(값이 fingerprint 문자열)나
+value 누락 시에는 본문 스크래핑으로 폴백한다.
+
 ## 필요한 환경변수 (서버 /opt/readum/.env = ENV_FILE secret)
 - `SLACK_SIGNING_SECRET` — Slack 앱 Basic Information 의 Signing Secret
 - `INCIDENT_DISPATCH_TOKEN` — GitHub 토큰. fine-grained PAT 로 이 저장소 **Contents: Read and write**

--- a/infra/slack-receiver/parse.go
+++ b/infra/slack-receiver/parse.go
@@ -16,6 +16,11 @@ type Incident struct {
 	Stacktrace  string
 }
 
+type slackAction struct {
+	ActionID string `json:"action_id"`
+	Value    string `json:"value"`
+}
+
 type slackInteraction struct {
 	Type    string `json:"type"`
 	Message struct {
@@ -25,10 +30,18 @@ type slackInteraction struct {
 	Channel struct {
 		ID string `json:"id"`
 	} `json:"channel"`
-	ResponseURL string `json:"response_url"`
-	Actions     []struct {
-		ActionID string `json:"action_id"`
-	} `json:"actions"`
+	ResponseURL string        `json:"response_url"`
+	Actions     []slackAction `json:"actions"`
+}
+
+// incidentValue 는 "분석 이슈 만들기" 버튼의 value 에 실린 구조화 장애 정보다.
+// 앱(SlackWebhookAppender)이 버튼을 만들 때 이 JSON 을 value 로 넣는다.
+type incidentValue struct {
+	Fingerprint string `json:"fingerprint"`
+	Deploy      string `json:"deploy"`
+	TraceID     string `json:"traceId"`
+	Message     string `json:"message"`
+	Stacktrace  string `json:"stacktrace"`
 }
 
 var (
@@ -52,7 +65,38 @@ func parseInteraction(body []byte) (*slackInteraction, *Incident, error) {
 	if err := json.Unmarshal([]byte(raw), &si); err != nil {
 		return nil, nil, fmt.Errorf("payload 언마샬 실패: %w", err)
 	}
-	return &si, extractIncident(si.Message.Text), nil
+	// 우선 버튼 value(구조화 JSON)에서 뽑는다. Slack 은 클릭된 버튼의 value 를 항상 실어 보내므로
+	// message.text 스크래핑(본문 포맷에 의존하는 취약한 방식)보다 견고하다.
+	// value 가 없거나(옛 메시지) 비면 본문 스크래핑으로 폴백한다.
+	inc := incidentFromActionValue(si.Actions)
+	if inc == nil {
+		inc = extractIncident(si.Message.Text)
+	}
+	return &si, inc, nil
+}
+
+// incidentFromActionValue 는 클릭된 "분석 이슈 만들기" 버튼의 value 에서 장애 정보를 읽는다.
+//   - value 가 구조화 JSON 이면 그대로 매핑한다.
+//   - value 가 JSON 이 아닌 문자열(옛 포맷 = fingerprint 만 실었던 메시지)이면 fingerprint 로 간주한다.
+//   - 해당 버튼이 없거나 value 가 비어 있으면 nil 을 돌려 본문 스크래핑 폴백에 맡긴다.
+func incidentFromActionValue(actions []slackAction) *Incident {
+	for _, action := range actions {
+		if action.ActionID != createIssueActionID || action.Value == "" {
+			continue
+		}
+		var v incidentValue
+		if err := json.Unmarshal([]byte(action.Value), &v); err == nil && (v.Fingerprint != "" || v.Deploy != "") {
+			return &Incident{
+				Fingerprint: v.Fingerprint,
+				DeploySha:   v.Deploy,
+				TraceID:     v.TraceID,
+				Message:     v.Message,
+				Stacktrace:  v.Stacktrace,
+			}
+		}
+		return &Incident{Fingerprint: action.Value}
+	}
+	return nil
 }
 
 func extractIncident(text string) *Incident {

--- a/infra/slack-receiver/parse_test.go
+++ b/infra/slack-receiver/parse_test.go
@@ -23,13 +23,17 @@ const sampleMessageText = ":rotating_light: *readum ERROR 발생*\n" +
 	"*message*\n```에러 메시지```\n\n" +
 	"*stacktrace*\n```java.lang.NullPointerException\n\tat Foo.bar(Foo.java:1)```\n"
 
+// sampleValueJSON 은 앱(SlackWebhookAppender)이 "분석 이슈 만들기" 버튼 value 에 싣는 구조화 JSON 이다.
+const sampleValueJSON = `{"fingerprint":"NullPointerException @ Foo.bar","deploy":"6119aa2","traceId":"abc123","message":"에러 메시지","stacktrace":"java.lang.NullPointerException\n\tat Foo.bar(Foo.java:1)"}`
+
+// sampleBody 는 버튼 value(구조화 JSON) + 메시지 본문을 모두 담은 실제 모양의 상호작용 폼 바디다.
 func sampleBody() []byte {
 	payload := `{"type":"block_actions","response_url":"https://hooks.slack/x","channel":{"id":"C1"},"message":{"ts":"111.222","text":` +
-		mustJSONString(sampleMessageText) + `},"actions":[{"action_id":"create_incident_issue"}]}`
+		mustJSONString(sampleMessageText) + `},"actions":[{"action_id":"create_incident_issue","value":` + mustJSONString(sampleValueJSON) + `}]}`
 	return []byte("payload=" + url.QueryEscape(payload))
 }
 
-func TestParse_필드추출(t *testing.T) {
+func TestParse_버튼value에서_필드추출(t *testing.T) {
 	si, inc, err := parseInteraction(sampleBody())
 	if err != nil {
 		t.Fatalf("파싱 실패: %v", err)
@@ -51,6 +55,51 @@ func TestParse_필드추출(t *testing.T) {
 	}
 	if inc.Stacktrace != "java.lang.NullPointerException\n\tat Foo.bar(Foo.java:1)" {
 		t.Errorf("stacktrace=%q", inc.Stacktrace)
+	}
+}
+
+// 이번 장애의 핵심 회귀: 실제 Slack payload 에서 message.text 가 비어 있어도(원인),
+// 버튼 value 만으로 fingerprint·deploy 를 뽑아 dispatch 가 성립해야 한다.
+func TestParse_본문이비어도_버튼value로_추출(t *testing.T) {
+	payload := `{"type":"block_actions","message":{"ts":"1","text":""},"actions":[{"action_id":"create_incident_issue","value":` +
+		mustJSONString(sampleValueJSON) + `}]}`
+	body := []byte("payload=" + url.QueryEscape(payload))
+
+	_, inc, err := parseInteraction(body)
+	if err != nil {
+		t.Fatalf("파싱 실패: %v", err)
+	}
+	if inc.Fingerprint != "NullPointerException @ Foo.bar" || inc.DeploySha != "6119aa2" {
+		t.Fatalf("버튼 value 로 추출 실패: %+v", inc)
+	}
+}
+
+// value 가 비면(옛 메시지 등) 메시지 본문 스크래핑으로 폴백한다.
+func TestParse_value없으면_본문폴백(t *testing.T) {
+	payload := `{"type":"block_actions","message":{"ts":"1","text":` +
+		mustJSONString(sampleMessageText) + `},"actions":[{"action_id":"create_incident_issue","value":""}]}`
+	body := []byte("payload=" + url.QueryEscape(payload))
+
+	_, inc, err := parseInteraction(body)
+	if err != nil {
+		t.Fatalf("파싱 실패: %v", err)
+	}
+	if inc.Fingerprint != "NullPointerException @ Foo.bar" || inc.DeploySha != "6119aa2" {
+		t.Fatalf("본문 폴백 추출 실패: %+v", inc)
+	}
+}
+
+// 옛 포맷 호환: value 가 JSON 이 아니라 fingerprint 문자열이면 fingerprint 로만 채운다.
+func TestParse_옛포맷_value는_fingerprint로(t *testing.T) {
+	payload := `{"type":"block_actions","message":{"ts":"1","text":""},"actions":[{"action_id":"create_incident_issue","value":"SomeException @ Foo.bar"}]}`
+	body := []byte("payload=" + url.QueryEscape(payload))
+
+	_, inc, err := parseInteraction(body)
+	if err != nil {
+		t.Fatalf("파싱 실패: %v", err)
+	}
+	if inc.Fingerprint != "SomeException @ Foo.bar" {
+		t.Fatalf("옛 포맷 fingerprint 추출 실패: %+v", inc)
 	}
 }
 

--- a/src/main/java/com/readum/infrastructure/logging/SlackWebhookAppender.java
+++ b/src/main/java/com/readum/infrastructure/logging/SlackWebhookAppender.java
@@ -35,6 +35,11 @@ public class SlackWebhookAppender extends AppenderBase<ILoggingEvent> {
 
     private static final String UNKNOWN_DEPLOY_COMMIT = "unknown";
 
+    // 버튼 value 는 Slack Block Kit 제한(최대 2000자)을 넘으면 메시지 전송 자체가 거부된다.
+    // message·stacktrace 는 value 용으로 짧게 자른다(사람이 보는 표시 텍스트는 전체 노출).
+    private static final int MAX_VALUE_MESSAGE_CHARS = 300;
+    private static final int MAX_VALUE_STACKTRACE_CHARS = 1000;
+
     private String webhookUrl;
     private String appName = "readum";
     private String env = "unknown";
@@ -133,7 +138,19 @@ public class SlackWebhookAppender extends AppenderBase<ILoggingEvent> {
             }
         }
 
-        // fallback text = 파싱 계약(수신기가 이 포맷을 regex 로 읽는다). *deploy* 줄 필수.
+        // 마스킹된 값을 한 번만 만들어 표시 텍스트와 버튼 value 에 함께 쓴다.
+        String maskedAppName = SensitiveDataMasker.mask(appName);
+        String maskedEnv = SensitiveDataMasker.mask(env);
+        String maskedLogger = SensitiveDataMasker.mask(event.getLoggerName());
+        String maskedFingerprint = SensitiveDataMasker.mask(fingerprint);
+        String maskedDeploy = SensitiveDataMasker.mask(deployCommit);
+        String maskedTraceId = SensitiveDataMasker.mask(traceId);
+        String maskedSpanId = SensitiveDataMasker.mask(spanId);
+        String maskedMessage = SensitiveDataMasker.mask(event.getFormattedMessage());
+        String maskedStackTrace = SensitiveDataMasker.mask(stackTrace);
+
+        // 표시 텍스트: 사람이 읽는 알림 본문. incident-analysis.yml 의 스레드 탐색이
+        // "fingerprint 포함 + ERROR 발생" 으로 원본 알림을 찾으므로 이 두 요소는 유지한다.
         String text = """
                 :rotating_light: *%s ERROR 발생*
                 *env*: `%s`
@@ -150,20 +167,30 @@ public class SlackWebhookAppender extends AppenderBase<ILoggingEvent> {
                 *stacktrace*
                 ```%s```
                 """.formatted(
-                SensitiveDataMasker.mask(appName),
-                SensitiveDataMasker.mask(env),
-                SensitiveDataMasker.mask(event.getLoggerName()),
-                SensitiveDataMasker.mask(fingerprint),
-                SensitiveDataMasker.mask(deployCommit),
-                SensitiveDataMasker.mask(traceId),
-                SensitiveDataMasker.mask(spanId),
+                maskedAppName,
+                maskedEnv,
+                maskedLogger,
+                maskedFingerprint,
+                maskedDeploy,
+                maskedTraceId,
+                maskedSpanId,
                 Instant.ofEpochMilli(event.getTimeStamp()),
-                SensitiveDataMasker.mask(event.getFormattedMessage()),
-                SensitiveDataMasker.mask(stackTrace)
+                maskedMessage,
+                maskedStackTrace
         );
 
+        // 버튼 value = 수신기가 그대로 읽는 구조화 JSON. 수신기가 본문(text)을 regex 로 긁던 방식은
+        // 실제 Slack 상호작용 payload 의 message.text 에 의존해 취약했다 — value 는 클릭된 버튼에 항상 실려 안전하다.
+        String buttonValue = "{"
+                + "\"fingerprint\":\"" + escapeJson(maskedFingerprint) + "\","
+                + "\"deploy\":\"" + escapeJson(maskedDeploy) + "\","
+                + "\"traceId\":\"" + escapeJson(maskedTraceId) + "\","
+                + "\"message\":\"" + escapeJson(truncate(maskedMessage, MAX_VALUE_MESSAGE_CHARS)) + "\","
+                + "\"stacktrace\":\"" + escapeJson(truncate(maskedStackTrace, MAX_VALUE_STACKTRACE_CHARS)) + "\""
+                + "}";
+
         String escapedText = escapeJson(text);
-        // blocks: 섹션(요약 표시) + 버튼. 수신기는 blocks 가 아니라 text 를 읽으므로 섹션은 표시용이다.
+        // blocks: 섹션(표시) + 버튼. 필요한 필드는 버튼 value 로 전달하므로 섹션·text 는 표시 전용이다.
         return "{\"text\":\"" + escapedText + "\","
                 + "\"blocks\":["
                 + "{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"" + escapedText + "\"}},"
@@ -171,9 +198,16 @@ public class SlackWebhookAppender extends AppenderBase<ILoggingEvent> {
                 + "{\"type\":\"button\",\"style\":\"primary\","
                 + "\"text\":{\"type\":\"plain_text\",\"text\":\"분석 이슈 만들기\"},"
                 + "\"action_id\":\"create_incident_issue\","
-                + "\"value\":\"" + escapeJson(fingerprint) + "\"}"
+                + "\"value\":\"" + escapeJson(buttonValue) + "\"}"
                 + "]}"
                 + "]}";
+    }
+
+    private static String truncate(String value, int maxChars) {
+        if (value.length() <= maxChars) {
+            return value;
+        }
+        return value.substring(0, maxChars) + "…";
     }
 
     private String escapeJson(String value) {

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -29,7 +29,9 @@
     <springProperty scope="context" name="AI_AUDIT_TOTAL_SIZE_CAP" source="log.config.ai-audit.total-size-cap"/>
 
     <springProperty scope="context" name="SLACK_WEBHOOK_URL" source="slack.webhook-url" defaultValue=""/>
-    <springProperty scope="context" name="APP_ENV" source="APP_ENV"/>
+    <!-- 알림 라벨용 환경 이름. 별도 환경변수 대신 활성 프로파일(local/dev/prod)을 그대로 쓴다 —
+         프로파일이 곧 환경이라 진실의 원본이 하나가 된다. 미해석 시 unknown. -->
+    <springProperty scope="context" name="APP_ENV" source="spring.profiles.active" defaultValue="unknown"/>
     <springProperty scope="context" name="APP_NAME" source="spring.application.name"/>
 
     <!-- 콘솔 출력 (모든 환경 공통, 색상 포함). 자체 필터 없음 → root 레벨(DEBUG)까지 그대로 출력 -->


### PR DESCRIPTION
## 문제

Slack 에러 알림의 "분석 이슈 만들기" 버튼을 눌러도 아무 일도 일어나지 않았다. 수신기(slack-receiver) 로그를 보면 `fingerprint·deploy 둘 다 비어 있어 dispatch 건너뜀` 으로, 클릭은 수신기까지 도달하고 서명 검증·버튼 식별까지 통과했으나 **장애 필드를 못 뽑아 GitHub 분석 요청이 조용히 유실**됐다.

원인은 수신기가 상호작용 payload 의 `message.text`(사람이 보는 표시 본문)를 regex 로 긁어 fingerprint·deploy 를 추출한 데 있다. 실제 Slack 버튼 클릭 payload 에서 `message.text` 를 신뢰할 수 없어 두 값이 비었고, 수신기는 `fingerprint == "" && deploy == ""` 이면 dispatch 를 건너뛴다. 이 경로는 단위 테스트가 `message.text` 를 손으로 채운 가짜 payload 로 통과했고, 유일한 성공 실행(#155)도 "테스트" 제목의 워크플로우 수동 검증이라 실제 버튼→파싱 경로는 검증된 적이 없었다.

정작 버튼에는 이미 fingerprint 가 `value` 로 실려 있었는데 수신기가 그 `value` 를 버리고 본문만 긁고 있었다. Slack 은 클릭된 버튼의 `value` 를 상호작용 payload 에 항상 실어 보내므로(수신기가 같은 배열의 `action_id` 를 이미 정상적으로 읽고 있는 것이 그 증거다), 본문 스크래핑 대신 `value` 를 쓰면 표시 본문 포맷에 의존하는 취약한 계약을 없앨 수 있다.

부수적으로, 알림의 `*env*` 라벨이 `APP_ENV_IS_UNDEFINED` 로 표시되던 문제도 함께 고쳤다. logback 이 참조하던 `APP_ENV` 환경변수가 어디에도 설정돼 있지 않았다(프로파일과 별개의 미사용 변수).

## 변경

**수신기 (slack-receiver)**
- 앱(`SlackWebhookAppender`)이 "분석 이슈 만들기" 버튼 `value` 에 fingerprint·deploy·traceId·message·stacktrace 를 구조화 JSON 으로 싣는다 (Slack 버튼 value 2000자 제한에 맞춰 message·stacktrace 는 절단; 표시 본문은 전체 노출 유지).
- 수신기(`parse.go`)는 클릭된 버튼의 `value` JSON 을 그대로 읽어 장애 필드를 채운다. `value` 가 없거나 옛 포맷(fingerprint 문자열)이면 본문 스크래핑/fingerprint 로 폴백한다.
- 회귀 테스트 추가: `message.text` 가 비어도 버튼 `value` 만으로 dispatch 가 성립하는지 검증 (이번 장애의 정확한 재현).

**알림 env 라벨**
- logback 의 env 소스를 `APP_ENV`(미설정 환경변수) → `spring.profiles.active` 로 교체. 프로파일(local/dev/prod)이 곧 환경이라 진실의 원본을 하나로 모은다.

## 효과

- "분석 이슈 만들기" 버튼이 실제로 GitHub 분석 워크플로우를 발동한다.
- 알림 본문의 파싱 포맷이 바뀌어도 버튼 경로가 깨지지 않는다 (표시 본문과 데이터 전달이 분리됨).
- 알림 `*env*` 라벨이 `dev`/`prod` 로 정확히 표시된다.

## 테스트 결과
- [x] `./gradlew test` 통과
- [x] `go test ./...` (slack-receiver) 통과 — 회귀 테스트 포함
- [ ] dev 머지 후 실제 Slack 버튼 클릭 → 분석 워크플로우 발동 확인 (수신기·앱 양쪽 재배포 필요)

## 참고 사항
- 이 PR 이 dev 에 머지되면 앱 배포(deploy.yml)와 수신기 배포(slack-receiver-deploy.yml)가 함께 돌아 양쪽이 새 버전으로 갱신된다. 두 배포가 잠깐 엇갈려도(옛 앱↔새 수신기 등) 폴백 경로가 있어 수렴한다.
- CI(ci.yml)는 Java 빌드만 돌고 go 테스트는 자동화돼 있지 않다 — 수신기 테스트는 로컬/도커에서 수동 실행했다. (별도 후속 고려 사항)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack 알림 버튼에 구조화된 정보를 포함해, 클릭 시 장애 관련 세부 정보를 더 정확하게 전달할 수 있게 되었습니다.
  * 활성 프로파일 기준으로 환경 표시값을 더 일관되게 보여주도록 개선되었습니다.

* **Bug Fixes**
  * Slack 버튼의 본문 의존도를 줄여, 본문이 비어 있어도 정보 추출이 실패하지 않도록 했습니다.
  * 버튼 값이 없거나 예전 형식인 경우에도 기존 방식으로 이어서 처리되도록 보완했습니다.

* **Tests**
  * 버튼 값 우선 처리, 본문 폴백, 하위 호환 동작을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->