### PR TITLE
chore(verify): 검증 체크리스트 탐지 항목 확장 및 Stop hook 개선

### DIFF
--- a/.claude/agents/verify.md
+++ b/.claude/agents/verify.md
@@ -1,10 +1,10 @@
 ---
 name: verify
-description: 구현 직후 결정론적 체크리스트를 전부 실행해 잔존물을 보고한다. hook(verify-fast)과 달리 ./gradlew test 포함 전체 4개 항목을 실행한다. 메인 세션이 기능 구현을 마친 직후 "verify 돌려줘" 또는 "/verify subagent"로 호출한다.
+description: 구현 직후 결정론적 체크리스트를 전부 실행해 잔존물을 보고한다. hook(verify-fast)과 달리 ./gradlew test 포함 전체 7개 항목을 실행한다. 메인 세션이 기능 구현을 마친 직후 "verify 돌려줘" 또는 "/verify subagent"로 호출한다.
 tools: Bash
 ---
 
-구현 직후 검증 에이전트다. 결정론적 명령만 실행하고 판단하지 않는다. 아래 4개 항목을 순서대로 실행한 뒤 결과 표를 출력하고 종료한다.
+구현 직후 검증 에이전트다. 결정론적 명령만 실행하고 판단하지 않는다. 아래 7개 항목을 순서대로 실행한 뒤 결과 표를 출력하고 종료한다.
 
 ## 실행 항목
 
@@ -29,7 +29,28 @@ grep -rn "@Value" src/main --include="*.java" \
   | grep -v "src/main/java/com/readum/.*/example/"
 ```
 
-### 4. Service/Repository 대응 테스트 클래스 존재 여부
+### 4. Entity 에 of() 팩토리 사용 탐지
+
+```bash
+grep -rn "static.*\bof(" src/main/java/com/readum/model --include="*.java" \
+  | grep -v "src/main/java/com/readum/.*/example/"
+```
+
+### 5. raw RuntimeException / IllegalArgumentException 탐지
+
+```bash
+grep -rn "new RuntimeException\|new IllegalArgumentException" src/main --include="*.java" \
+  | grep -v "src/main/java/com/readum/.*/example/"
+```
+
+### 6. 역방향 의존 (domain → infrastructure) 탐지
+
+```bash
+grep -rn "import com.readum.infrastructure" src/main/java/com/readum/domain --include="*.java" \
+  | grep -v "src/main/java/com/readum/.*/example/"
+```
+
+### 7. Service/Repository 대응 테스트 클래스 존재 여부
 
 ```bash
 comm -23 \
@@ -42,7 +63,7 @@ comm -23 \
 
 ## 결과 보고 형식
 
-4개 항목을 모두 실행한 뒤 아래 표로 보고한다.
+7개 항목을 모두 실행한 뒤 아래 표로 보고한다.
 
 ```
 ## /verify 결과 (subagent)
@@ -52,6 +73,9 @@ comm -23 \
 | TODO | ✅ 없음 / ❌ N건 |
 | 테스트 | ✅ 전체 통과 / ❌ 실패 |
 | @Value | ✅ 없음 / ⚠️ N건 |
+| of() 팩토리 | ✅ 없음 / ❌ N건 |
+| raw 예외 | ✅ 없음 / ❌ N건 |
+| 역방향 의존 | ✅ 없음 / ❌ N건 |
 | 누락 테스트 | ✅ 없음 / ❌ N건 |
 ```
 

--- a/.claude/hooks/verify-fast.sh
+++ b/.claude/hooks/verify-fast.sh
@@ -37,7 +37,49 @@ else
   done <<< "$VALUE_HITS"
 fi
 
