### PR TITLE
feat(infra): 운영 서버 무중단 배포 파이프라인을 개발 서버와 공존 구성

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,86 @@
+# 운영 서버 배포 파이프라인. 개발 배포(deploy.yml)와 같은 인스턴스·같은 blue/green 방식이되,
+# release 브랜치에서 트리거되고 포트·유닛·경로·upstream·env 파일이 분리된 운영 스택으로 배포한다.
+# 빌드(테스트 포함)는 GitHub Actions 가 하고, 서버는 jar 실행만 한다 (구조는 docs/ops/infrastructure.md).
+#
+# 최초 배포 전 수동 전제(1회): DNS(prod-api.readum.kr → EIP) + 인증서 발급 + setup.sh(운영 디렉토리·유닛)
+#   + 운영 DB/Redis 컨테이너 기동 + PROD_ENV_FILE 시크릿 등록 + sites-enabled 심링크(cutover).
+#   상세 절차는 docs/ops/infrastructure.md 의 "운영 서버 최초 세팅" 참조.
+
+name: deploy-prod
+
+on:
+  # 수동 실행(workflow_dispatch) + release 브랜치 머지 시 자동 배포.
+  workflow_dispatch:
+  push:
+    branches: [release]
+
+# 운영 배포는 한 번에 하나만. 개발 배포(deploy-dev-server)와 별도 그룹이라 서로 막지 않는다.
+concurrency:
+  group: deploy-prod-server
+  cancel-in-progress: false
+
+env:
+  # 개발과 같은 인스턴스(EIP). prod-api.readum.kr 도 이 IP 로 해석된다.
+  DEPLOY_HOST: 54.116.108.68
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: 빌드 (전체 테스트 포함 — 테스트 통과가 배포 자격)
+        run: ./gradlew build
+
+      - name: jar 에 커밋 식별자 부여
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
+          cp build/libs/readum-*-SNAPSHOT.jar "readum-${SHORT_SHA}.jar"
+
+      - name: SSH 접속 준비
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+
+      - name: 서버 운영 .env 재작성 (원본 = PROD_ENV_FILE secret)
+        run: |
+          printf '%s\n' "${{ secrets.PROD_ENV_FILE }}" > prod.env.deploy
+          scp -i ~/.ssh/deploy_key prod.env.deploy "ubuntu@${DEPLOY_HOST}:/opt/readum/prod.env.tmp"
+          ssh -i ~/.ssh/deploy_key "ubuntu@${DEPLOY_HOST}" \
+            'chmod 600 /opt/readum/prod.env.tmp && mv /opt/readum/prod.env.tmp /opt/readum/prod.env'
+
+      - name: jar·배포 스크립트·nginx·compose 설정 업로드
+        run: |
+          ssh -i ~/.ssh/deploy_key "ubuntu@${DEPLOY_HOST}" 'mkdir -p /opt/readum/prod/releases /opt/readum/prod/nginx /opt/readum/prod/mysql'
+          scp -i ~/.ssh/deploy_key "readum-${SHORT_SHA}.jar" \
+            "ubuntu@${DEPLOY_HOST}:/opt/readum/prod/releases/"
+          # deploy.sh 는 개발·운영 공용(매개변수화)이라 같은 경로로 동기화한다.
+          scp -i ~/.ssh/deploy_key infra/scripts/deploy.sh \
+            "ubuntu@${DEPLOY_HOST}:/opt/readum/bin/deploy.sh"
+          # nginx 설정은 운영 스테이징 디렉토리에만 올린다. /etc/nginx 반영(변경분만)과 검증·reload 는
+          # deploy.sh 의 sync_nginx_conf 가 수행한다. websocket-upgrade.conf 는 개발과 공유하는 conf.d map 이다.
+          scp -i ~/.ssh/deploy_key infra/nginx/prod-app.conf infra/nginx/websocket-upgrade.conf \
+            "ubuntu@${DEPLOY_HOST}:/opt/readum/prod/nginx/"
+          # 운영 컨테이너 정의·MySQL 설정도 최신본을 서버에 둔다(파일만 최신화). MySQL·Redis 기동·재시작은
+          # 수동이다 — 상태 서비스라 코드 배포 사이드이펙트로 재시작하지 않는다.
+          scp -i ~/.ssh/deploy_key infra/docker/docker-compose.prod.yml \
+            "ubuntu@${DEPLOY_HOST}:/opt/readum/docker-compose.prod.yml"
+          scp -i ~/.ssh/deploy_key infra/mysql/my.prod.cnf \
+            "ubuntu@${DEPLOY_HOST}:/opt/readum/prod/mysql/my.cnf"
+
+      - name: blue/green 배포 실행 (운영)
+        run: |
+          ssh -i ~/.ssh/deploy_key "ubuntu@${DEPLOY_HOST}" \
+            "/opt/readum/bin/deploy.sh prod deploy /opt/readum/prod/releases/readum-${SHORT_SHA}.jar"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,19 +59,32 @@ jobs:
           ssh -i ~/.ssh/deploy_key "ubuntu@${DEPLOY_HOST}" \
             'chmod 600 /opt/readum/.env.tmp && mv /opt/readum/.env.tmp /opt/readum/.env'
 
-      - name: jar·배포 스크립트·nginx 설정 업로드
+      - name: jar·배포 스크립트·nginx·compose 설정 업로드
         run: |
+          ssh -i ~/.ssh/deploy_key "ubuntu@${DEPLOY_HOST}" 'mkdir -p /opt/readum/nginx /opt/readum/mysql'
           scp -i ~/.ssh/deploy_key "readum-${SHORT_SHA}.jar" \
             "ubuntu@${DEPLOY_HOST}:/opt/readum/releases/"
           scp -i ~/.ssh/deploy_key infra/scripts/deploy.sh \
             "ubuntu@${DEPLOY_HOST}:/opt/readum/bin/deploy.sh"
           # nginx 설정은 스테이징 디렉토리에만 올린다. /etc/nginx 반영(변경분만)과 검증·reload 는
           # deploy.sh 의 sync_nginx_conf 가 수행한다.
-          ssh -i ~/.ssh/deploy_key "ubuntu@${DEPLOY_HOST}" 'mkdir -p /opt/readum/nginx'
           scp -i ~/.ssh/deploy_key infra/nginx/app.conf infra/nginx/websocket-upgrade.conf \
             "ubuntu@${DEPLOY_HOST}:/opt/readum/nginx/"
+          # 컨테이너 정의·MySQL 설정도 최신본을 서버에 둔다(파일만 최신화). MySQL·Redis 기동·재시작은
+          # 수동이다 — 상태 서비스라 코드 배포 사이드이펙트로 재시작하지 않는다.
+          scp -i ~/.ssh/deploy_key infra/docker/docker-compose.dev.yml \
+            "ubuntu@${DEPLOY_HOST}:/opt/readum/docker-compose.dev.yml"
+          scp -i ~/.ssh/deploy_key infra/mysql/my.cnf \
+            "ubuntu@${DEPLOY_HOST}:/opt/readum/mysql/my.cnf"
+
+      - name: infra 부트스트랩 파일 업로드 (setup.sh 용 — 서버 git 체크아웃 대체)
+        run: |
+          # setup.sh(디렉토리·systemd 유닛·sudoers 설치)가 서버에서 git 없이 돌 수 있도록 infra 전체를 배달한다.
+          # 실제 실행은 root 권한이라 수동: sudo /opt/readum/infra/scripts/setup.sh /opt/readum/infra
+          ssh -i ~/.ssh/deploy_key "ubuntu@${DEPLOY_HOST}" 'rm -rf /opt/readum/infra'
+          scp -r -i ~/.ssh/deploy_key infra "ubuntu@${DEPLOY_HOST}:/opt/readum/"
 
       - name: blue/green 배포 실행
         run: |
           ssh -i ~/.ssh/deploy_key "ubuntu@${DEPLOY_HOST}" \
-            "/opt/readum/bin/deploy.sh deploy /opt/readum/releases/readum-${SHORT_SHA}.jar"
+            "/opt/readum/bin/deploy.sh dev deploy /opt/readum/releases/readum-${SHORT_SHA}.jar"

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ out/
 ### Environment ###
 .env
 .env.dev
+.env.prod
 .mcp.json
 .DS_Store
 

--- a/docs/ops/infrastructure.md
+++ b/docs/ops/infrastructure.md
@@ -9,33 +9,33 @@
 
 2026-07-06 부터 단일 EC2 에 전부 상주한다 (RDS 는 Docker MySQL 로 이관 후 폐기 — 최종 스냅샷 보존).
 
+개발(dev)과 운영(prod)이 **같은 EC2 인스턴스에 공존**한다. 도메인·포트·systemd 유닛·nginx upstream·MySQL/Redis 컨테이너·환경 파일이 모두 분리되어, 되돌릴 수 없는 데이터 계층까지 격리한다. (트래픽이 실재하면 인스턴스 증설 또는 운영 분리 — 아래 "운영 서버 공존" 참조.)
+
 ```text
-                Internet
-                    │
-      ┌─────────────┴─────────────┐
-      │                           │
-┌─────▼──────┐             ┌──────▼──────┐
-│ readum.kr  │             │api.readum.kr│
-│ 프론트엔드    │             │  백엔드 API  │
-│ (CloudFront)│            │  HTTPS :443 │
-└────────────┘             └──────┬──────┘
-                                  │
-                     ┌────────────▼────────────────┐
-                     │  EC2 t3.small · Ubuntu       │
-                     │  ap-northeast-2 · 스왑 2GB    │
-                     │                              │
-                     │  nginx (:80→:443, TLS 종료)   │
-                     │    │ upstream readum_backend │
-                     │    ▼                         │
-                     │  readum-blue(:8081) ─┐       │
-                     │  readum-green(:8082)─┤ 한쪽만 │
-                     │   (systemd 유닛 2개)  │ 상주   │
-                     │                              │
-                     │  Docker:                     │
-                     │   readum-mysql (MySQL 8.4)   │
-                     │   readum-redis (Redis 7.4)   │
-                     │   → 둘 다 127.0.0.1 바인딩     │
-                     └──────────────────────────────┘
+                        Internet
+                            │
+      ┌─────────────┬───────┴───────────┬──────────────────┐
+      │             │                   │                  │
+┌─────▼──────┐ ┌────▼────────┐   ┌──────▼──────────┐        │
+│ readum.kr  │ │api.readum.kr│   │prod-api.readum.kr        │
+│ 프론트엔드    │ │ 개발 API     │   │ 운영 API          │        │
+│ (CloudFront)│ │ HTTPS :443  │   │ HTTPS :443       │        │
+└────────────┘ └────┬────────┘   └──────┬──────────┘        │
+                    │                   │                   │
+        ┌───────────▼───────────────────▼───────────────────▼──┐
+        │  EC2 t3.small · Ubuntu · ap-northeast-2 · 스왑 2GB     │
+        │  nginx (:80→:443, TLS 종료) — server 블록 2개(도메인별)  │
+        │                                                       │
+        │  개발: upstream readum_backend                         │
+        │    readum-blue(:8081) / readum-green(:8082)  한쪽만 상주 │
+        │  운영: upstream readum_prod_backend                    │
+        │    readum-prod-blue(:8083) / readum-prod-green(:8084)  │
+        │                                                       │
+        │  Docker (전부 127.0.0.1 바인딩):                        │
+        │    개발: readum-mysql(:3306)      · readum-redis(:6379) │
+        │    운영: readum-prod-mysql(:3307) · readum-prod-redis(:6380)
+        │    공용: readum-slack-receiver(:8090)                  │
+        └───────────────────────────────────────────────────────┘
 ```
 
 ## 배포 (blue/green)
@@ -53,24 +53,56 @@
 | 배포 스크립트 | `/opt/readum/bin/deploy.sh` | `infra/scripts/deploy.sh` (CI 가 배포 때마다 동기화) |
 | jar | `/opt/readum/{blue,green}/app.jar`, 보관 `/opt/readum/releases/` (최근 5개) | CI 가 빌드·업로드 |
 | 환경 변수 | `/opt/readum/.env` | GitHub Secret `ENV_FILE` — CI 가 배포 때마다 재작성. 변경 = Secret 수정 → 재배포. **`SERVER_PORT` 금지**(유닛의 포트 지정을 덮어씀) |
-| MySQL 설정 | `/opt/readum/mysql/my.cnf` | `infra/mysql/my.cnf` (반영은 `setup.sh` + 컨테이너 재시작) |
-| 컨테이너 정의 | — | `infra/docker/docker-compose.dev.yml` (로컬 개발용은 `docker-compose.local.yml`) |
+| MySQL 설정 | `/opt/readum/mysql/my.cnf` | `infra/mysql/my.cnf` — CI 가 배포 때마다 최신본을 올린다(파일만). 실제 반영은 컨테이너 재시작(수동) |
+| 컨테이너 정의 | `/opt/readum/docker-compose.dev.yml` | `infra/docker/docker-compose.dev.yml` — CI 가 배포 때마다 올린다(로컬 개발용은 `docker-compose.local.yml`). MySQL·Redis 기동·재시작은 수동(`docker compose ... up -d`) — 상태 서비스라 코드 배포로 재시작하지 않는다 |
 | sudo 권한 | `/etc/sudoers.d/readum-deploy` | `infra/sudoers/readum-deploy` |
 
 서버에서 직접 쓰는 명령:
 
 ```bash
-/opt/readum/bin/deploy.sh status     # 활성 색·양쪽 유닛 상태·readiness
-/opt/readum/bin/deploy.sh rollback   # 직전 버전(반대 색 jar)으로 되돌리기 (~1분)
+/opt/readum/bin/deploy.sh dev status     # 활성 색·양쪽 유닛 상태·readiness (운영은 dev 대신 prod)
+/opt/readum/bin/deploy.sh dev rollback   # 직전 버전(반대 색 jar)으로 되돌리기 (~1분)
 ```
+
+> `deploy.sh` 는 개발·운영 공용이다. 첫 인자로 환경(`dev`|`prod`)을 받아 포트·유닛 접두사·경로·upstream 을 고른다. 두 환경은 이 값들만 다르고 로직은 공유한다.
 
 배포 수칙:
 
 - ~~**05:50~06:10 배포 회피**~~ (2026-07 해소) — 6시 감상문 적재 스캔과 전환 구간(두 프로세스 동시 상주)이 겹치면 외부 API(OpenAI) 호출 예산이 잠깐 2배가 됐었다. 전역 게이트(Redis) 도입으로 호출 예산이 프로세스 간 공유되어 이 회피는 불필요해졌다.
 - 전환 구간엔 JVM 2개(각 `-Xmx256m`)가 동시에 뜬다. 배포 중 스왑 피크가 계속 커지면 인스턴스 증설을 검토한다.