-# 3. Service/Repository 대응 테스트 클래스 존재 여부
+# 3. Entity 에 of() 팩토리 사용 탐지
+OF_HITS=$(grep -rn "static.*\bof(" src/main/java/com/readum/model --include="*.java" \
+  | grep -v "src/main/java/com/readum/.*/example/" 2>/dev/null)
+if [ -z "$OF_HITS" ]; then
+  OUT+="  of() 팩토리  ✅ 없음\n"
+else
+  COUNT=$(echo "$OF_HITS" | wc -l | tr -d ' ')
+  OUT+="  of() 팩토리  ❌ ${COUNT}건\n"
+  while IFS= read -r line; do
+    OUT+="    $line\n"
+  done <<< "$OF_HITS"
+  FAIL=$((FAIL + 1))
+fi
+
+# 4. raw RuntimeException / IllegalArgumentException 탐지
+RAW_EX_HITS=$(grep -rn "new RuntimeException\|new IllegalArgumentException" src/main --include="*.java" \
+  | grep -v "src/main/java/com/readum/.*/example/" 2>/dev/null)
+if [ -z "$RAW_EX_HITS" ]; then
+  OUT+="  raw 예외    ✅ 없음\n"
+else
+  COUNT=$(echo "$RAW_EX_HITS" | wc -l | tr -d ' ')
+  OUT+="  raw 예외    ❌ ${COUNT}건\n"
+  while IFS= read -r line; do
+    OUT+="    $line\n"
+  done <<< "$RAW_EX_HITS"
+  FAIL=$((FAIL + 1))
+fi
+
+# 5. 역방향 의존 (domain → infrastructure) 탐지
+REVERSE_DEP_HITS=$(grep -rn "import com.readum.infrastructure" src/main/java/com/readum/domain --include="*.java" \
+  | grep -v "src/main/java/com/readum/.*/example/" 2>/dev/null)
+if [ -z "$REVERSE_DEP_HITS" ]; then
+  OUT+="  역방향 의존  ✅ 없음\n"
+else
+  COUNT=$(echo "$REVERSE_DEP_HITS" | wc -l | tr -d ' ')
+  OUT+="  역방향 의존  ❌ ${COUNT}건\n"
+  while IFS= read -r line; do
+    OUT+="    $line\n"
+  done <<< "$REVERSE_DEP_HITS"
+  FAIL=$((FAIL + 1))
+fi
+
+# 6. Service/Repository 대응 테스트 클래스 존재 여부
 MISSING=$(comm -23 \
   <(find src/main/java -name "*Service.java" -o -name "*Repository.java" \
       | grep -v "src/main/java/com/readum/.*/example/" \
@@ -55,11 +97,12 @@ else
   FAIL=$((FAIL + 1))
 fi
 
-# 결과 출력 (이상 있을 때만 표시해 노이즈 최소화)
+# 결과 출력 (이상 있을 때만 stderr + exit 1 로 사용자에게 표시)
 if [ $FAIL -gt 0 ] || [ -n "$VALUE_HITS" ]; then
-  echo ""
-  echo "── /verify (fast) ──────────────────────"
-  echo -e "$OUT"
-  echo "(./gradlew test 는 /verify 수동 실행에서 확인)"
-  echo "────────────────────────────────────────"
+  echo "" >&2
+  echo "── /verify (fast) ──────────────────────" >&2
+  echo -e "$OUT" >&2
+  echo "(./gradlew test 는 /verify 수동 실행에서 확인)" >&2
+  echo "────────────────────────────────────────" >&2
+  exit 1
 fi

--- a/.claude/hooks/verify-fast.sh
+++ b/.claude/hooks/verify-fast.sh
@@ -5,6 +5,12 @@
 
 cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
 
+# .java 파일 변경이 없으면 검사 생략
+CHANGED=$(git diff --name-only HEAD -- '*.java' 2>/dev/null; git diff --cached --name-only -- '*.java' 2>/dev/null)
+if [ -z "$CHANGED" ]; then
+  exit 0
+fi
+
 PASS=0
 FAIL=0
 OUT=""

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify
-description: 구현 직후 결정론적 체크리스트를 실행해 잔존물을 보고한다. 현재 항목: (1) TODO 탐지, (2) 전체 테스트 통과 여부, (3) domain/presentation 계층 @Value 탐지, (4) Service/Repository 대응 테스트 클래스 존재 여부. 사용자가 "/verify" 로 호출할 때 사용.
+description: 구현 직후 결정론적 체크리스트를 실행해 잔존물을 보고한다. 현재 항목: (1) TODO 탐지, (2) 전체 테스트 통과 여부, (3) @Value 탐지, (4) of() 팩토리 탐지, (5) raw 예외 탐지, (6) 역방향 의존 탐지, (7) 누락 테스트 탐지. 사용자가 "/verify" 로 호출할 때 사용.
 ---
 
 # `/verify` 스킬
@@ -44,7 +44,40 @@ grep -rn "@Value" src/main --include="*.java" \
 > 현재 기준선(2026-05-31): `presentation/` 2건 — `AuthController:39`, `UserController:44`.
 > 이 2건은 `@ConfigurationProperties` 미이전 상태로 기존 인지된 항목이다. 새로 추가된 건만 주의 깊게 보면 된다.
 
-### 4. Service/Repository 대응 테스트 클래스 존재 여부
+### 4. Entity 에 of() 팩토리 사용 탐지
+
+```bash
+grep -rn "static.*\bof(" src/main/java/com/readum/model --include="*.java" \
+  | grep -v "src/main/java/com/readum/.*/example/"
+```
+
+- 결과가 0줄이면: `✅ of() 팩토리 없음`
+- 1줄 이상이면: 파일경로:줄번호와 내용을 출력하고 `❌ of() 팩토리 N건` 보고
+- Entity 규칙: 불변식을 강제하는 `create()` 계열만 허용, `of()`(전체 필드 지정) 금지
+
+### 5. raw RuntimeException / IllegalArgumentException 탐지
+
+```bash
+grep -rn "new RuntimeException\|new IllegalArgumentException" src/main --include="*.java" \
+  | grep -v "src/main/java/com/readum/.*/example/"
+```
+
+- 결과가 0줄이면: `✅ raw 예외 없음`
+- 1줄 이상이면: 파일경로:줄번호와 내용을 출력하고 `❌ raw 예외 N건` 보고
+- 예외 규칙: `BusinessException` 서브클래스 + `ErrorCode` 조합만 허용
+
+### 6. 역방향 의존 (domain → infrastructure) 탐지
+
+```bash
+grep -rn "import com.readum.infrastructure" src/main/java/com/readum/domain --include="*.java" \
+  | grep -v "src/main/java/com/readum/.*/example/"
+```
+
+- 결과가 0줄이면: `✅ 역방향 의존 없음`
+- 1줄 이상이면: 파일경로:줄번호와 내용을 출력하고 `❌ 역방향 의존 N건` 보고
+- 계층 규칙: domain → infrastructure 방향 의존 금지
+
+### 7. Service/Repository 대응 테스트 클래스 존재 여부
 
 ```bash
 comm -23 \
@@ -71,6 +104,9 @@ comm -23 \
 | TODO | ✅ 없음 / ❌ N건 |
 | 테스트 | ✅ 전체 통과 / ❌ 실패 |
 | @Value | ✅ 없음 / ⚠️ N건 |
+| of() 팩토리 | ✅ 없음 / ❌ N건 |
+| raw 예외 | ✅ 없음 / ❌ N건 |
+| 역방향 의존 | ✅ 없음 / ❌ N건 |
 | 누락 테스트 | ✅ 없음 / ❌ N건 |
 
 (실패/경고 항목이 있으면 세부 내용을 항목 아래에 나열)


### PR DESCRIPTION
## 작업 사항

의도적 결함 10건을 주입해 Hook, /verify, Subagent 세 방식의 탐지 성능을 비교한 결과, 팀 규칙 위반 중 grep 으로 잡을 수 있는 3가지(Entity `of()` 팩토리 사용, raw `RuntimeException` 던지기, domain → infrastructure 역방향 의존)가 체크리스트에 빠져 있었다. 이 3개를 추가해 탐지율을 4/10 → 7/10 으로 올렸다.

부수적으로, Stop hook 이 `.java` 파일 변경 없이도 매 응답마다 기존 기준선 항목을 반복 표시하던 문제를 수정했다. `git diff` 로 `.java` 변경이 없으면 검사를 건너뛰도록 가드를 추가해, 대화만 오가는 동안에는 hook 이 조용히 넘어간다.

### 기능

**탐지 항목 추가 (Hook · /verify · Subagent 공통)**
- Entity 패키지(`model/`)에서 `of()` 정적 팩토리 사용 탐지 — `create()` 계열만 허용하는 규칙 위반 검출
- `new RuntimeException` / `new IllegalArgumentException` 사용 탐지 — `BusinessException` + `ErrorCode` 조합 규칙 위반 검출
- domain 계층에서 infrastructure 패키지 import 탐지 — 계층 의존 방향 위반 검출

**Stop hook 노이즈 제거**
- `.java` 파일 변경이 없으면 hook 을 즉시 종료해 불필요한 반복 표시 방지

## 테스트 결과
- [x] 의도적 결함 10건 주입 후 탐지 여부 확인 완료 (탐지 매트릭스 아래 참고)
- [x] 결함 전부 되돌린 뒤 기존 기준선과 일치 확인
- [x] `.java` 변경 없을 때 hook 미표시 확인

## 관련 이슈
- closes #62

## 참고 사항

**탐지 매트릭스 (결함 주입 실험 결과)**

| # | 결함 유형 | Hook (0.1초) | /verify (~26초) | Subagent (~72초) |
|---|----------|:-----------:|:-------------:|:---------------:|
| 1 | TODO 주석 | O | O | O |
| 2 | 테스트 없는 서비스 | O | O | O |
| 3 | 금지된 @Value | O | O | O |
| 4 | 컴파일 오류 | X | O | O |
| 5 | of() 팩토리 | O ✨ | O ✨ | O ✨ |
| 6 | raw RuntimeException | O ✨ | O ✨ | O ✨ |
| 7 | Service 내 DTO 변환 | X | X | X |
| 8 | 역방향 의존 | O ✨ | O ✨ | O ✨ |
| 9 | @Transactional 남용 | X | X | X |
| 10 | Swagger 누락 | X | X | X |

✨ = 이번 PR 에서 추가된 탐지

미탐지 항목(7, 9, 10)은 grep 으로 신뢰성 있게 판별하기 어려워 코드 리뷰 영역으로 남겨뒀다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 구현 검증 항목이 4개에서 7개로 확대되었습니다.
  * 불변식 위반, 원시 예외 사용, 계층 간 역방향 의존성 및 누락된 테스트를 추가로 점검합니다.
  * 검증 결과가 항목별로 명확하게 표시됩니다.
  * Java 변경 사항이 없으면 빠른 검증을 자동으로 건너뜁니다.

* **버그 수정**
  * 검증 실패 또는 위반 사항 발견 시 오류 메시지를 표시하고 즉시 실패하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->