-- nginx 설정(`app.conf`·`websocket-upgrade.conf`)은 배포 파이프라인이 반영한다 — sudo 는 고정 경로 `tee` 두 줄만 추가로 허용(sudoers 에 명시). systemd·sudoers 파일 변경은 여전히 CI 가 반영하지 않는다(root 권한 불필요 원칙) — `sudo ./infra/scripts/setup.sh <repo>/infra` 재실행으로 수동 반영한다. sudoers 갱신 전에는 nginx 설정 자동 반영이 sudo 거부로 실패하므로, 이 구조를 처음 켤 때 setup.sh 재실행이 선행돼야 한다.
+- nginx 설정(`app.conf`·`websocket-upgrade.conf`)은 배포 파이프라인이 반영한다 — sudo 는 고정 경로 `tee` 두 줄만 추가로 허용(sudoers 에 명시). systemd 유닛 설치·sudoers 갱신은 root 권한이라 CI 가 직접 실행하지 않는다(root 권한 불필요 원칙). 대신 CI(`deploy.yml`)가 배포 때마다 `infra/` 전체를 `/opt/readum/infra` 로 배달하므로, 서버 git 체크아웃 없이 `sudo /opt/readum/infra/scripts/setup.sh /opt/readum/infra` 로 반영한다. sudoers 갱신 전에는 nginx 설정 자동 반영이 sudo 거부로 실패하므로, 이 구조를 처음 켜거나 유닛·sudoers 가 바뀌면 setup.sh 재실행이 선행돼야 한다.
 
-새 서버를 처음 준비할 때도 같은 `setup.sh` 가 시작점이다 (디렉토리·유닛·sudoers·MySQL 설정 배치).
+새 서버를 처음 준비할 때도 같은 `setup.sh` 가 시작점이다 (디렉토리·유닛·sudoers·MySQL 설정 배치 — 개발·운영 양쪽). CI 가 `/opt/readum/infra` 를 최신화해 두므로 서버에 repo 를 clone 할 필요가 없다.
+
+## 운영 서버 공존 (prod)
+
+운영은 개발과 **같은 인스턴스**에 나란히 올라가되, 아래가 전부 분리된다. 로직(blue/green 전환·nginx 반영·graceful 종료)은 `deploy.sh` 하나를 공유하고, 첫 인자 `dev|prod` 로 갈린다.
+
+| 항목 | 개발(dev) | 운영(prod) |
+|---|---|---|
+| 도메인 | api.readum.kr | prod-api.readum.kr |
+| 트리거 브랜치 | `dev` ([`deploy.yml`](../../.github/workflows/deploy.yml)) | `release` ([`deploy-prod.yml`](../../.github/workflows/deploy-prod.yml)) |
+| blue/green 포트 | 8081 / 8082 | 8083 / 8084 |
+| systemd 유닛 | `readum-{blue,green}` | `readum-prod-{blue,green}` |
+| nginx server 블록 | `app.conf` | `prod-app.conf` |
+| upstream | `readum_backend` / `readum-upstream.conf` | `readum_prod_backend` / `readum-prod-upstream.conf` |
+| 색·릴리스 경로 | `/opt/readum/{blue,green,releases}` | `/opt/readum/prod/{blue,green,releases}` |
+| 환경 파일 | `/opt/readum/.env` (Secret `ENV_FILE`) | `/opt/readum/prod.env` (Secret `PROD_ENV_FILE`) |
+| MySQL | readum-mysql :3306 (버퍼 256M·perf_schema ON) | readum-prod-mysql :3307 (버퍼 128M·perf_schema OFF) |
+| Redis | readum-redis :6379 | readum-prod-redis :6380 |
+| Swagger | 공개 | 비공개(`application-prod.yml` 에서 springdoc off) |
+| slack-receiver | **공용** — 수신기 하나가 개발·운영 버튼을 모두 처리(Slack Request URL 이 api.readum.kr 하나) |
+
+운영 ERROR 알림은 운영 전용 Slack 채널로 간다 — `prod.env` 의 `SLACK_WEBHOOK_URL` 이 그 채널 Incoming Webhook 을 가리키고, 알림 라벨 `env` 는 활성 프로파일 `prod` 를 그대로 쓴다(logback). 별도 Slack 앱·봇 토큰·signing secret 은 필요 없다.
+
+### 최초 활성화가 수동인 이유
+
+`deploy.sh` 는 운영 nginx 설정(`prod-app.conf`)을 `sites-available` 에만 두고 **활성화(cutover)는 자동으로 하지 않는다** — 개발의 최초 전환과 같은 방식이다. 활성화하려면 두 전제가 먼저 갖춰져야 하고, 그 전에 `sites-enabled` 로 심링크하면 `nginx -t` 가 실패하기 때문이다.
+
+1. `prod-api.readum.kr` DNS A 레코드가 이 서버 EIP 로 해석될 것
+2. 그 도메인용 Let's Encrypt 인증서가 발급돼 있을 것 (`ssl_certificate` 경로) — DNS 가 이 서버로 해석돼야 ACME http-01 검증이 통과하므로 **반드시 DNS 뒤에 발급**한다
+
+두 전제가 갖춰지고 첫 배포로 `readum-prod-upstream.conf` 가 생기면, `sites-enabled` 심링크 + `nginx -t && reload` 로 운영 트래픽을 흘린다. (구체적 최초 세팅 절차는 이 구성을 도입한 PR 참조 — 한 번 하고 끝나는 작업이라 문서에 상주시키지 않는다.)
 
 ## DB (Docker MySQL)
 
@@ -114,5 +146,5 @@ mysql -h 127.0.0.1 -P 3306 -u {DB_USER} -p
 
 ## 비용
 
-- 운영 서버는 별도 프로비저닝 예정 (그 전까지 이 개발 서버가 운영을 겸함)
+- 운영은 당분간 이 개발 서버와 **같은 t3.small 에 공존**한다 (사용자 0명 · 환경 세팅 목적). 트래픽이 실재하면 t3.medium 증설 또는 운영 별도 인스턴스로 분리 — 그때 운영 JVM 힙(`-Xmx`)과 운영 MySQL 버퍼 풀도 상향한다.
 - RDS 폐기로 DB 비용 소멸 — 그 몫을 인스턴스 증설(t3.micro → t3.small)에 사용

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -1,0 +1,48 @@
+# readum 운영 서버 전용 컨테이너 — 개발 서버(docker-compose.dev.yml)와 같은 EC2 에 공존하되,
+# 프로세스·볼륨·포트가 완전히 분리된 운영 전용 MySQL·Redis 다. 서버에서 다음으로 기동한다:
+#   docker compose --env-file /opt/readum/prod.env -f docker-compose.prod.yml up -d
+#
+# --env-file 이 /opt/readum/prod.env(운영 시크릿) 라서, 개발과 같은 변수 이름(MYSQL_*·REDIS_*)이라도
+# 값은 운영 것으로 채워진다. 개발 .env 와 섞이지 않는다.
+#
+# slack-receiver 는 여기 두지 않는다 — 수신기 하나가 개발·운영 Slack 버튼을 모두 처리한다
+# (Slack 앱의 Interactivity Request URL 이 하나뿐이라 api.readum.kr 수신기로 모인다).
+services:
+  mysql:
+    # 개발 MySQL(8.4)과 동일 버전 — 형태를 맞춰 개발 검증이 운영에서 재현되게 한다.
+    image: mysql:8.4
+    container_name: readum-prod-mysql
+    restart: unless-stopped
+    # 호스트 밖에서는 접근 불가 — 루프백의 3307 에만 바인딩(개발 MySQL 3306 과 포트 분리).
+    ports:
+      - "127.0.0.1:3307:3306"
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      TZ: Asia/Seoul
+    volumes:
+      # 운영 데이터는 개발과 별도 경로에 — 컨테이너 재생성/업그레이드에도 유지되고 개발과 섞이지 않는다.
+      - /opt/readum/prod/mysql-data:/var/lib/mysql
+      - /opt/readum/prod/mysql/my.cnf:/etc/mysql/conf.d/readum.cnf:ro
+
+  redis:
+    image: redis:7.4-alpine
+    container_name: readum-prod-redis
+    restart: unless-stopped
+    # 호스트 밖에서는 접근 불가 — 루프백의 6380 에만 바인딩(개발 Redis 6379 와 포트 분리).
+    ports:
+      - "127.0.0.1:6380:6379"
+    # 개발과 동일한 예산·정책(64mb·noeviction). rate limiter·토큰 예산 상태가 개발과 섞이면 안 되므로 분리 컨테이너다.
+    command:
+      - redis-server
+      - --requirepass
+      - ${REDIS_PASSWORD}
+      - --maxmemory
+      - 64mb
+      - --maxmemory-policy
+      - noeviction
+    volumes:
+      # RDB 스냅샷을 운영 전용 경로에 보존 — 컨테이너 재생성 시 토큰 예산 카운터 유실 방지.
+      - /opt/readum/prod/redis-data:/data

--- a/infra/mysql/my.prod.cnf
+++ b/infra/mysql/my.prod.cnf
@@ -1,0 +1,22 @@
+# readum 운영 서버 MySQL 컨테이너 설정. 원본은 repo 의 infra/mysql/my.prod.cnf 이고,
+# 서버의 /opt/readum/prod/mysql/my.cnf 로 복사해 컨테이너에 마운트한다 (docker-compose.prod.yml).
+#
+# 개발 MySQL(infra/mysql/my.cnf)과의 차이는 "메모리 예산"뿐이다 — 형태(버전 8.4·문자셋·격리수준)는 같게 유지해
+# 개발에서 검증한 동작이 운영에서 그대로 재현되게 한다.
+#   - performance_schema OFF: 운영과 개발이 한 t3.small(2GB)에 공존하는 동안 mysqld 고정 오버헤드(~100~200M)를
+#     한 번이라도 줄이려는 조치. 관측이 필요하면 slow_query_log(아래)로 대체하고, 정밀 관측이 필요할 때만 잠시 켠다.
+#   - innodb_buffer_pool_size 128M: 개발(256M)보다 작게 시작한다. 인스턴스 증설(t3.medium+) 시 상향한다.
+
+[mysqld]
+# ---- 관측 (개발과 동일한 기본값, perf_schema 만 제외) ----
+slow_query_log = ON
+log_output = TABLE
+long_query_time = 1
+performance_schema = OFF
+
+# ---- 문자셋 (개발과 동일) ----
+character-set-server = utf8mb4
+collation-server = utf8mb4_0900_ai_ci
+
+# ---- 메모리 (t3.small 공존 기준, 증설 시 상향) ----
+innodb_buffer_pool_size = 128M

--- a/infra/nginx/prod-app.conf
+++ b/infra/nginx/prod-app.conf
@@ -1,0 +1,89 @@
+# readum 운영 백엔드 nginx 설정. 원본은 repo 의 infra/nginx/prod-app.conf 이고,
+# CI(deploy-prod.yml)가 배포 때마다 /opt/readum/prod/nginx/ 로 올리면 deploy.sh 가 변경분만
+# 서버의 /etc/nginx/sites-available/prod-app.conf 에 반영한다 (구조는 docs/ops/infrastructure.md).
+#
+# 개발(app.conf)과 별개의 도메인·인증서·upstream 을 쓴다. 최초 활성화(cutover)는 수동이다:
+#   sites-available/prod-app.conf → sites-enabled/ 심링크. 이때 아래 두 전제가 먼저 갖춰져야 한다.
+#     1) prod-api.readum.kr DNS A 레코드가 이 서버 EIP 로 해석될 것
+#     2) 그 도메인용 Let's Encrypt 인증서가 발급돼 있을 것 (아래 ssl_certificate 경로)
+#   두 전제 전에는 nginx -t 가 실패하므로, deploy.sh 는 sites-available 에만 두고 활성화는 하지 않는다.
+#
+# 트래픽 전환(blue/green)은 이 파일이 아니라 /etc/nginx/conf.d/readum-prod-upstream.conf 가 담당한다.
+# 그 파일은 "지금 어느 포트가 활성인가"라는 서버의 런타임 상태라서 repo 로 관리하지 않고
+# 배포 스크립트(deploy.sh)가 생성·갱신한다. 내용은 한 줄이다:
+#   upstream readum_prod_backend { server 127.0.0.1:8083; }
+#
+# 아래 proxy_set_header 의 $connection_upgrade 는 infra/nginx/websocket-upgrade.conf 의 map 으로만
+# 정의되는 변수다 (개발과 공유하는 conf.d 파일). 그 파일이 /etc/nginx/conf.d/ 에 없으면 nginx 가 기동하지 않는다.
+
+# Slack 인터랙션(/slack/incident-actions)은 이 도메인에 두지 않는다 — Slack 앱의 Request URL 이
+# api.readum.kr 하나뿐이라, 운영 채널 버튼도 그 도메인의 수신기로 모인다.
+
+# 1) HTTP → HTTPS 리다이렉트
+server {
+    listen 80;
+    listen [::]:80;
+    server_name prod-api.readum.kr;
+
+    # Let's Encrypt 갱신(ACME http-01)은 리다이렉트 예외
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# 2) HTTPS → 백엔드(upstream readum_prod_backend) 프록시
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name prod-api.readum.kr;
+
+    ssl_certificate     /etc/letsencrypt/live/prod-api.readum.kr/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/prod-api.readum.kr/privkey.pem;
+
+    ssl_session_timeout 1d;
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_tickets off;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+
+    client_max_body_size 20m;
+
+    # 내부 운영 경로는 외부에 열지 않는다 (Actuator 지표).
+    # 서버 내부에서는 nginx 를 거치지 않고 127.0.0.1:808x 로 직접 접근하므로 영향 없다
+    # (배포 스크립트의 readiness 확인, 내부 지표 수집 모두 해당).
+    # Swagger 는 운영에서 공개하지 않는다 (application-prod.yml 에서 springdoc 비활성).
+    location ^~ /actuator/ {
+        return 404;
+    }
+
+    location / {
+        proxy_pass http://readum_prod_backend;
+
+        proxy_http_version 1.1;
+
+        # 백엔드(Spring Boot)가 원래 요청 정보를 알 수 있도록 전달.
+        # X-Forwarded-For 는 들어온 체인에 덧붙여($proxy_add_x_forwarded_for) 실제 사용자 IP 를 보존한다
+        # — 프론트 서버 프록시를 거쳐 오는 요청에서 체인을 덮어쓰면 프록시 IP 만 남는다 (429 사고 #103 계열 교훈).
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $host;
+        proxy_set_header X-Forwarded-Port  $server_port;
+
+        # WebSocket / SSE 사용 시 필요
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        $connection_upgrade;
+
+        # read timeout 은 "총 시간"이 아니라 "다음 데이터 조각까지의 대기"라서,
+        # 토큰이 계속 흘러나오는 SSE 스트림은 60초를 넘겨도 끊기지 않는다.
+        proxy_connect_timeout 60s;
+        proxy_send_timeout    60s;
+        proxy_read_timeout    60s;
+
+        proxy_redirect off;
+    }
+}

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -3,9 +3,10 @@
 # 서버의 /opt/readum/bin/deploy.sh 로 동기화해 사용한다 (전체 구조는 docs/ops/infrastructure.md).
 #
 # 사용법:
-#   deploy.sh deploy <jar 경로>   # 비활성 색에 jar 를 올리고 기동 → readiness 통과 → 트래픽 전환 → 구 프로세스 종료
-#   deploy.sh rollback            # 반대 색(직전 버전 jar 보유)을 재기동해 트래픽을 되돌림
-#   deploy.sh status              # 활성 색·양쪽 유닛 상태·readiness 를 출력
+#   deploy.sh <env> deploy <jar 경로>   # 비활성 색에 jar 를 올리고 기동 → readiness 통과 → 트래픽 전환 → 구 프로세스 종료
+#   deploy.sh <env> rollback            # 반대 색(직전 버전 jar 보유)을 재기동해 트래픽을 되돌림
+#   deploy.sh <env> status              # 활성 색·양쪽 유닛 상태·readiness 를 출력
+#   <env> 는 dev | prod. 개발·운영이 같은 인스턴스에 공존하되 포트·유닛·경로·upstream 이 분리된다.
 #
 # 설계 원칙:
 # - "지금 어느 색이 활성인가"의 유일한 판단 근거는 nginx upstream 파일이다.
@@ -14,23 +15,48 @@
 # - 구 프로세스 종료는 systemctl stop → 앱의 graceful shutdown(진행 중 요청 60초 대기)에 맡긴다.
 set -euo pipefail
 
-BASE_DIR="/opt/readum"
-RELEASES_DIR="$BASE_DIR/releases"
-UPSTREAM_CONF="/etc/nginx/conf.d/readum-upstream.conf"
-NGINX_SYNC_DIR="$BASE_DIR/nginx"
-# CI 가 NGINX_SYNC_DIR 에 올려두는 nginx 설정 원본(repo infra/nginx)과 실제 적용 경로의 짝. "파일명:적용경로"
-# 적용 경로를 바꾸면 sudoers(infra/sudoers/readum-deploy)의 tee 허용 경로도 함께 바꿔야 한다.
-NGINX_CONF_TARGETS=(
-  "app.conf:/etc/nginx/sites-available/app.conf"
-  "websocket-upgrade.conf:/etc/nginx/conf.d/websocket-upgrade.conf"
-)
-BLUE_PORT=8081
-GREEN_PORT=8082
-READINESS_TIMEOUT_SECONDS=90
 RELEASE_KEEP_COUNT=5
+READINESS_TIMEOUT_SECONDS=90
 
 log() { echo "==> $*"; }
 fail() { echo "!! $*" >&2; exit 1; }
+
+# 환경(dev|prod)별 포트·유닛 접두사·경로·upstream 을 고른다. 두 환경은 이 값들만 다르고 로직은 공유한다.
+# 적용 경로(NGINX_CONF_TARGETS·UPSTREAM_CONF)를 바꾸면 sudoers(infra/sudoers/readum-deploy)의
+# 허용 경로(tee·systemctl 유닛)도 함께 바꿔야 한다.
+resolve_env() {
+  case "$1" in
+    dev)
+      BLUE_PORT=8081
+      GREEN_PORT=8082
+      UNIT_PREFIX="readum"
+      UPSTREAM_CONF="/etc/nginx/conf.d/readum-upstream.conf"
+      UPSTREAM_NAME="readum_backend"
+      COLOR_BASE="/opt/readum"                 # 색 디렉토리 = $COLOR_BASE/<color>
+      RELEASES_DIR="/opt/readum/releases"
+      NGINX_SYNC_DIR="/opt/readum/nginx"
+      NGINX_CONF_TARGETS=(
+        "app.conf:/etc/nginx/sites-available/app.conf"
+        "websocket-upgrade.conf:/etc/nginx/conf.d/websocket-upgrade.conf"
+      )
+      ;;
+    prod)
+      BLUE_PORT=8083
+      GREEN_PORT=8084
+      UNIT_PREFIX="readum-prod"
+      UPSTREAM_CONF="/etc/nginx/conf.d/readum-prod-upstream.conf"
+      UPSTREAM_NAME="readum_prod_backend"
+      COLOR_BASE="/opt/readum/prod"
+      RELEASES_DIR="/opt/readum/prod/releases"
+      NGINX_SYNC_DIR="/opt/readum/prod/nginx"
+      NGINX_CONF_TARGETS=(
+        "prod-app.conf:/etc/nginx/sites-available/prod-app.conf"
+        "websocket-upgrade.conf:/etc/nginx/conf.d/websocket-upgrade.conf"
+      )
+      ;;
+    *) fail "알 수 없는 환경: '$1' (dev|prod)" ;;
+  esac
+}
 
 port_of() {
   case "$1" in
@@ -113,8 +139,8 @@ sync_nginx_conf() {
 
 switch_traffic_to() {
   local port="$1"
-  log "nginx upstream 을 127.0.0.1:$port 로 전환"
-  printf 'upstream readum_backend { server 127.0.0.1:%s; }\n' "$port" \
+  log "nginx upstream($UPSTREAM_NAME) 을 127.0.0.1:$port 로 전환"
+  printf 'upstream %s { server 127.0.0.1:%s; }\n' "$UPSTREAM_NAME" "$port" \
     | sudo /usr/bin/tee "$UPSTREAM_CONF" >/dev/null
   sudo /usr/sbin/nginx -t
   sudo /usr/bin/systemctl reload nginx
@@ -127,28 +153,28 @@ activate() {
   target_port="$(port_of "$target")"
   old="$(other_of "$target")"
 
-  [[ -f "$BASE_DIR/$target/app.jar" ]] || fail "$BASE_DIR/$target/app.jar 이 없음"
+  [[ -f "$COLOR_BASE/$target/app.jar" ]] || fail "$COLOR_BASE/$target/app.jar 이 없음"
 
   # 이전 배포 잔재가 떠 있으면 내리고 새로 기동한다.
-  sudo /usr/bin/systemctl stop "readum-$target" 2>/dev/null || true
-  log "readum-$target 기동"
-  sudo /usr/bin/systemctl start "readum-$target"
+  sudo /usr/bin/systemctl stop "${UNIT_PREFIX}-$target" 2>/dev/null || true
+  log "${UNIT_PREFIX}-$target 기동"
+  sudo /usr/bin/systemctl start "${UNIT_PREFIX}-$target"
 
   if ! wait_readiness "$target_port"; then
-    sudo /usr/bin/systemctl stop "readum-$target" || true
-    fail "readum-$target 이 ${READINESS_TIMEOUT_SECONDS}초 안에 readiness 를 통과하지 못함. 트래픽은 기존 프로세스에 그대로 남아 있음. 로그: journalctl -u readum-$target"
+    sudo /usr/bin/systemctl stop "${UNIT_PREFIX}-$target" || true
+    fail "${UNIT_PREFIX}-$target 이 ${READINESS_TIMEOUT_SECONDS}초 안에 readiness 를 통과하지 못함. 트래픽은 기존 프로세스에 그대로 남아 있음. 로그: journalctl -u ${UNIT_PREFIX}-$target"
   fi
 
   switch_traffic_to "$target_port"
 
   # 재부팅 시 활성 색만 자동 기동되도록 enable 을 활성 색으로 맞춘다.
-  sudo /usr/bin/systemctl enable "readum-$target" >/dev/null 2>&1 || true
-  sudo /usr/bin/systemctl disable "readum-$old" >/dev/null 2>&1 || true
+  sudo /usr/bin/systemctl enable "${UNIT_PREFIX}-$target" >/dev/null 2>&1 || true
+  sudo /usr/bin/systemctl disable "${UNIT_PREFIX}-$old" >/dev/null 2>&1 || true
 
   # 구 프로세스는 graceful 종료 (앱이 진행 중 요청을 최대 60초 마무리, systemd 는 75초 대기 후 강제 종료).
-  if systemctl is-active --quiet "readum-$old"; then
-    log "readum-$old graceful 종료"
-    sudo /usr/bin/systemctl stop "readum-$old"
+  if systemctl is-active --quiet "${UNIT_PREFIX}-$old"; then
+    log "${UNIT_PREFIX}-$old graceful 종료"
+    sudo /usr/bin/systemctl stop "${UNIT_PREFIX}-$old"
   fi
 
   log "완료: $target($target_port) 활성"
@@ -156,7 +182,7 @@ activate() {
 
 cmd_deploy() {
   local jar="${1:-}"
-  [[ -n "$jar" && -f "$jar" ]] || fail "사용법: deploy.sh deploy <jar 경로>"
+  [[ -n "$jar" && -f "$jar" ]] || fail "사용법: deploy.sh $ENV deploy <jar 경로>"
 
   sync_nginx_conf
 
@@ -164,9 +190,9 @@ cmd_deploy() {
   active="$(active_color)"
   # 최초 전환(cutover) 전에는 upstream 파일이 없다 → blue 부터 시작.
   target="$([[ -n "$active" ]] && other_of "$active" || echo "blue")"
-  log "활성: ${active:-없음} → 배포 대상: $target"
+  log "[$ENV] 활성: ${active:-없음} → 배포 대상: $target"
 
-  cp "$jar" "$BASE_DIR/$target/app.jar"
+  cp "$jar" "$COLOR_BASE/$target/app.jar"
   activate "$target"
 
   # 오래된 릴리스 정리 (최근 N개 유지).
@@ -178,29 +204,33 @@ cmd_rollback() {
   active="$(active_color)"
   [[ -n "$active" ]] || fail "upstream 파일이 없어 활성 색을 알 수 없음. rollback 불가."
   target="$(other_of "$active")"
-  log "rollback: $active → $target (직전 버전 jar 로 재기동)"
+  log "[$ENV] rollback: $active → $target (직전 버전 jar 로 재기동)"
   activate "$target"
 }
 
 cmd_status() {
   local active
   active="$(active_color)"
-  echo "활성 색: ${active:-없음 (upstream 파일 없음)}"
+  echo "[$ENV] 활성 색: ${active:-없음 (upstream 파일 없음)}"
   for color in blue green; do
     local state port
-    state="$(systemctl is-active "readum-$color" 2>/dev/null || true)"
+    state="$(systemctl is-active "${UNIT_PREFIX}-$color" 2>/dev/null || true)"
     port="$(port_of "$color")"
     local ready="-"
     if curl -fsS "http://127.0.0.1:${port}/actuator/health/readiness" >/dev/null 2>&1; then
       ready="UP"
     fi
-    echo "readum-$color (:$port) — unit=$state, readiness=$ready"
+    echo "${UNIT_PREFIX}-$color (:$port) — unit=$state, readiness=$ready"
   done
 }
 
-case "${1:-}" in
-  deploy) shift; cmd_deploy "$@" ;;
+ENV="${1:-}"
+[[ -n "$ENV" ]] || fail "사용법: deploy.sh {dev|prod} {deploy <jar 경로>|rollback|status}"
+resolve_env "$ENV"
+
+case "${2:-}" in
+  deploy) cmd_deploy "${3:-}" ;;
   rollback) cmd_rollback ;;
   status) cmd_status ;;
-  *) fail "사용법: deploy.sh {deploy <jar 경로>|rollback|status}" ;;
+  *) fail "사용법: deploy.sh $ENV {deploy <jar 경로>|rollback|status}" ;;
 esac

--- a/infra/scripts/setup.sh
+++ b/infra/scripts/setup.sh
@@ -17,23 +17,31 @@ INFRA_DIR="${1:-}"
 }
 [[ "$(id -u)" -eq 0 ]] || { echo "sudo 로 실행해야 한다" >&2; exit 1; }
 
-echo "==> /opt/readum 디렉토리 구조"
+echo "==> /opt/readum 디렉토리 구조 (개발 + 운영)"
 mkdir -p /opt/readum/{blue,green,releases,bin,nginx}
+# 운영은 /opt/readum/prod 아래에 개발과 같은 구조로 분리해 둔다 (색 디렉토리·릴리스·nginx 스테이징).
+mkdir -p /opt/readum/prod/{blue,green,releases,nginx}
 chown -R ubuntu:ubuntu /opt/readum
 
-echo "==> systemd 유닛 설치"
+echo "==> systemd 유닛 설치 (개발 + 운영)"
 cp "$INFRA_DIR"/systemd/readum-blue.service /etc/systemd/system/
 cp "$INFRA_DIR"/systemd/readum-green.service /etc/systemd/system/
+cp "$INFRA_DIR"/systemd/readum-prod-blue.service /etc/systemd/system/
+cp "$INFRA_DIR"/systemd/readum-prod-green.service /etc/systemd/system/
 systemctl daemon-reload
 
 echo "==> 배포·백업 스크립트 설치"
 install -m 0755 -o ubuntu -g ubuntu "$INFRA_DIR"/scripts/deploy.sh /opt/readum/bin/deploy.sh
 install -m 0755 -o ubuntu -g ubuntu "$INFRA_DIR"/scripts/backup-mysql.sh /opt/readum/bin/backup-mysql.sh
 
-echo "==> MySQL 설정 배치"
+echo "==> MySQL 설정 배치 (개발 + 운영)"
 mkdir -p /opt/readum/mysql /opt/readum/mysql-data /opt/readum/mysql-backup
 install -m 0644 -o ubuntu -g ubuntu "$INFRA_DIR"/mysql/my.cnf /opt/readum/mysql/my.cnf
 chown ubuntu:ubuntu /opt/readum/mysql /opt/readum/mysql-backup
+# 운영 MySQL 설정·데이터 경로 (개발과 완전 분리).
+mkdir -p /opt/readum/prod/mysql /opt/readum/prod/mysql-data
+install -m 0644 -o ubuntu -g ubuntu "$INFRA_DIR"/mysql/my.prod.cnf /opt/readum/prod/mysql/my.cnf
+chown ubuntu:ubuntu /opt/readum/prod/mysql
 
 echo "==> sudoers 설치 (ubuntu 가 배포에 필요한 명령만 비밀번호 없이 실행)"
 visudo -cf "$INFRA_DIR"/sudoers/readum-deploy

--- a/infra/sudoers/readum-deploy
+++ b/infra/sudoers/readum-deploy
@@ -10,8 +10,18 @@ ubuntu ALL=(root) NOPASSWD: /usr/bin/systemctl start readum-blue, \
   /usr/bin/systemctl stop readum-green, \
   /usr/bin/systemctl enable readum-green, \
   /usr/bin/systemctl disable readum-green, \
+  /usr/bin/systemctl start readum-prod-blue, \
+  /usr/bin/systemctl stop readum-prod-blue, \
+  /usr/bin/systemctl enable readum-prod-blue, \
+  /usr/bin/systemctl disable readum-prod-blue, \
+  /usr/bin/systemctl start readum-prod-green, \
+  /usr/bin/systemctl stop readum-prod-green, \
+  /usr/bin/systemctl enable readum-prod-green, \
+  /usr/bin/systemctl disable readum-prod-green, \
   /usr/bin/systemctl reload nginx, \
   /usr/sbin/nginx -t, \
   /usr/bin/tee /etc/nginx/conf.d/readum-upstream.conf, \
   /usr/bin/tee /etc/nginx/sites-available/app.conf, \
-  /usr/bin/tee /etc/nginx/conf.d/websocket-upgrade.conf
+  /usr/bin/tee /etc/nginx/conf.d/websocket-upgrade.conf, \
+  /usr/bin/tee /etc/nginx/conf.d/readum-prod-upstream.conf, \
+  /usr/bin/tee /etc/nginx/sites-available/prod-app.conf

--- a/infra/systemd/readum-prod-blue.service
+++ b/infra/systemd/readum-prod-blue.service
@@ -1,0 +1,31 @@
+# readum 운영 backend blue 인스턴스 (포트 8083). 원본은 repo 의 infra/systemd/.
+# 설치: sudo cp → /etc/systemd/system/ 후 daemon-reload (setup.sh 가 수행, 절차는 docs/ops/infrastructure.md)
+#
+# 개발 유닛(readum-blue :8081 / readum-green :8082)과 포트·경로·env 파일만 다르다.
+# 평상시에는 한쪽만 떠 있고, 배포 순간에만 잠깐 둘 다 상주한다.
+
+[Unit]
+Description=readum backend (prod, blue, :8083)
+After=network.target
+
+[Service]
+User=ubuntu
+WorkingDirectory=/opt/readum/prod/blue
+# 힙을 명시해 배포 전환 구간(JVM 2개 동시 상주)의 메모리 사용을 예측 가능하게 고정한다.
+# t3.small 공존 기준의 Phase-1 값(개발과 동일 256m). 인스턴스 증설(t3.medium+) 시 운영을 크게 상향한다.
+ExecStart=/usr/bin/java -Xmx256m -jar /opt/readum/prod/blue/app.jar
+EnvironmentFile=/opt/readum/prod.env
+Environment=SERVER_PORT=8083
+
+# 크래시(OOM 등)로 죽으면 자동 재기동. systemctl stop 에 의한 의도적 종료는 재기동하지 않는다.
+Restart=on-failure
+RestartSec=5
+
+# stop 시 SIGTERM → 앱의 graceful shutdown(진행 중 요청 60초 대기)이 끝나기를 기다린 뒤,
+# 그래도 살아 있으면 SIGKILL. 앱의 60초보다 여유 있게 잡아 SIGKILL 이 graceful 을 앞지르지 않게 한다.
+TimeoutStopSec=75
+# SIGTERM 종료 시 JVM 의 관례적 종료 코드(143)를 정상 종료로 취급한다.
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/systemd/readum-prod-green.service
+++ b/infra/systemd/readum-prod-green.service
@@ -1,0 +1,31 @@
+# readum 운영 backend green 인스턴스 (포트 8084). 원본은 repo 의 infra/systemd/.
+# 설치: sudo cp → /etc/systemd/system/ 후 daemon-reload (setup.sh 가 수행, 절차는 docs/ops/infrastructure.md)
+#
+# 개발 유닛(readum-blue :8081 / readum-green :8082)과 포트·경로·env 파일만 다르다.
+# 평상시에는 한쪽만 떠 있고, 배포 순간에만 잠깐 둘 다 상주한다.
+
+[Unit]
+Description=readum backend (prod, green, :8084)
+After=network.target
+
+[Service]
+User=ubuntu
+WorkingDirectory=/opt/readum/prod/green
+# 힙을 명시해 배포 전환 구간(JVM 2개 동시 상주)의 메모리 사용을 예측 가능하게 고정한다.
+# t3.small 공존 기준의 Phase-1 값(개발과 동일 256m). 인스턴스 증설(t3.medium+) 시 운영을 크게 상향한다.
+ExecStart=/usr/bin/java -Xmx256m -jar /opt/readum/prod/green/app.jar
+EnvironmentFile=/opt/readum/prod.env
+Environment=SERVER_PORT=8084
+
+# 크래시(OOM 등)로 죽으면 자동 재기동. systemctl stop 에 의한 의도적 종료는 재기동하지 않는다.
+Restart=on-failure
+RestartSec=5
+
+# stop 시 SIGTERM → 앱의 graceful shutdown(진행 중 요청 60초 대기)이 끝나기를 기다린 뒤,
+# 그래도 살아 있으면 SIGKILL. 앱의 60초보다 여유 있게 잡아 SIGKILL 이 graceful 을 앞지르지 않게 한다.
+TimeoutStopSec=75
+# SIGTERM 종료 시 JVM 의 관례적 종료 코드(143)를 정상 종료로 취급한다.
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,36 @@
+# 운영 서버 프로파일 (SPRING_PROFILES_ACTIVE=prod). 환경별 값만 둔다 —
+# 환경 무관 값(openai 옵션·jpa·guardrail·aladin)은 application.yml 이 정본이다.
+# 개발 서버와 같은 EC2 인스턴스에 공존하되, 접속 대상(운영 전용 MySQL·Redis 컨테이너)만 다르다.
+# 접속 대상은 infra/docker/docker-compose.prod.yml 의 운영 전용 MySQL(127.0.0.1:3307)·Redis(127.0.0.1:6380)다.
+# logback 은 prod 블록(콘솔 + 롤링 파일 + Slack + AI 감사)이 켜진다 — 운영 ERROR 는 운영 전용 Slack 채널로 간다
+# (채널 구분은 운영 prod.env 의 SLACK_WEBHOOK_URL 이 담당하고, 알림 라벨 env 는 활성 프로파일 prod 를 그대로 쓴다).
+spring:
+  datasource:
+    # 운영 전용 MySQL 컨테이너(127.0.0.1:3307). 호스트에서 systemd 로 도는 앱이 루프백으로 접속한다.
+    # 개발 MySQL(3306)과 프로세스·볼륨·설정이 완전히 분리되어, 되돌릴 수 없는 데이터 계층을 격리한다.
+    url: jdbc:mysql://${MYSQL_HOST:127.0.0.1}:${MYSQL_PORT:3307}/${MYSQL_DATABASE}?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    username: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    # 워커 풀(summary-job 12 + context-summary-job 4 = 최대 16)의 짧은 DB 단계와 웹 요청이 경합하지 않도록
+    # 개발과 동일하게 24 로 둔다 (워커 동시성 계산값은 환경과 무관하므로 dev 와 같게 맞춘다).
+    hikari:
+      maximum-pool-size: 24
+  data:
+    redis:
+      host: ${REDIS_HOST:127.0.0.1}   # 앱은 호스트에서 systemd 로 돌고 운영 Redis 는 루프백(6380) 바인딩
+      port: ${REDIS_PORT:6380}
+      password: ${REDIS_PASSWORD}
+
+# 운영 콘솔(journald)에는 앱 코드 INFO 이상만 남긴다 — 운영은 DEBUG 도배를 피한다.
+# (개발은 DEBUG 로 관찰하지만, 운영에서 상세 관찰이 필요하면 이 값을 한시적으로 DEBUG 로 올린다.)
+logging:
+  level:
+    com.readum: INFO
+
+# 운영에서는 API 문서(Swagger)를 공개하지 않는다 — 프론트 협업용 문서는 개발 서버(dev)에서만 노출한다.
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false


### PR DESCRIPTION
## 배경

개발 서버가 떠 있는 t3.small 인스턴스에 운영(prod) 서버도 무중단(blue/green)으로 배포되게 한다. 아직 사용자가 없어 **환경 세팅이 목적**이라, 별도 인스턴스 대신 같은 박스에 공존시키되 되돌릴 수 없는 데이터 계층까지 포함해 전부 분리한다. (트래픽이 실재하면 t3.medium 증설 또는 운영 분리 — 문서에 명시.)

전환 로직(blue/green·nginx 반영·graceful 종료)은 검증된 `deploy.sh` 하나를 그대로 공유하고, 첫 인자 `dev|prod` 로만 갈리게 매개변수화했다. 개발 배포 경로는 인자 추가(`deploy.sh dev deploy ...`) 외에 동작이 바뀌지 않는다.

## 변경

**분리한 운영 스택 (개발과 나란히)**
- 도메인 `prod-api.readum.kr` · blue/green 포트 `8083/8084` · systemd `readum-prod-{blue,green}`
- 운영 전용 MySQL(`:3307`, 버퍼 128M·perf_schema off)·Redis(`:6380`) 컨테이너 (`docker-compose.prod.yml` + `my.prod.cnf`)
- 운영 nginx server 블록 `prod-app.conf`(upstream `readum_prod_backend`) · 환경 파일 `/opt/readum/prod.env`(Secret `PROD_ENV_FILE`)
- `application-prod.yml`: 운영 DB/Redis 접속, Swagger 비공개, `com.readum` INFO

**공용 유지**
- `deploy.sh` 환경 매개변수화(dev|prod) · slack-receiver 하나가 개발·운영 버튼 모두 처리(Slack Request URL 하나)
- 운영 ERROR 는 `prod.env` 의 `SLACK_WEBHOOK_URL`(운영 채널)로, 라벨 `env` 는 활성 프로파일 `prod` 로. 새 Slack 앱·봇 토큰·signing secret 불필요.

**배포 파이프라인**
- `release` 브랜치 트리거 `deploy-prod.yml` 신설 (concurrency 그룹 `deploy-prod-server` 분리)
- compose·my.cnf 를 배포 때 서버로 **자동 업로드**(파일만 최신화). MySQL·Redis 기동·재시작은 수동 — 상태 서비스라 코드 배포 사이드이펙트로 재시작하지 않는다.
- `deploy.yml` 이 `infra/` 전체를 `/opt/readum/infra` 로 **배달** — 서버 git 체크아웃 없이 `sudo /opt/readum/infra/scripts/setup.sh /opt/readum/infra` 로 부트스트랩 반영(#154 의 "서버 git 사본 의존 제거" 방향과 일치)

**부트스트랩·문서**
- `setup.sh`·`sudoers`: 운영 디렉토리·유닛·nginx 경로 추가
- `.gitignore`: `.env.prod` 무시 추가 (운영 env 원본, `.env.dev` 와 같은 방식)
- `docs/ops/infrastructure.md`: 공존 구성도·개발/운영 비교표·활성화 수동 이유

## 효과

- `release` 브랜치 머지 → 운영 서버 무중단 자동 배포. 개발(dev 브랜치) 경로는 그대로.
- 개발/운영이 프로세스·볼륨·포트·도메인까지 분리돼, 한쪽 사고가 데이터 계층을 넘나들지 않는다.
- setup.sh 반영에 서버 repo 체크아웃이 필요 없어진다.

## 테스트 결과
- [x] `./gradlew build` 통과 (Java·테스트 변경 없음, 회귀 없음 확인)
- [x] `bash -n` (deploy.sh·setup.sh) · `visudo -cf` (sudoers) 통과
- [ ] 운영 최초 세팅(수동, 아래 순서) 후 실제 배포 검증

## 참고 사항 — 운영 최초 세팅 (1회, 순서 중요)

배포 파이프라인이 자동으로 하지 않는, root·외부 자원 단계다. **핵심: DB/Redis 컨테이너가 첫 배포보다 먼저 떠 있어야 한다** — 앱 기동 시 Flyway 가 MySQL 에 붙으므로, DB 가 없으면 readiness 실패로 배포가 중단된다.

1. **로컬**: `.env.prod`(gitignore)의 외부 키 3개(OpenAI·알라딘·Slack webhook) 채우고 → GitHub Secret **`PROD_ENV_FILE`** 등록 (DB·Redis 비번·JWT 는 생성돼 있음)
2. **가비아 DNS**: `prod-api.readum.kr` A → EIP `54.116.108.68`. `dig +short prod-api.readum.kr` 로 해석 확인
3. **prod.env 배치**(첫 DB 기동용): 로컬 `.env.prod` 를 서버 `/opt/readum/prod.env` 로 scp (첫 배포가 어차피 `PROD_ENV_FILE` 로 같은 내용을 덮는다)
4. **부트스트랩**: dev 머지 후 dev 배포가 `/opt/readum/infra` 를 배달하면 → `sudo /opt/readum/infra/scripts/setup.sh /opt/readum/infra` (디렉토리·유닛·sudoers·my.prod.cnf, 멱등 — dev 무영향)
5. **컨테이너 기동(첫 배포보다 먼저)**: `docker compose --env-file /opt/readum/prod.env -f /opt/readum/infra/docker/docker-compose.prod.yml up -d`
6. **인증서**(DNS 해석 확인 후): `sudo certbot certonly --webroot -w /var/www/certbot -d prod-api.readum.kr`
7. **첫 배포**: `release` 브랜치 생성·push → `deploy-prod.yml` 발동 (DB 떠 있으니 readiness 통과)
8. **cutover**: `sudo ln -s /etc/nginx/sites-available/prod-app.conf /etc/nginx/sites-enabled/prod-app.conf && sudo nginx -t && sudo systemctl reload nginx`

> **env 라벨**(dev/prod 버튼 구분)은 넣지 않았다(앱·수신기·워크플로 무변경). 자동 생성 이슈에 env 구분은 없지만, 운영 SHA 는 `release` 브랜치에서만 나오므로 `deploy` 필드로 역추적 가능. 필요하면 후속 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)